### PR TITLE
Use Interface instead of abstract ListPreloader

### DIFF
--- a/library/src/main/java/com/bumptech/glide/util/FixedPreloadSizeProvider.java
+++ b/library/src/main/java/com/bumptech/glide/util/FixedPreloadSizeProvider.java
@@ -6,7 +6,7 @@ import java.util.Arrays;
 
 /**
  * A {@link com.bumptech.glide.ListPreloader.PreloadSizeProvider} with a fixed width and height.
- * @param <T>
+ * @param <T> The type of the model the size should be provided for.
  */
 public class FixedPreloadSizeProvider<T> implements ListPreloader.PreloadSizeProvider<T> {
 
@@ -23,7 +23,7 @@ public class FixedPreloadSizeProvider<T> implements ListPreloader.PreloadSizePro
     }
 
     @Override
-    public int[] getPreloadSize(T item, int position) {
+    public int[] getPreloadSize(T item) {
         return Arrays.copyOf(this.size, this.size.length);
     }
 }

--- a/library/src/main/java/com/bumptech/glide/util/ViewPreloadSizeProvider.java
+++ b/library/src/main/java/com/bumptech/glide/util/ViewPreloadSizeProvider.java
@@ -12,7 +12,7 @@ import java.util.Arrays;
 /**
  * A {@link com.bumptech.glide.ListPreloader.PreloadSizeProvider} that will extract the preload size from a given
  * {@link android.view.View}.
- * @param <T>
+ * @param <T> The type of the model the size should be provided for.
  */
 public class ViewPreloadSizeProvider<T> implements ListPreloader.PreloadSizeProvider<T>, SizeReadyCallback {
     private int[] size = null;
@@ -33,7 +33,7 @@ public class ViewPreloadSizeProvider<T> implements ListPreloader.PreloadSizeProv
     }
 
     @Override
-    public int[] getPreloadSize(T item, int position) {
+    public int[] getPreloadSize(T item) {
         if (size == null) {
             return null;
         } else {

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoGrid.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoGrid.java
@@ -168,12 +168,12 @@ public class FlickrPhotoGrid extends Fragment implements PhotoViewer {
         }
 
         @Override
-        public Photo getPreloadItem(int position) {
-            return photos.get(position);
+        public List<Photo> getPreloadItems(int start, int end) {
+            return photos.subList(start, end);
         }
 
         @Override
-        public GenericRequestBuilder getPreloadRequestBuilder(Photo item, int position) {
+        public GenericRequestBuilder getPreloadRequestBuilder(Photo item) {
             return preloadRequest.load(item);
         }
     }

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoList.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoList.java
@@ -166,12 +166,12 @@ public class FlickrPhotoList extends Fragment implements PhotoViewer {
         }
 
         @Override
-        public Photo getPreloadItem(int position) {
-            return photos.get(position);
+        public List<Photo> getPreloadItems(int start, int end) {
+            return photos.subList(start, end);
         }
 
         @Override
-        public GenericRequestBuilder getPreloadRequestBuilder(Photo item, int position) {
+        public GenericRequestBuilder getPreloadRequestBuilder(Photo item) {
             return fullRequest
                     .thumbnail(thumbRequest.load(item))
                     .load(item);

--- a/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
+++ b/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
@@ -21,6 +21,8 @@ import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.util.ViewPreloadSizeProvider;
 
 import java.io.InputStream;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * The primary activity in the Giphy sample that allows users to view trending animated GIFs from Giphy's api.
@@ -153,12 +155,16 @@ public class MainActivity extends Activity implements Api.Monitor {
         }
 
         @Override
-        public Api.GifResult getPreloadItem(int position) {
-            return getItem(position);
+        public List<Api.GifResult> getPreloadItems(int start, int end) {
+            List<Api.GifResult> items = new ArrayList<Api.GifResult>(end - start);
+            for (int i = start; i < end; i++) {
+                items.add(getItem(i));
+        }
+            return items;
         }
 
         @Override
-        public GenericRequestBuilder getPreloadRequestBuilder(Api.GifResult item, int position) {
+        public GenericRequestBuilder getPreloadRequestBuilder(Api.GifResult item) {
             return requestBuilder.load(item);
         }
     }


### PR DESCRIPTION
In your examples the ListAdapter and the final ListPreloader are strongly connected. Using an Interface will remove this strong connection.

Using an interface that an Adapter can implement has the following advantages:
1. the dimensions don´t must be passed to the ListPreloader while the Adapter has the first access to the dimensions of the ImageView
2. you don´t have to pass the items to the ListPreloader, while the Adapter already has the newest set of items (e.g.: CursorAdapter)
3. in most cases the ListAdapter already has an RequestBuilder, so you don´t have to pass them twice
4. you get rid of an extra class (ListPreloader) you have to implement

Take a look at adjusted samples in this PullRequest (e.g.: FlickrPhotoList [FlickrPhotoList.java](https://github.com/DavidWiesner/glide/commit/78e46914d418885eeffaedade154bb677a18dc31#diff-ce67ed1d36407a6c2aa6b69fd7d9132f) )

To achieve i moved the abstact methods to an new interface PreloadModelProvider that later will be passed as argument to the ListPreloader

**Future Work**
Think about changing the request to the PreloadModelProvider to  load the preload items one by one instead of requesting a list of items. If you do so you can get ride of the extra List of items will be created in the Adapter.

regards,
David
