### PR TITLE
Before draw bitmap, check bitmap was recycled.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapDrawable.java
@@ -98,7 +98,9 @@ public class GlideBitmapDrawable extends GlideDrawable {
             Gravity.apply(BitmapState.GRAVITY, width, height, getBounds(), destRect);
             applyGravity = false;
         }
-        canvas.drawBitmap(state.bitmap, null, destRect, state.paint);
+        if (!state.bitmap.isRecycled()) {
+            canvas.drawBitmap(state.bitmap, null, destRect, state.paint);
+        }
     }
 
     @Override


### PR DESCRIPTION
sometimes glide occured exception as java.lang.IllegalArgumentException

exception message

```
GlideBitmapDrawable.java line 101 in GlideBitmapDrawable.draw()
Cannot draw recycled bitmaps
```

so add checking bitmap was recycled.

I reviewed GifDrawable.java. it was checked recycle state.
so add same one to GlideBitmapDrawable.java