### PR TITLE
Exposing image view on ImageViewTarget

### DIFF
--- a/library/src/com/bumptech/glide/presenter/target/ImageViewTarget.java
+++ b/library/src/com/bumptech/glide/presenter/target/ImageViewTarget.java
@@ -1,7 +1,5 @@
 package com.bumptech.glide.presenter.target;
 
-import static android.view.ViewGroup.LayoutParams;
-
 import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.os.Handler;
@@ -9,6 +7,8 @@ import android.view.View;
 import android.view.animation.Animation;
 import android.widget.ImageView;
 import com.bumptech.glide.presenter.ImagePresenter;
+
+import static android.view.ViewGroup.LayoutParams;
 
 /**
  * A target wrapping an ImageView. Obtains the runtime dimensions of the ImageView.


### PR DESCRIPTION
This was helpful for us since we need access to the image view on our listener callbacks. Cannot see a reason why the view should not be accessible unless I am missing something subtle.
