### PR TITLE
fixed the null model within thumbnail request

### DIFF
--- a/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
@@ -763,6 +763,11 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
             ThumbnailRequestCoordinator coordinator = new ThumbnailRequestCoordinator(parentCoordinator);
             Request fullRequest = obtainRequest(target, sizeMultiplier, priority, coordinator);
             // Recursively generate thumbnail requests.
+            if(!thumbnailRequestBuilder.isModelSet && thumbnailRequestBuilder.modelClass.isInstance( this.model )) {
+                @SuppressWarnings("unchecked")
+                GenericRequestBuilder<ModelType, ?, ?, TranscodeType> theBuilder = ( GenericRequestBuilder<ModelType, ?, ?, TranscodeType> )thumbnailRequestBuilder;
+                theBuilder.model = this.model;
+            }
             Request thumbRequest = thumbnailRequestBuilder.buildRequestRecursive(target, coordinator);
             coordinator.setRequests(fullRequest, thumbRequest);
             return coordinator;


### PR DESCRIPTION
The thumbnail request model is null when use "GenericRequestBuilder.thumbnail(GenericRequestBuilder<?, ?, ?, TranscodeType>)", it cause the thumbnail request do nothing.

For example

``` java
DrawableRequestBuilder<Uri> fullRequest = Glide.with( context ).fromUri();
DrawableRequestBuilder<Uri> thumbnailRequest = Glide.with( context ).fromUri().override( 160, 160 );
fullRequest.thumbnail( thumbnailRequest );
fullRequest.load( uri ).into( target );
```

Then, in the "com.bumptech.glide.GenericRequestBuilder.buildRequestRecursive(Target<TranscodeType>, ThumbnailRequestCoordinator)"

``` java
Request thumbRequest = thumbnailRequestBuilder.buildRequestRecursive(target, coordinator); // created request's model is null
```
