### PR TITLE
Set view tag to null in clear(View view) to avoid memory leak.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -450,6 +450,7 @@ public class Glide {
     public static void clear(View view) {
         Target<?> viewTarget = new ClearTarget(view);
         clear(viewTarget);
+        view.setTag(null);
     }
 
     /**


### PR DESCRIPTION
If the ImageView is used in recyclable view (like ListView), when the request is cleared, should set ImageView tag to null, or else there maybe a reference to GlideBitmapDrawableResource, which takes a big memory.