### PR TITLE
Api dealing with outdated RequestQueue

### DIFF
--- a/samples/flickr/src/com/bumptech/glide/samples/flickr/FlickrSearchActivity.java
+++ b/samples/flickr/src/com/bumptech/glide/samples/flickr/FlickrSearchActivity.java
@@ -1,6 +1,12 @@
 package com.bumptech.glide.samples.flickr;
 
-import android.os.Build;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
 import android.os.Bundle;
 import android.os.StrictMode;
 import android.support.v4.app.Fragment;
@@ -15,31 +21,15 @@ import android.view.inputmethod.EditorInfo;
 import android.widget.Button;
 import android.widget.EditText;
 import android.widget.TextView;
+
 import com.actionbarsherlock.app.ActionBar;
 import com.actionbarsherlock.app.SherlockFragmentActivity;
-import com.android.volley.RequestQueue;
-import com.android.volley.toolbox.Volley;
 import com.bumptech.glide.Glide;
-import com.bumptech.glide.resize.ImageManager;
-import com.bumptech.glide.resize.bitmap_recycle.LruBitmapPool;
-import com.bumptech.glide.resize.cache.DiskCache;
-import com.bumptech.glide.resize.cache.DiskLruCacheWrapper;
-import com.bumptech.glide.resize.cache.LruMemoryCache;
 import com.bumptech.glide.samples.flickr.api.Api;
 import com.bumptech.glide.samples.flickr.api.Photo;
-import com.bumptech.glide.volley.VolleyUrlLoader;
-
-import java.io.File;
-import java.net.URL;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.HashSet;
-import java.util.List;
-import java.util.Map;
-import java.util.Set;
 
 public class FlickrSearchActivity extends SherlockFragmentActivity {
-    private static final String CACHE_NAME = "flickr_cache";
+    
     private static final String TAG = "FlickrSearchActivity";
 
     private int searchCount = 0;
@@ -49,7 +39,6 @@ public class FlickrSearchActivity extends SherlockFragmentActivity {
     private Set<PhotoViewer> photoViewers = new HashSet<PhotoViewer>();
     private List<Photo> currentPhotos = new ArrayList<Photo>();
     private View searchLoading;
-    private RequestQueue requestQueue;
 
     private enum Page {
         SMALL,
@@ -87,28 +76,6 @@ public class FlickrSearchActivity extends SherlockFragmentActivity {
                 .detectAll()
                 .penaltyLog()
                 .build());
-
-        final Glide glide = Glide.get();
-        if (!glide.isImageManagerSet()) {
-            File cacheDir = ImageManager.getPhotoCacheDir(this, CACHE_NAME);
-
-            DiskCache diskCache = DiskLruCacheWrapper.get(cacheDir, 50 * 1024 * 1024);
-
-            // When we can recycle bitmaps, the smaller our cache is, the more quickly our scrolling will become smooth
-            // so prefer large bitmap pool and a small cache.
-            final int safeMemCacheSize = ImageManager.getSafeMemoryCacheSize(this);
-            glide.setImageManager(new ImageManager.Builder(this)
-                    .setBitmapCompressQuality(70)
-                    .setMemoryCache(new LruMemoryCache(
-                            Build.VERSION.SDK_INT >= 11 ? safeMemCacheSize / 2 : safeMemCacheSize))
-                    .setBitmapPool(new LruBitmapPool(
-                            Build.VERSION.SDK_INT >= 11 ? Math.round(safeMemCacheSize * 1.5f) : safeMemCacheSize))
-                    .setDiskCache(diskCache));
-        }
-
-        requestQueue = Volley.newRequestQueue(this);
-
-        glide.register(URL.class, new VolleyUrlLoader.Factory(requestQueue));
 
         searching = findViewById(R.id.searching);
         searchLoading = findViewById(R.id.search_loading);
@@ -185,7 +152,7 @@ public class FlickrSearchActivity extends SherlockFragmentActivity {
         searchLoading.setVisibility(View.VISIBLE);
         searchTerm.setText(getString(R.string.searching_for, searchString));
 
-        Api.get(requestQueue).search(searchString, new Api.SearchCallback() {
+        Api.get(getApplicationContext()).search(searchString, new Api.SearchCallback() {
             @Override
             public void onSearchCompleted(List<Photo> photos) {
                 if (currentSearch != searchCount) return;


### PR DESCRIPTION
The issue
If we search once or more, then click back, navigate to the app again, and try to search again, no callback methods get called.

why?
If we click back from the activity the API object still the same because it's a static object
and if we navigate again to the activity, we are creating a new RequestQueue in the onCreate() of the FlickrSearchActivity, but in Api.get(requestQueue) the API object is not null so here we are dealing with two request queues and the callback functions is never called.
