### PR TITLE
make ConnectivityMonitorFactory injectable

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -294,7 +294,7 @@ public class Glide implements ComponentCallbacks2 {
     return arrayPool;
   }
 
-  public ConnectivityMonitorFactory getConnectivityMonitorFactory() {
+  ConnectivityMonitorFactory getConnectivityMonitorFactory() {
     return connectivityMonitorFactory;
   }
 

--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -62,6 +62,7 @@ import com.bumptech.glide.load.resource.gif.StreamGifDecoder;
 import com.bumptech.glide.load.resource.transcode.BitmapBytesTranscoder;
 import com.bumptech.glide.load.resource.transcode.BitmapDrawableTranscoder;
 import com.bumptech.glide.load.resource.transcode.GifDrawableBytesTranscoder;
+import com.bumptech.glide.manager.ConnectivityMonitorFactory;
 import com.bumptech.glide.manager.RequestManagerRetriever;
 import com.bumptech.glide.module.GlideModule;
 import com.bumptech.glide.module.ManifestParser;
@@ -96,6 +97,7 @@ public class Glide implements ComponentCallbacks2 {
   private final Registry registry;
   private final ArrayPool arrayPool;
   private final ByteArrayPool byteArrayPool;
+  private final ConnectivityMonitorFactory connectivityMonitorFactory;
   private final List<RequestManager> managers = new ArrayList<>();
 
   /**
@@ -169,17 +171,19 @@ public class Glide implements ComponentCallbacks2 {
 
   @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   Glide(
+      Context context,
       Engine engine,
       MemoryCache memoryCache,
       BitmapPool bitmapPool,
       ArrayPool arrayPool,
-      Context context,
+      ConnectivityMonitorFactory connectivityMonitorFactory,
       int logLevel,
       RequestOptions defaultRequestOptions) {
     this.engine = engine;
     this.bitmapPool = bitmapPool;
     this.arrayPool = arrayPool;
     this.memoryCache = memoryCache;
+    this.connectivityMonitorFactory = connectivityMonitorFactory;
     this.byteArrayPool = new LruByteArrayPool();
 
     DecodeFormat decodeFormat = defaultRequestOptions.getOptions().get(Downsampler.DECODE_FORMAT);
@@ -288,6 +292,10 @@ public class Glide implements ComponentCallbacks2 {
 
   public ArrayPool getArrayPool() {
     return arrayPool;
+  }
+
+  public ConnectivityMonitorFactory getConnectivityMonitorFactory() {
+    return connectivityMonitorFactory;
   }
 
   GlideContext getGlideContext() {

--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -17,6 +17,8 @@ import com.bumptech.glide.load.engine.cache.LruResourceCache;
 import com.bumptech.glide.load.engine.cache.MemoryCache;
 import com.bumptech.glide.load.engine.cache.MemorySizeCalculator;
 import com.bumptech.glide.load.engine.executor.GlideExecutor;
+import com.bumptech.glide.manager.ConnectivityMonitorFactory;
+import com.bumptech.glide.manager.DefaultConnectivityMonitorFactory;
 import com.bumptech.glide.request.RequestOptions;
 
 /**
@@ -33,6 +35,7 @@ public final class GlideBuilder {
   private GlideExecutor diskCacheExecutor;
   private DiskCache.Factory diskCacheFactory;
   private MemorySizeCalculator memorySizeCalculator;
+  private ConnectivityMonitorFactory connectivityMonitorFactory;
   private int logLevel = Log.INFO;
   private RequestOptions defaultRequestOptions = new RequestOptions();
 
@@ -206,6 +209,19 @@ public final class GlideBuilder {
   }
 
   /**
+   * Sets the {@link com.bumptech.glide.manager.ConnectivityMonitorFactory}
+   * to use to notify {@link com.bumptech.glide.RequestManager} of connectivity events.
+   * If not set {@link com.bumptech.glide.manager.DefaultConnectivityMonitorFactory} would be used.
+   *
+   * @param factory The factory to use
+   * @return This builder.
+   */
+  public GlideBuilder setConnectivityMonitorFactory(ConnectivityMonitorFactory factory) {
+    this.connectivityMonitorFactory = factory;
+    return this;
+  }
+
+  /**
    * Sets a log level constant from those in {@link Log} to indicate the desired log verbosity.
    *
    * <p>The level must be one of {@link Log#VERBOSE}, {@link Log#DEBUG}, {@link Log#INFO},
@@ -258,6 +274,10 @@ public final class GlideBuilder {
       memorySizeCalculator = new MemorySizeCalculator.Builder(context).build();
     }
 
+    if (connectivityMonitorFactory == null) {
+      connectivityMonitorFactory = new DefaultConnectivityMonitorFactory();
+    }
+
     if (bitmapPool == null) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.HONEYCOMB) {
         int size = memorySizeCalculator.getBitmapPoolSize();
@@ -284,11 +304,12 @@ public final class GlideBuilder {
     }
 
     return new Glide(
+        context,
         engine,
         memoryCache,
         bitmapPool,
         arrayPool,
-        context,
+        connectivityMonitorFactory,
         logLevel,
         defaultRequestOptions.lock());
   }

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -73,7 +73,8 @@ public class RequestManager implements LifecycleListener {
   private BaseRequestOptions<?> requestOptions;
 
   public RequestManager(Context context, Lifecycle lifecycle, RequestManagerTreeNode treeNode) {
-    this(context, lifecycle, treeNode, new RequestTracker(), new ConnectivityMonitorFactory());
+    this(context, lifecycle, treeNode,
+        new RequestTracker(), Glide.get(context).getConnectivityMonitorFactory());
   }
 
   RequestManager(Context context, final Lifecycle lifecycle, RequestManagerTreeNode treeNode,

--- a/library/src/main/java/com/bumptech/glide/manager/ConnectivityMonitorFactory.java
+++ b/library/src/main/java/com/bumptech/glide/manager/ConnectivityMonitorFactory.java
@@ -1,23 +1,16 @@
 package com.bumptech.glide.manager;
 
 import android.content.Context;
-import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
 
 /**
- * A factory class that produces a functional {@link com.bumptech.glide.manager.ConnectivityMonitor}
- * if the application has the {@code android.permission.ACCESS_NETWORK_STATE} permission and a no-op
- * non functional {@link com.bumptech.glide.manager.ConnectivityMonitor} if the app does not have
- * the required permission.
+ * A factory class that produces a functional
+ * {@link com.bumptech.glide.manager.ConnectivityMonitor}.
  */
-public class ConnectivityMonitorFactory {
-  public ConnectivityMonitor build(Context context,
-      ConnectivityMonitor.ConnectivityListener listener) {
-    final int res = context.checkCallingOrSelfPermission("android.permission.ACCESS_NETWORK_STATE");
-    final boolean hasPermission = res == PackageManager.PERMISSION_GRANTED;
-    if (hasPermission) {
-      return new DefaultConnectivityMonitor(context, listener);
-    } else {
-      return new NullConnectivityMonitor();
-    }
-  }
+public interface ConnectivityMonitorFactory {
+
+  @NonNull
+  ConnectivityMonitor build(
+      @NonNull Context context,
+      @NonNull ConnectivityMonitor.ConnectivityListener listener);
 }

--- a/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitor.java
+++ b/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitor.java
@@ -7,6 +7,9 @@ import android.content.IntentFilter;
 import android.net.ConnectivityManager;
 import android.net.NetworkInfo;
 
+/**
+ * Uses {@link android.net.ConnectivityManager} to identify connectivity changes.
+ */
 class DefaultConnectivityMonitor implements ConnectivityMonitor {
   private final Context context;
   private final ConnectivityListener listener;

--- a/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactory.java
+++ b/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactory.java
@@ -1,0 +1,27 @@
+package com.bumptech.glide.manager;
+
+import android.content.Context;
+import android.content.pm.PackageManager;
+import android.support.annotation.NonNull;
+
+/**
+ * A factory class that produces a functional {@link com.bumptech.glide.manager.ConnectivityMonitor}
+ * if the application has the {@code android.permission.ACCESS_NETWORK_STATE} permission and a no-op
+ * non functional {@link com.bumptech.glide.manager.ConnectivityMonitor} if the app does not have
+ * the required permission.
+ */
+public class DefaultConnectivityMonitorFactory implements ConnectivityMonitorFactory {
+
+  @NonNull
+  public ConnectivityMonitor build(
+      @NonNull Context context,
+      @NonNull ConnectivityMonitor.ConnectivityListener listener) {
+    final int res = context.checkCallingOrSelfPermission("android.permission.ACCESS_NETWORK_STATE");
+    final boolean hasPermission = res == PackageManager.PERMISSION_GRANTED;
+    if (hasPermission) {
+      return new DefaultConnectivityMonitor(context, listener);
+    } else {
+      return new NullConnectivityMonitor();
+    }
+  }
+}

--- a/library/src/test/java/com/bumptech/glide/manager/ConnectivityMonitorFactoryTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/ConnectivityMonitorFactoryTest.java
@@ -18,7 +18,7 @@ public class ConnectivityMonitorFactoryTest {
 
   @Before
   public void setUp() {
-    factory = new ConnectivityMonitorFactory();
+    factory = new DefaultConnectivityMonitorFactory();
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactoryTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactoryTest.java
@@ -13,7 +13,7 @@ import org.robolectric.shadows.ShadowApplication;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 18)
-public class ConnectivityMonitorFactoryTest {
+public class DefaultConnectivityMonitorFactoryTest {
   private ConnectivityMonitorFactory factory;
 
   @Before


### PR DESCRIPTION
Our app needs some higher level connectivity states not related to just android.net.ConnectivityManager (e.g. work via wi-fi ony or offline at despite device connectivity), so this change allows Glide to respect such states