### PR TITLE
Add an original size constant.

### DIFF
--- a/library/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
+++ b/library/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
@@ -10,10 +10,13 @@ import android.graphics.Bitmap;
 
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.request.target.Target;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
@@ -21,11 +24,12 @@ import org.robolectric.annotation.Config;
 @Config(manifest = Config.NONE, emulateSdk = 18)
 public class BitmapTransformationTest {
 
+    @Mock
     private BitmapPool bitmapPool;
 
     @Before
     public void setUp() {
-        bitmapPool = mock(BitmapPool.class);
+        MockitoAnnotations.initMocks(this);
     }
 
     @Test
@@ -42,14 +46,12 @@ public class BitmapTransformationTest {
             }
         };
 
-        Resource<Bitmap> resource = mock(Resource.class);
-        when(resource.get()).thenReturn(Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_4444));
+        Resource<Bitmap> resource = mockResource(100, 100);
         assertEquals(resource, transformation.transform(resource, 1, 1));
     }
 
     @Test
     public void testReturnsNewResourceWhenBitmapTransformed() {
-        final Bitmap toTransform = Bitmap.createBitmap(1, 2, Bitmap.Config.RGB_565);
         final Bitmap transformed = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_4444);
         BitmapTransformation transformation = new BitmapTransformation(bitmapPool) {
             @Override
@@ -63,9 +65,7 @@ public class BitmapTransformationTest {
             }
         };
 
-        Resource<Bitmap> resource = mock(Resource.class);
-        when(resource.get()).thenReturn(toTransform);
-
+        Resource<Bitmap> resource = mockResource(1, 2);
         assertNotSame(resource, transformation.transform(resource, 100, 100));
     }
 
@@ -73,15 +73,15 @@ public class BitmapTransformationTest {
     public void testPassesGivenArgumentsToTransform() {
         final int expectedWidth = 13;
         final int expectedHeight = 148;
-        final Bitmap expected = Bitmap.createBitmap(223, 4123, Bitmap.Config.RGB_565);
+        final Resource<Bitmap> resource = mockResource(223, 4123);
         BitmapTransformation transformation = new BitmapTransformation(bitmapPool) {
             @Override
             protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
                 assertEquals(bitmapPool, pool);
-                assertEquals(expected, toTransform);
+                assertEquals(resource.get(), toTransform);
                 assertEquals(expectedWidth, outWidth);
                 assertEquals(expectedHeight, outHeight);
-                return expected;
+                return resource.get();
             }
 
             @Override
@@ -89,8 +89,7 @@ public class BitmapTransformationTest {
                 return null;
             }
         };
-        Resource<Bitmap> resource = mock(Resource.class);
-        when(resource.get()).thenReturn(expected);
+
         transformation.transform(resource, expectedWidth, expectedHeight);
     }
 
@@ -145,8 +144,58 @@ public class BitmapTransformationTest {
             }
         };
 
-        Resource<Bitmap> resource = mock(Resource.class);
-        when(resource.get()).thenReturn(Bitmap.createBitmap(100, 100, Bitmap.Config.RGB_565));
+        Resource<Bitmap> resource = mockResource(100, 100);
         assertNull(transform.transform(resource, 100, 100));
+    }
+
+    @Test
+    public void testCallsTransformWithGivenBitmapWidthIfWidthIsSizeOriginal() {
+        SizeTrackingTransform transform = new SizeTrackingTransform();
+
+        int expectedWidth = 200;
+        Resource<Bitmap> resource = mockResource(expectedWidth, 300);
+        transform.transform(resource, Target.SIZE_ORIGINAL, 500);
+
+        assertEquals(expectedWidth, transform.givenWidth);
+    }
+
+    @Test
+    public void testCallsTransformWithGivenBitmapHeightIfHeightIsSizeOriginal() {
+        SizeTrackingTransform transform = new SizeTrackingTransform();
+
+        int expectedHeight = 500;
+        Resource<Bitmap> resource = mockResource(123, expectedHeight);
+        transform.transform(resource, 444, expectedHeight);
+
+        assertEquals(expectedHeight, transform.givenHeight);
+    }
+
+    @SuppressWarnings("unchecked")
+    private Resource<Bitmap> mockResource(int width, int height) {
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Resource<Bitmap> resource = mock(Resource.class);
+        when(resource.get()).thenReturn(bitmap);
+        return resource;
+    }
+
+    private class SizeTrackingTransform extends BitmapTransformation {
+        int givenWidth;
+        int givenHeight;
+
+        public SizeTrackingTransform() {
+            super(bitmapPool);
+        }
+
+        @Override
+        protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+            givenWidth = outWidth;
+            givenHeight = outHeight;
+            return null;
+        }
+
+        @Override
+        public String getId() {
+            return null;
+        }
     }
 }

