### PR TITLE
Notifying request listeners after the target is notified

### DIFF
--- a/library/src/com/bumptech/glide/Glide.java
+++ b/library/src/com/bumptech/glide/Glide.java
@@ -84,13 +84,13 @@ public class Glide {
          * </p>
          *
          * @param e The exception, or null
-         * @param model The model we were trying to load when the exception occured
+         * @param model The model we were trying to load when the exception occurred
          * @param target The {@link Target} we were trying to load the image into
          */
         public abstract void onException(Exception e, T model, Target target);
 
         /**
-         * Called when a load completes successfully, immediately before
+         * Called when a load completes successfully, immediately after
          * {@link Target#onImageReady(android.graphics.Bitmap)}.
          *
          * @param model The specific model that was used to load the image.

--- a/library/src/com/bumptech/glide/presenter/ImagePresenter.java
+++ b/library/src/com/bumptech/glide/presenter/ImagePresenter.java
@@ -453,9 +453,9 @@ public class ImagePresenter<T> {
             public boolean onImageReady(Bitmap image) {
                 if (loadCount != currentCount || !canSetImage() || image == null) return false;
 
+                target.onImageReady(image);
                 if (imageReadyCallback != null)
                     imageReadyCallback.onImageReady(model, target, loadedFromCache);
-                target.onImageReady(image);
                 isImageSet = true;
                 return true;
             }
@@ -463,12 +463,12 @@ public class ImagePresenter<T> {
             @Override
             public void onException(Exception e) {
                 final boolean relevant = loadCount == currentCount;
-                if (exceptionHandler != null) {
-                    exceptionHandler.onException(e, model, relevant);
-                }
                 if (relevant && canSetPlaceholder() && errorDrawable != null) {
                     isErrorSet = true;
                     target.setPlaceholder(errorDrawable);
+                }
+                if (exceptionHandler != null) {
+                    exceptionHandler.onException(e, model, relevant);
                 }
             }
         });


### PR DESCRIPTION
This might not be what you would like the library to behave like, but I thought I'd submit it as a pull request since I went ahead and implentented cause we needed it.

It seems to me that once you get notified that an image is ready on a target. you would expect the target to already have received that image so you can act on it.

Let me know if this is completely different to what you envisioned. 
