### PR TITLE
Don't call executePendingTransactions.

### DIFF
--- a/library/src/androidTest/java/com/bumptech/glide/manager/Issue117Activity.java
+++ b/library/src/androidTest/java/com/bumptech/glide/manager/Issue117Activity.java
@@ -1,0 +1,67 @@
+package com.bumptech.glide.manager;
+
+import android.content.Context;
+import android.os.Bundle;
+import android.support.v4.app.Fragment;
+import android.support.v4.app.FragmentActivity;
+import android.support.v4.app.FragmentManager;
+import android.support.v4.app.FragmentPagerAdapter;
+import android.support.v4.view.ViewPager;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.ImageView;
+import com.bumptech.glide.Glide;
+
+/**
+ * A test activity to reproduce Issue #117: https://github.com/bumptech/glide/issues/117.
+ */
+public class Issue117Activity extends FragmentActivity {
+    @Override
+    protected void onCreate(Bundle savedInstanceState) {
+        super.onCreate(savedInstanceState);
+        ViewPager viewPager = new ViewPager(this);
+        int id = View.generateViewId();
+        viewPager.setId(id);
+        setContentView(viewPager,
+                new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
+        viewPager.setAdapter(new Issue117Adapter(getSupportFragmentManager()));
+    }
+
+    private static class Issue117Adapter extends FragmentPagerAdapter {
+
+        public Issue117Adapter(FragmentManager fm) {
+            super(fm);
+        }
+
+        @Override
+        public Fragment getItem(int position) {
+            return new Issue117Fragment();
+        }
+
+        @Override
+        public int getCount() {
+            return 1;
+        }
+    }
+
+    public static class Issue117Fragment extends Fragment {
+        @Override
+        public View onCreateView(LayoutInflater inflater, ViewGroup container, Bundle savedInstanceState) {
+            return new Issue117ImageView(getActivity());
+        }
+    }
+
+    public static class Issue117ImageView extends ImageView {
+        public Issue117ImageView(Context context) {
+            super(context);
+        }
+
+        @Override
+        protected void onAttachedToWindow() {
+            super.onAttachedToWindow();
+            Glide.with(getContext()).load(android.R.drawable.ic_menu_rotate).into(this);
+        }
+    }
+}
+

--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -534,7 +534,8 @@ public class Glide {
      * @return A RequestManager for the top level application that can be used to start a load.
      */
     public static RequestManager with(Context context) {
-        return RequestManagerRetriever.get(context);
+        RequestManagerRetriever retriever = RequestManagerRetriever.get();
+        return retriever.get(context);
     }
 
     /**
@@ -545,7 +546,8 @@ public class Glide {
      * @return A RequestManager for the given activity that can be used to start a load.
      */
     public static RequestManager with(Activity activity) {
-        return RequestManagerRetriever.get(activity);
+        RequestManagerRetriever retriever = RequestManagerRetriever.get();
+        return retriever.get(activity);
     }
 
     /**
@@ -556,7 +558,8 @@ public class Glide {
      * @return A RequestManager for the given FragmentActivity that can be used to start a load.
      */
     public static RequestManager with(FragmentActivity activity) {
-        return RequestManagerRetriever.get(activity);
+        RequestManagerRetriever retriever = RequestManagerRetriever.get();
+        return retriever.get(activity);
     }
 
     /**
@@ -568,7 +571,8 @@ public class Glide {
      */
     @TargetApi(Build.VERSION_CODES.HONEYCOMB)
     public static RequestManager with(android.app.Fragment fragment) {
-        return RequestManagerRetriever.get(fragment);
+        RequestManagerRetriever retriever = RequestManagerRetriever.get();
+        return retriever.get(fragment);
     }
 
     /**
@@ -579,7 +583,8 @@ public class Glide {
      * @return A RequestManager for the given Fragment that can be used to start a load.
      */
     public static RequestManager with(Fragment fragment) {
-        return RequestManagerRetriever.get(fragment);
+        RequestManagerRetriever retriever = RequestManagerRetriever.get();
+        return retriever.get(fragment);
     }
 
     private static class ClearTarget extends ViewTarget<View, Object> {

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -344,8 +344,8 @@ public class RequestManager implements LifecycleListener {
     public DrawableTypeRequest<byte[]> load(byte[] model, final String id) {
         final StreamByteArrayLoader loader = new StreamByteArrayLoader(id);
         return optionsApplier.apply(model,
-                new DrawableTypeRequest<byte[]>(model, loader, null, context, glide, requestTracker,
-                        lifecycle, optionsApplier));
+                new DrawableTypeRequest<byte[]>(model, loader, null, context, glide, requestTracker, lifecycle,
+                        optionsApplier));
     }
 
     /**


### PR DESCRIPTION
Fixes #117 

We call `executePendingTransactions()` because the sub-fragments we use to store RequestManagers and observe lifecycles per fragment/activity are not added synchronously in the `commitAllowingStateLoss()` call. Instead they are posted to the main thread and run in the next loop. 

This means that if we have two `Glide.with(fragment/activity)` calls in a row before we've added our sub-fragment we could end up adding two sub-fragments instead of one. `executePendingTransactions()` forces the fragments to be added synchronously so our second `Glide.with()` call will find the sub-fragment and not add a second one.

However it looks like certain classes, like FragmentPagerAdapter, also call `executePendingTransacations()` which means it's not safe for us to do so. In turn that means we need some other way to tell whether or not a transaction is pending so we can still avoid adding multiple sub-fragments. 

I've done so by keeping a temporary map of fragment manager to pending sub-fragment. Posting a message to a Handler that removes each temporary entry when we call `commitAllowingStateLoss()` ensures that the entry is removed when the sub-fragment is added and avoids memory leaks.

If anyone has any comments I'd welcome them, this is not particularly simple.
