### PR TITLE
Do not try to clear a non existent request

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
@@ -220,7 +220,9 @@ public class RequestFutureTarget<T, R> implements FutureTarget<R>, Runnable {
      */
     @Override
     public void run() {
-        request.clear();
+        if (request != null) {
+            request.clear();
+        }
     }
 
     /**


### PR DESCRIPTION
During some test with Glide and FutureTarget it appears that when you cancel a FutureTarget very fast, the request may not yet be set in RequestFutureTarget leading to a crash.

This simple PR fix this case.