### PR TITLE
Do not re-allocate an entire MessageDigest instance for every key.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/SafeKeyGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/SafeKeyGenerator.java
@@ -14,14 +14,21 @@ import java.security.NoSuchAlgorithmException;
 public class SafeKeyGenerator {
   private final LruCache<Key, String> loadIdToSafeHash = new LruCache<>(1000);
 
-  private static String calculateHexStringDigest(Key key) {
-     try {
-        MessageDigest messageDigest = MessageDigest.getInstance("SHA-256");
-        key.updateDiskCacheKey(messageDigest);
-        return Util.sha256BytesToHex(messageDigest.digest());
-      } catch (NoSuchAlgorithmException e) {
-       throw new RuntimeException(e);
-      }
+  private static final MessageDigest MESSAGE_DIGEST;
+
+  static {
+    try {
+      MESSAGE_DIGEST = MessageDigest.getInstance("SHA-256");
+    } catch (NoSuchAlgorithmException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  private static synchronized String calculateHexStringDigest(Key key) {
+    key.updateDiskCacheKey(MESSAGE_DIGEST);
+
+    // calling digest() will automatically reset()
+    return Util.sha256BytesToHex(MESSAGE_DIGEST.digest());
   }
 
   public String getSafeKey(Key key) {


### PR DESCRIPTION
Right now, Glides `SafeKeyGenerator` creates a new `MessageDigest` instance (via `getInstance`) every time a new key needs to be generated, causing significant overhead as shown in systrace.
![screen shot 2015-12-09 at 13 02 28](https://cloud.githubusercontent.com/assets/269860/11677257/c7b60fb2-9e76-11e5-8412-b9530b1cb511.png)

It should follow http://stackoverflow.com/a/13802730/375209 and use a pre-allocated MessageDigest. 