--- a/library/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
+++ b/library/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
@@ -4,6 +4,7 @@ import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.mock;
@@ -136,6 +137,22 @@ public class TransformationUtilsTest {
     }
 
     @Test
+    public void testCenterCropReturnsNullIfGivenBitmapIsNull() {
+        Bitmap transformed = TransformationUtils.centerCrop(null /*recycled*/, null /*toCrop*/, 100, 100);
+        assertNull(transformed);
+    }
+
+    @Test
+    public void testCenterCropReturnsGivenBitmapIfGivenBitmapExactlyMatchesGivenDimensions() {
+        Bitmap toCrop = Bitmap.createBitmap(200, 300, Bitmap.Config.ARGB_8888);
+        Bitmap transformed = TransformationUtils.centerCrop(null /*recycled*/, toCrop, toCrop.getWidth(),
+                toCrop.getHeight());
+
+        // Robolectric incorrectly implements equals() for Bitmaps, we want the original object not just an equivalent.
+        assertTrue(toCrop == transformed);
+    }
+
+    @Test
     public void testCenterCropSetsOutBitmapToHaveAlphaIfInBitmapHasAlphaAndOutBitmapIsReused() {
         Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
 
@@ -179,7 +196,7 @@ public class TransformationUtilsTest {
     }
 
     @Test
-    public void testSetsOutBitmapToNotHaveAlphaIfInBitmapDoesNotHaveAlpha() {
+    public void testCenterCropSetsOutBitmapToNotHaveAlphaIfInBitmapDoesNotHaveAlpha() {
         Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
 
         toTransform.setHasAlpha(false);

--- a/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
@@ -643,8 +643,7 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
                     break;
                 //$CASES-OMITTED$
                 default:
-                    // silently ignore
-                    break;
+                    // Do nothing.
             }
         }
 
@@ -654,10 +653,10 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
     /**
      * Returns a future that can be used to do a blocking get on a background thread.
      *
-     * @param width The desired width in pixels (note this will be overriden by {@link #override(int, int)} if
-     *              previously called).
-     * @param height The desired height in pixels (note this will be overriden by {@link #override(int, int)}}
-     *               if previously called).
+     * @param width The desired width in pixels, or {@link Target#SIZE_ORIGINAL}. This will be overridden by
+     *             {@link #override * (int, int)} if previously called.
+     * @param height The desired height in pixels, or {@link Target#SIZE_ORIGINAL}. This will be overridden by
+     *              {@link #override * (int, int)}} if previously called).
      *
      * @see Glide#clear(com.bumptech.glide.request.FutureTarget)
      *
@@ -689,11 +688,32 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
      *     available quickly.
      * </p>
      *
+     *
      * @see com.bumptech.glide.ListPreloader
+     *
+     * @param width The desired width in pixels, or {@link Target#SIZE_ORIGINAL}. This will be overridden by
+     *             {@link #override * (int, int)} if previously called.
+     * @param height The desired height in pixels, or {@link Target#SIZE_ORIGINAL}. This will be overridden by
+     *              {@link #override * (int, int)}} if previously called).
+     * @return A {@link Target} that can be used to cancel the load via
+     *        {@link Glide#clear(com.bumptech.glide.request.target.Target)}.
      */
     public Target<TranscodeType> preload(int width, int height) {
         final PreloadTarget<TranscodeType> target = PreloadTarget.obtain(width, height);
         return into(target);
+    }
+
+    /**
+     * Preloads the resource into the cache using {@link Target#SIZE_ORIGINAL} as the target width and height.
+     * Equivalent to calling {@link #preload(int, int)} with {@link Target#SIZE_ORIGINAL} as the width and height.
+     *
+     * @see #preload(int, int)
+     *
+     * @return A {@link Target} that can be used to cancel the load via
+     *        {@link Glide#clear(com.bumptech.glide.request.target.Target)}.
+     */
+    public Target<TranscodeType> preload() {
+        return preload(Target.SIZE_ORIGINAL, Target.SIZE_ORIGINAL);
     }
 
     void applyCenterCrop() {

--- a/library/src/main/java/com/bumptech/glide/load/ResourceDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/ResourceDecoder.java
@@ -26,8 +26,12 @@ public interface ResourceDecoder<T, Z> {
      * </p>
      *
      * @param source The data the resource should be decoded from.
-     * @param width The ideal width in pixels of the decoded resource.
-     * @param height The ideal height in pixels of the decoded resource.
+     * @param width The ideal width in pixels of the decoded resource, or
+     *              {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate the original resource
+     *              width.
+     * @param height The ideal height in pixels of the decoded resource, or
+     *               {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate the original resource
+     *               height.
      * @throws IOException
      */
     Resource<Z> decode(T source, int width, int height) throws IOException;

--- a/library/src/main/java/com/bumptech/glide/load/Transformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/Transformation.java
@@ -21,8 +21,12 @@ public interface Transformation<T> {
      * </p>
      *
      * @param resource The resource to transform.
-     * @param outWidth The width of the view or target the resource will be displayed in.
-     * @param outHeight The height of the view or target the resource will be displayed in.
+     * @param outWidth The width of the view or target the resource will be displayed in, or
+     *                 {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate the original
+     *                 resource width.
+     * @param outHeight The height of the view or target the resource will be displayed in, or
+     *                  {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate the original
+     *                  resource height.
      * @return The transformed resource.
      */
     Resource<T> transform(Resource<T> resource, int outWidth, int outHeight);

--- a/library/src/main/java/com/bumptech/glide/load/model/ModelLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ModelLoader.java
@@ -37,8 +37,12 @@ public interface ModelLoader<T, Y> {
      * </p>
      *
      * @param model The model representing the resource.
-     * @param width The width in pixels of the view or target the resource will be loaded into
-     * @param height The height in pixels of the view or target the resource will be loaded into
+     * @param width The width in pixels of the view or target the resource will be loaded into, or
+     *              {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate that the resource should
+     *              be loaded at its original width.
+     * @param height The height in pixels of the view or target the resource will be loaded into, or
+     *               {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate that the resource should
+     *               be loaded at its original height.
      * @return A {@link DataFetcher} that can obtain the data the resource can be decoded from if the resource is not
      * cached, or null if no valid {@link com.bumptech.glide.load.data.DataFetcher} could be constructed.
      */

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
@@ -7,6 +7,7 @@ import com.bumptech.glide.Glide;
 import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.request.target.Target;
 
 /**
  * A simple {@link com.bumptech.glide.load.Transformation} for transforming {@link android.graphics.Bitmap}s that
@@ -42,12 +43,15 @@ public abstract class BitmapTransformation implements Transformation<Bitmap> {
 
     @Override
     public final Resource<Bitmap> transform(Resource<Bitmap> resource, int outWidth, int outHeight) {
-        if (outWidth <= 0 || outHeight <= 0) {
+        if ((outWidth <= 0 && outWidth != Target.SIZE_ORIGINAL)
+                || (outHeight <= 0 && outHeight != Target.SIZE_ORIGINAL)) {
             throw new IllegalArgumentException("Cannot apply transformation on width: " + outWidth + " or height: "
-                    + outHeight + " less than or equal to zero");
+                    + outHeight + " less than or equal to zero and not Target.SIZE_ORIGINAL");
         }
         Bitmap toTransform = resource.get();
-        Bitmap transformed = transform(bitmapPool, toTransform, outWidth, outHeight);
+        int targetWidth = outWidth == Target.SIZE_ORIGINAL ? toTransform.getWidth() : outWidth;
+        int targetHeight = outHeight == Target.SIZE_ORIGINAL ? toTransform.getHeight() : outHeight;
+        Bitmap transformed = transform(bitmapPool, toTransform, targetWidth, targetHeight);
 
         final Resource<Bitmap> result;
         if (toTransform.equals(transformed)) {
@@ -63,13 +67,19 @@ public abstract class BitmapTransformation implements Transformation<Bitmap> {
      * Transforms the given {@link android.graphics.Bitmap} based on the given dimensions and returns the transformed
      * result.
      *
+     * <p>
+     *     outWidth and outHeight will never be {@link com.bumptech.glide.request.target.Target#SIZE_ORIGINAL}, this
+     *     class converts them to be the size of the Bitmap we're going to transform before calling this method.
+     * </p>
+     *
      * @param pool A {@link com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool} that can be used to obtain and
      *             return intermediate {@link Bitmap}s used in this transformation. For every
      *             {@link android.graphics.Bitmap} obtained from the pool during this transformation, a
      *             {@link android.graphics.Bitmap} must also be returned.
      * @param toTransform The {@link android.graphics.Bitmap} to transform.
-     * @param outWidth The ideal width of the transformed bitmap (does not need to match exactly).
-     * @param outHeight The ideal height of the transformed bitmap (does not need to match exactly).
+     * @param outWidth The ideal width of the transformed bitmap (the transformed width does not need to match exactly).
+     * @param outHeight The ideal height of the transformed bitmap (the transformed heightdoes not need to match
+     *                  exactly).
      */
     protected abstract Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight);
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -8,6 +8,7 @@ import android.util.Log;
 
 import com.bumptech.glide.load.DecodeFormat;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.util.ByteArrayPool;
 import com.bumptech.glide.util.ExceptionCatchingInputStream;
 import com.bumptech.glide.util.Util;
@@ -168,13 +169,16 @@ public abstract class Downsampler implements BitmapDecoder<InputStream> {
     }
 
     private int getRoundedSampleSize(int degreesToRotate, int inWidth, int inHeight, int outWidth, int outHeight) {
+        int targetHeight = outHeight == Target.SIZE_ORIGINAL ? inHeight : outHeight;
+        int targetWidth = outWidth == Target.SIZE_ORIGINAL ? inWidth : outWidth;
+
         final int exactSampleSize;
         if (degreesToRotate == 90 || degreesToRotate == 270) {
             // If we're rotating the image +-90 degrees, we need to downsample accordingly so the image width is
             // decreased to near our target's height and the image height is decreased to near our target width.
-            exactSampleSize = getSampleSize(inHeight, inWidth, outWidth, outHeight);
+            exactSampleSize = getSampleSize(inHeight, inWidth, targetWidth, targetHeight);
         } else {
-            exactSampleSize = getSampleSize(inWidth, inHeight, outWidth, outHeight);
+            exactSampleSize = getSampleSize(inWidth, inHeight, targetWidth, targetHeight);
         }
 
         // BitmapFactory only accepts powers of 2, so it will round down to the nearest power of two that is less than
@@ -264,10 +268,10 @@ public abstract class Downsampler implements BitmapDecoder<InputStream> {
      *
      * @see android.graphics.BitmapFactory.Options#inSampleSize
      *
-     * @param inWidth The width of the image to be downsampled.
-     * @param inHeight The height of the image to be downsampled.
-     * @param outWidth The width of the view/target the image will be displayed in.
-     * @param outHeight The height of the view/target the imag will be displayed in.
+     * @param inWidth The width in pixels of the image to be downsampled.
+     * @param inHeight The height in piexels of the image to be downsampled.
+     * @param outWidth The width in pixels of the view/target the image will be displayed in.
+     * @param outHeight The height in pixels of the view/target the imag will be displayed in.
      * @return An integer to pass in to {@link BitmapFactory#decodeStream(java.io.InputStream, android.graphics.Rect,
      *          android.graphics.BitmapFactory.Options)}.
      */

--- a/library/src/main/java/com/bumptech/glide/request/target/AppWidgetTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/AppWidgetTarget.java
@@ -32,9 +32,9 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
      * @param context     Context to use in the AppWidgetManager initialization.
      * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
      * @param viewId      The id of the ImageView view that will load the image.
-     * @param width       Desired width of the bitmap that will be loaded.(Need to be manually set
+     * @param width       Desired width in pixels of the bitmap that will be loaded. (Needs to be manually set
      *                    because of RemoteViews limitations.)
-     * @param height      Desired height of the bitmap that will be loaded. (Need to be manually set
+     * @param height      Desired height in pixels of the bitmap that will be loaded. (Needs to be manually set
      *                    because of RemoteViews limitations.)
      * @param widgetIds   The int[] that contains the widget ids of an application.
      */
@@ -61,8 +61,8 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
     }
 
     /**
-     * Constructor using an int array of widgetIds to get a handle on the Widget in order to update it when an override
-     * width and height have been set been set.
+     * Constructor using an int array of widgetIds to get a handle on the Widget in order to update it that uses
+     * {@link #SIZE_ORIGINAL} as the target width and height.
      *
      * @param context     Context to use in the AppWidgetManager initialization.
      * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
@@ -70,7 +70,7 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
      * @param widgetIds   The int[] that contains the widget ids of an application.
      */
     public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId, int... widgetIds) {
-        this(context, remoteViews, viewId, INVALID_SIZE, INVALID_SIZE, widgetIds);
+        this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, widgetIds);
     }
 
     /**
@@ -79,9 +79,9 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
      * @param context     Context to use in the AppWidgetManager initialization.
      * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
      * @param viewId      The id of the ImageView view that will load the image.
-     * @param width       Desired width of the bitmap that will be loaded.(Need to be manually set
+     * @param width       Desired width in pixels of the bitmap that will be loaded. (Needs to be manually set
      *                    because of RemoteViews limitations.)
-     * @param height      Desired height of the bitmap that will be loaded. (Need to be manually set
+     * @param height      Desired height in pixels of the bitmap that will be loaded. (Needs to be manually set
      *                    because of RemoteViews limitations.)
      * @param componentName   The ComponentName that refers to our AppWidget.
      */
@@ -106,7 +106,7 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
 
     /**
      * Constructor using a ComponentName, when override has been set to get a handle on the Widget in order to update
-     * it.
+     * it that uses {@link #SIZE_ORIGINAL} as the target width and height.
      *
      * @param context     Context to use in the AppWidgetManager initialization.
      * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
@@ -114,7 +114,7 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
      * @param componentName   The ComponentName that refers to our AppWidget.
      */
     public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId, ComponentName componentName) {
-        this(context, remoteViews, viewId, INVALID_SIZE, INVALID_SIZE, componentName);
+        this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, componentName);
     }
 
     /**

--- a/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
@@ -27,7 +27,7 @@ public class NotificationTarget extends SimpleTarget<Bitmap> {
 
     /**
      * Constructor using a Notification object and a notificationId to get a handle on the Notification in order to
-     * update it when an override width and height have been set.
+     * update it that uses {@link #SIZE_ORIGINAL} as the target width and height.
      *
      * @param context     Context to use in the AppWidgetManager initialization.
      * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
@@ -37,7 +37,7 @@ public class NotificationTarget extends SimpleTarget<Bitmap> {
      */
     public NotificationTarget(Context context, RemoteViews remoteViews, int viewId, Notification notification,
             int  notificationId) {
-        this(context, remoteViews, viewId, INVALID_SIZE, INVALID_SIZE, notification, notificationId);
+        this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, notification, notificationId);
     }
 
     /**

--- a/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
@@ -24,24 +24,14 @@ package com.bumptech.glide.request.target;
  * @param <Z> The type of resource that this target will receive.
  */
 public abstract class SimpleTarget<Z> extends BaseTarget<Z> {
-    /** A constant indicating an invalid pixel size. */
-    protected static final int INVALID_SIZE = -1;
-
     private final int width;
     private final int height;
 
     /**
-     * Constructor for the target that assumes you will have called
-     * {@link com.bumptech.glide.GenericRequestBuilder#override(int, int)} on the request builder this target is given
-     * to.
-     *
-     * <p>
-     *     Requests that load into this target will throw an {@link java.lang.IllegalArgumentException} if
-     *     {@link com.bumptech.glide.GenericRequestBuilder#override(int, int)} was not called on the request builder.
-     * </p>
+     * Constructor for the target that uses {@link Target#SIZE_ORIGINAL} as the target width and height.
      */
     public SimpleTarget() {
-        this(INVALID_SIZE, INVALID_SIZE);
+        this(SIZE_ORIGINAL, SIZE_ORIGINAL);
     }
 
     /**

--- a/library/src/main/java/com/bumptech/glide/request/target/SizeReadyCallback.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/SizeReadyCallback.java
@@ -8,8 +8,10 @@ public interface SizeReadyCallback {
     /**
      * A callback called on the main thread.
      *
-     * @param width The width in pixels of the target.
-     * @param height The height in pixels of the target.
+     * @param width The width in pixels of the target, or {@link Target#SIZE_ORIGINAL} to indicate that we want the
+     *              resource at its original width.
+     * @param height The height in pixels of the target, or {@link Target#SIZE_ORIGINAL} to indicate that we want the
+     *               resource at its original height.
      */
     void onSizeReady(int width, int height);
 }

--- a/library/src/main/java/com/bumptech/glide/request/target/Target.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/Target.java
@@ -27,6 +27,10 @@ import com.bumptech.glide.request.animation.GlideAnimation;
  * @param <R> The type of resource the target can display.
  */
 public interface Target<R> extends LifecycleListener {
+    /**
+     * Indicates that we want the resource in its original unmodified width and/or height.
+     */
+    int SIZE_ORIGINAL = Integer.MIN_VALUE;
 
     /**
      * A lifecycle callback that is called when a load is started.


### PR DESCRIPTION
I'm still defaulting to screen dimensions when given wrap_content for Views on the theory that, on average, downsampling to around the screen size and providing an image that can be displayed (isn't over the max gl texture size) and that won't blow through huge quantities of memory is preferable, despite the occasional issue with cropping (see #151). Although this is safer from a display/memory perspective, it's also less correct. You could definitely make a reasonable argument that `WRAP_CONTENT` should be treated as `SIZE_ORIGINAL`.

All that said, I did included fixes for #135, so if `WRAP_CONTENT` is set for only one of width/height, we will only substitute in the screen size for the single dimension. I'd expect that change will at least mitigate some of the issues people have raised in #151 and #263.
