### PR TITLE
Add filter to mavenDeployer for glide package to also distribute it with aar

### DIFF
--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -97,6 +97,12 @@ afterEvaluate { project ->
                         }
                     }
                 }
+
+                addFilter('aar_upload') { artifact, file ->
+                    artifact.name == 'Glide'
+                }
+
+                pom('aar_upload').packaging = 'aar'
             }
         }
     }


### PR DESCRIPTION
First try at this. Follow up / requirement because of #761 

I'm not quite sure whether this is the right way to go or not since I've never tried any of this before though according to the [Gradle documentation](https://docs.gradle.org/current/userguide/maven_plugin.html#sub:multiple_artifacts_per_project) this is the way. At least if I didn't misread it.