### PR TITLE
Fix unclosed OutputStream in DiskLruCacheWrapper (reported by StrictMode...

### DIFF
--- a/library/src/com/bumptech/glide/resize/cache/DiskLruCacheWrapper.java
+++ b/library/src/com/bumptech/glide/resize/cache/DiskLruCacheWrapper.java
@@ -9,6 +9,7 @@ import com.jakewharton.disklrucache.DiskLruCache;
 import java.io.File;
 import java.io.IOException;
 import java.io.InputStream;
+import java.io.OutputStream;
 
 /**
  * The default DiskCache implementation. There must be no more than one active instance for a given
@@ -77,8 +78,10 @@ public class DiskLruCacheWrapper implements DiskCache {
             //editor will be null if there are two concurrent puts
             //worst case just silently fail
             if (editor != null) {
-                writer.write(editor.newOutputStream(0));
+                OutputStream os = editor.newOutputStream(0);
+                writer.write(os);
                 editor.commit();
+                os.close();
             }
         } catch (IOException e) {
             e.printStackTrace();


### PR DESCRIPTION
Hi there,

I've been using Glide in my project, and it sure is great to have the best of Picasso and the best of Volley. Thank you for this.

Recently I've turned on StrictMode in my app, and I frequently get the following message in LogCat:

``` java
E/StrictMode﹕ A resource was acquired at attached stack trace but never released. See java.io.Closeable for information on avoiding resource leaks.
    java.lang.Throwable: Explicit termination method 'close' not called
            at dalvik.system.CloseGuard.open(CloseGuard.java:184)
            at java.io.FileOutputStream.<init>(FileOutputStream.java:90)
            at java.io.FileOutputStream.<init>(FileOutputStream.java:73)
            at com.jakewharton.disklrucache.DiskLruCache$Editor.newOutputStream(DiskLruCache.java:779)
            at com.bumptech.glide.resize.cache.DiskLruCacheWrapper.put(DiskLruCacheWrapper.java:80)
            at com.bumptech.glide.resize.ImageManager.putInDiskCache(ImageManager.java:525)
            at com.bumptech.glide.resize.ImageManager.access$2400(ImageManager.java:57)
            at com.bumptech.glide.resize.ImageManager$ImageManagerRunner.finishResize(ImageManager.java:665)
            at com.bumptech.glide.resize.ImageManager$ImageManagerRunner.access$2000(ImageManager.java:549)
            at com.bumptech.glide.resize.ImageManager$ImageManagerRunner$1$1$1.run(ImageManager.java:641)
            at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:422)
            at java.util.concurrent.FutureTask.run(FutureTask.java:237)
            at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1112)
            at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:587)
            at java.lang.Thread.run(Thread.java:841)
```

This pull request corrects the issue by closing the `OutputStream` when it is no longer needed.
