### PR TITLE
Reorder AppWidgetTarget arguments to help Java disambiguate varargs

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/AppWidgetTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/AppWidgetTarget.java
@@ -17,7 +17,6 @@ import com.bumptech.glide.util.Preconditions;
  * for every subsequent load. </p>
  */
 public class AppWidgetTarget extends SimpleTarget<Bitmap> {
-
   private final int[] widgetIds;
   private final ComponentName componentName;
   private final RemoteViews remoteViews;
@@ -29,16 +28,16 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
    * it.
    *
    * @param context     Context to use in the AppWidgetManager initialization.
-   * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
-   * @param viewId      The id of the ImageView view that will load the image.
    * @param width       Desired width in pixels of the bitmap that will be loaded. (Needs to be
    *                    manually put because of RemoteViews limitations.)
    * @param height      Desired height in pixels of the bitmap that will be loaded. (Needs to be
    *                    manually put because of RemoteViews limitations.)
+   * @param viewId      The id of the ImageView view that will load the image.
+   * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
    * @param widgetIds   The int[] that contains the widget ids of an application.
    */
-  public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId, int width,
-      int height, int... widgetIds) {
+  public AppWidgetTarget(Context context, int width, int height,
+      int viewId, RemoteViews remoteViews, int... widgetIds) {
     super(width, height);
     if (widgetIds.length == 0) {
       throw new IllegalArgumentException("WidgetIds must have length > 0");
@@ -56,29 +55,30 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
    * that uses {@link #SIZE_ORIGINAL} as the target width and height.
    *
    * @param context     Context to use in the AppWidgetManager initialization.
-   * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
    * @param viewId      The id of the ImageView view that will load the image.
+   * @param remoteViews RemoteViews object which contains the ImageView that will load the bitmap.
    * @param widgetIds   The int[] that contains the widget ids of an application.
    */
-  public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId, int... widgetIds) {
-    this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, widgetIds);
+  public AppWidgetTarget(Context context,
+      int viewId, RemoteViews remoteViews, int... widgetIds) {
+    this(context, SIZE_ORIGINAL, SIZE_ORIGINAL, viewId, remoteViews, widgetIds);
   }
 
   /**
    * Constructor using a ComponentName to get a handle on the Widget in order to update it.
    *
    * @param context       Context to use in the AppWidgetManager initialization.
-   * @param remoteViews   RemoteViews object which contains the ImageView that will load the
-   *                      bitmap.
-   * @param viewId        The id of the ImageView view that will load the image.
    * @param width         Desired width in pixels of the bitmap that will be loaded. (Needs to be
    *                      manually put because of RemoteViews limitations.)
    * @param height        Desired height in pixels of the bitmap that will be loaded. (Needs to be
    *                      manually put because of RemoteViews limitations.)
+   * @param viewId        The id of the ImageView view that will load the image.
+   * @param remoteViews   RemoteViews object which contains the ImageView that will load the
+   *                      bitmap.
    * @param componentName The ComponentName that refers to our AppWidget.
    */
-  public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId, int width,
-      int height, ComponentName componentName) {
+  public AppWidgetTarget(Context context, int width, int height,
+      int viewId, RemoteViews remoteViews, ComponentName componentName) {
     super(width, height);
     this.context = Preconditions.checkNotNull(context, "Context can not be null!");
     this.remoteViews =
@@ -94,14 +94,14 @@ public class AppWidgetTarget extends SimpleTarget<Bitmap> {
    * order to update it that uses {@link #SIZE_ORIGINAL} as the target width and height.
    *
    * @param context       Context to use in the AppWidgetManager initialization.
+   * @param viewId        The id of the ImageView view that will load the image.
    * @param remoteViews   RemoteViews object which contains the ImageView that will load the
    *                      bitmap.
-   * @param viewId        The id of the ImageView view that will load the image.
    * @param componentName The ComponentName that refers to our AppWidget.
    */
-  public AppWidgetTarget(Context context, RemoteViews remoteViews, int viewId,
-      ComponentName componentName) {
-    this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, componentName);
+  public AppWidgetTarget(Context context,
+      int viewId, RemoteViews remoteViews, ComponentName componentName) {
+    this(context, SIZE_ORIGINAL, SIZE_ORIGINAL, viewId, remoteViews, componentName);
   }
 
   /**

--- a/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
@@ -18,7 +18,6 @@ import com.bumptech.glide.util.Preconditions;
  * for every subsequent load. </p>
  */
 public class NotificationTarget extends SimpleTarget<Bitmap> {
-
   private final RemoteViews remoteViews;
   private final Context context;
   private final int notificationId;
@@ -31,15 +30,15 @@ public class NotificationTarget extends SimpleTarget<Bitmap> {
    * height.
    *
    * @param context        Context to use in the AppWidgetManager initialization.
+   * @param viewId         The id of the ImageView view that will load the image.
    * @param remoteViews    RemoteViews object which contains the ImageView that will load the
    *                       bitmap.
-   * @param viewId         The id of the ImageView view that will load the image.
    * @param notification   The Notification object that we want to update.
    * @param notificationId The notificationId of the Notification that we want to load the Bitmap.
    */
-  public NotificationTarget(Context context, RemoteViews remoteViews, int viewId,
-      Notification notification, int notificationId) {
-    this(context, remoteViews, viewId, SIZE_ORIGINAL, SIZE_ORIGINAL, notification, notificationId);
+  public NotificationTarget(Context context,
+      int viewId, RemoteViews remoteViews, Notification notification, int notificationId) {
+    this(context, SIZE_ORIGINAL, SIZE_ORIGINAL, viewId, remoteViews, notification, notificationId);
   }
 
   /**
@@ -47,18 +46,18 @@ public class NotificationTarget extends SimpleTarget<Bitmap> {
    * Notification in order to update it.
    *
    * @param context        Context to use in the AppWidgetManager initialization.
-   * @param remoteViews    RemoteViews object which contains the ImageView that will load the
-   *                       bitmap.
-   * @param viewId         The id of the ImageView view that will load the image.
    * @param width          Desired width of the bitmap that will be loaded.(Need to be manually put
    *                       because of RemoteViews limitations.)
    * @param height         Desired height of the bitmap that will be loaded. (Need to be manually
    *                       put because of RemoteViews limitations.)
+   * @param viewId         The id of the ImageView view that will load the image.
+   * @param remoteViews    RemoteViews object which contains the ImageView that will load the
+   *                       bitmap.
    * @param notification   The Notification object that we want to update.
    * @param notificationId The notificationId of the Notification that we want to load the Bitmap.
    */
-  public NotificationTarget(Context context, RemoteViews remoteViews, int viewId, int width,
-      int height, Notification notification, int notificationId) {
+  public NotificationTarget(Context context, int width, int height,
+      int viewId, RemoteViews remoteViews, Notification notification, int notificationId) {
     super(width, height);
     this.context = Preconditions.checkNotNull(context, "Context must not be null!");
     this.notification =

--- a/library/src/test/java/com/bumptech/glide/request/target/AppWidgetTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/AppWidgetTargetTest.java
@@ -26,7 +26,6 @@ import org.robolectric.shadows.ShadowAppWidgetManager;
 @Config(manifest = Config.NONE, sdk = 18, shadows = AppWidgetTargetTest
     .UpdateShadowAppWidgetManager.class)
 public class AppWidgetTargetTest {
-
   private UpdateShadowAppWidgetManager shadowManager;
   private RemoteViews views;
   private int viewId;
@@ -43,7 +42,7 @@ public class AppWidgetTargetTest {
   public void testSetsBitmapOnRemoteViewsWithViewIdWhenCreatedWithComponentName() {
     ComponentName componentName = mock(ComponentName.class);
     AppWidgetTarget target =
-        new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, componentName);
+        new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, componentName);
 
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
     target.onResourceReady(bitmap, null /*glideAnimation*/);
@@ -55,7 +54,7 @@ public class AppWidgetTargetTest {
   public void testUpdatesAppWidgetWhenCreatedWithComponentName() {
     ComponentName componentName = mock(ComponentName.class);
     AppWidgetTarget target =
-        new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, componentName);
+        new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, componentName);
 
     target.onResourceReady(Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888), null
     /*glideAnimation*/);
@@ -68,7 +67,7 @@ public class AppWidgetTargetTest {
   public void testSetsBitmapOnRemoteViewsWithViewIdWhenCreatedWithWidgetIds() {
     int[] widgetIds = new int[] { 1 };
     AppWidgetTarget target =
-        new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, widgetIds);
+        new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, widgetIds);
 
     Bitmap bitmap = Bitmap.createBitmap(100, 200, Bitmap.Config.RGB_565);
     target.onResourceReady(bitmap, null /*glideAnimation*/);
@@ -80,7 +79,7 @@ public class AppWidgetTargetTest {
   public void testUpdatesAppWidgetWhenCreatedWithWidgetIds() {
     int[] widgetIds = new int[] { 1 };
     AppWidgetTarget target =
-        new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, widgetIds);
+        new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, widgetIds);
 
     target.onResourceReady(Bitmap.createBitmap(200, 100, Bitmap.Config.ARGB_8888), null
     /*glideAnimation*/);
@@ -91,39 +90,39 @@ public class AppWidgetTargetTest {
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullContextWithWidgetIds() {
-    new AppWidgetTarget(null /*context*/, views, 1234 /*viewId*/, 1 /*widgetIds*/);
+    new AppWidgetTarget(null /*context*/, 1234 /*viewId*/, views, 1 /*widgetIds*/);
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullContextWithComponentName() {
-    new AppWidgetTarget(null /*context*/, views, 1234 /*viewId*/, mock(ComponentName.class));
+    new AppWidgetTarget(null /*context*/, 1234 /*viewId*/, views, mock(ComponentName.class));
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullRemoteViewsWithWidgetIds() {
-    new AppWidgetTarget(RuntimeEnvironment.application, null /*remoteViews*/, viewId, 1
-    /*widgetIds*/);
+    new AppWidgetTarget(RuntimeEnvironment.application,
+        viewId, null /*remoteViews*/, 1 /*widgetIds*/);
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullRemoteViewsWithComponentName() {
-    new AppWidgetTarget(RuntimeEnvironment.application, null /*remoteViews*/, viewId,
-        mock(ComponentName.class));
+    new AppWidgetTarget(RuntimeEnvironment.application,
+        viewId, null /*remoteViews*/, mock(ComponentName.class));
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullWidgetIds() {
-    new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, (int[]) null /*widgetIds*/);
+    new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, (int[]) null /*widgetIds*/);
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testThrowsWhenGivenEmptyWidgetIds() {
-    new AppWidgetTarget(RuntimeEnvironment.application, views, viewId);
+    new AppWidgetTarget(RuntimeEnvironment.application, viewId, views);
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsWhenGivenNullComponentName() {
-    new AppWidgetTarget(RuntimeEnvironment.application, views, viewId, (ComponentName) null);
+    new AppWidgetTarget(RuntimeEnvironment.application, viewId, views, (ComponentName) null);
   }
 
   @Implements(AppWidgetManager.class)

--- a/library/src/test/java/com/bumptech/glide/request/target/NotificationTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/NotificationTargetTest.java
@@ -26,7 +26,6 @@ import org.robolectric.shadows.ShadowNotificationManager;
 @Config(manifest = Config.NONE, sdk = 18, shadows = NotificationTargetTest
     .UpdateShadowNotificationManager.class)
 public class NotificationTargetTest {
-
   private UpdateShadowNotificationManager shadowManager;
   private RemoteViews remoteViews;
   private int viewId;
@@ -47,8 +46,8 @@ public class NotificationTargetTest {
 
 
     target =
-        new NotificationTarget(RuntimeEnvironment.application, remoteViews, viewId, 100 /*width*/,
-            100 /*height*/, notification, notificationId);
+        new NotificationTarget(RuntimeEnvironment.application, 100 /*width*/, 100 /*height*/,
+            viewId, remoteViews, notification, notificationId);
   }
 
   @Test
@@ -69,22 +68,21 @@ public class NotificationTargetTest {
 
   @Test(expected = NullPointerException.class)
   public void testThrowsIfContextIsNull() {
-    new NotificationTarget(null /*context*/, mock(RemoteViews.class), 123 /*viewId*/, 100 /*width*/,
-        100 /*height*/, mock(Notification.class), 456 /*notificationId*/);
+    new NotificationTarget(null /*context*/, 100 /*width*/, 100 /*height*/,
+        123 /*viewId*/, mock(RemoteViews.class), mock(Notification.class), 456 /*notificationId*/);
   }
 
 
   @Test(expected = NullPointerException.class)
   public void testThrowsIfNotificationIsNull() {
-    new NotificationTarget(RuntimeEnvironment.application, mock(RemoteViews.class), 123 /*viewId*/,
-        100 /*width*/, 100 /*height*/, null /*notification*/, 456 /*notificationId*/);
+    new NotificationTarget(RuntimeEnvironment.application, 100 /*width*/, 100 /*height*/,
+        123 /*viewId*/, mock(RemoteViews.class), null /*notification*/, 456 /*notificationId*/);
   }
 
   @Test(expected = NullPointerException.class)
   public void testThrowsIfRemoteViewsIsNull() {
-    new NotificationTarget(RuntimeEnvironment.application, null /*remoteViews*/, 123 /*viewId*/,
-        100 /*width*/,
-        100 /*height*/, mock(Notification.class), 456 /*notificationId*/);
+    new NotificationTarget(RuntimeEnvironment.application, 100 /*width*/, 100 /*height*/,
+        123 /*viewId*/, null /*remoteViews*/, mock(Notification.class), 456 /*notificationId*/);
   }
 
   @Implements(NotificationManager.class)


### PR DESCRIPTION
When I tried to use AppWidgetTarget I ran into a problem with varargs, there are too many `int` arguments next to each other which confused Java. Consider:
```java
AppWidgetTarget(Context, RemoteViews, int, int, int, int...);
AppWidgetTarget(Context, RemoteViews, int, int...);
```
which one would you call for `AppWidgetTarget(context, rv, R.id.image, 400, 400, appWidgetId)`?

To prevent this ambiguity from coming up I reordered the arguments to be clear where the varargs start by moving `width/height/viewId` before `RemoteViews`. This is a change that requires a major version, so I think it's a good candidate for 4.0.

To keep it consistent with other `RemoteViews` targets, I also made the same change to `NotificationTarget`, however the can be no ambiguity there.