### PR TITLE
Introduce AAR publish for :library and stop publishing :glide

### DIFF
--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -44,6 +44,8 @@ def getAndroidJar() {
     "${getAndroidSdkDirectory()}/platforms/${getAndroidCompileSdkVersion()}/android.jar"
 }
 
+project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"
+
 // Generate javadocs and sources containing batched documentation and sources for all internal projects.
 ['release', 'debug'].each { variantName ->
 
@@ -102,5 +104,3 @@ artifacts {
         classifier 'sources'
     }
 }
-
-apply from: "$rootProject.projectDir/scripts/upload.gradle"

--- a/glide/gradle.properties
+++ b/glide/gradle.properties
@@ -1,4 +1,3 @@
-POM_NAME=Glide
-POM_ARTIFACT_ID=glide
+POM_NAME=Glide Full
+POM_ARTIFACT_ID=glide-full
 POM_PACKAGING=jar
-

--- a/integration/build.gradle
+++ b/integration/build.gradle
@@ -1,15 +1,1 @@
-evaluationDependsOnChildren()
-
-import com.android.build.gradle.api.BaseVariant
-subprojects {
-    android.libraryVariants.all { BaseVariant variant ->
-        def jarTask = project.tasks.create(name: "jar${variant.name.capitalize()}", type: Jar) {
-            from variant.javaCompile.destinationDir
-            exclude "**/R.class"
-            exclude "**/BuildConfig.class"
-            baseName "glide-${project.name}-integration"
-        }
-        jarTask.dependsOn variant.javaCompile
-        artifacts.add('archives', jarTask);
-    }
-}
+// keep an empty file to make sure Gradle recognizes the properties

--- a/integration/gifencoder/build.gradle
+++ b/integration/gifencoder/build.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.robolectric'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':glide')
+    compile project(':library')
 
     testCompile project(":testutil")
     testCompile "com.google.truth:truth:${TRUTH_VERSION}"
@@ -40,4 +36,4 @@ android {
     }
 }
 
-apply from: "$rootProject.projectDir/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/gifencoder/gradle.properties
+++ b/integration/gifencoder/gradle.properties
@@ -9,7 +9,3 @@ VERSION_PATCH=0
 VERSION_CODE=8
 
 POM_DESCRIPTION=An integration library allowing users to re-encode or create animated GIFs
-
-# Prefix and postfix for source and javadoc jars.
-JAR_PREFIX=glide-
-JAR_POSTFIX=-integration

--- a/integration/gradle.properties
+++ b/integration/gradle.properties
@@ -1,0 +1,3 @@
+# Prefix and postfix for source and javadoc jars.
+JAR_PREFIX=glide-
+JAR_POSTFIX=-integration

--- a/integration/okhttp/build.gradle
+++ b/integration/okhttp/build.gradle
@@ -1,11 +1,7 @@
 apply plugin: 'com.android.library'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':glide')
+    compile project(':library')
 
     compile "com.squareup.okhttp:okhttp:2.7.1"
 }
@@ -28,4 +24,4 @@ android {
     }
 }
 
-apply from: "$rootProject.projectDir/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/okhttp/gradle.properties
+++ b/integration/okhttp/gradle.properties
@@ -9,7 +9,3 @@ VERSION_PATCH=0
 VERSION_CODE=8
 
 POM_DESCRIPTION=An integration library to use OkHttp 2.x to fetch data over http/https in Glide
-
-# Prefix and postfix for source and javadoc jars.
-JAR_PREFIX=glide-
-JAR_POSTFIX=-integration

--- a/integration/okhttp3/build.gradle
+++ b/integration/okhttp3/build.gradle
@@ -1,11 +1,7 @@
 apply plugin: 'com.android.library'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':glide')
+    compile project(':library')
 
     compile "com.squareup.okhttp3:okhttp:${OK_HTTP_VERSION}"
 }
@@ -28,4 +24,4 @@ android {
     }
 }
 
-apply from: "$rootProject.projectDir/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/okhttp3/gradle.properties
+++ b/integration/okhttp3/gradle.properties
@@ -9,7 +9,3 @@ VERSION_PATCH=0
 VERSION_CODE=8
 
 POM_DESCRIPTION=An integration library to use OkHttp 3.x to fetch data over http/https in Glide
-
-# Prefix and postfix for source and javadoc jars.
-JAR_PREFIX=glide-
-JAR_POSTFIX=-integration

--- a/integration/recyclerview/build.gradle
+++ b/integration/recyclerview/build.gradle
@@ -1,11 +1,7 @@
 apply plugin: 'com.android.library'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':glide')
+    compile project(':library')
     compile "com.android.support:recyclerview-v7:${SUPPORT_V7_VERSION}"
     compile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"
 }
@@ -28,4 +24,4 @@ android {
     }
 }
 
-apply from: "$rootProject.projectDir/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/recyclerview/gradle.properties
+++ b/integration/recyclerview/gradle.properties
@@ -9,7 +9,3 @@ VERSION_PATCH=0
 VERSION_CODE=8
 
 POM_DESCRIPTION=An integration library to display images in RecyclerView.
-
-# Prefix and postfix for source and javadoc jars.
-JAR_PREFIX=glide-
-JAR_POSTFIX=-integration

--- a/integration/volley/build.gradle
+++ b/integration/volley/build.gradle
@@ -1,12 +1,8 @@
 apply plugin: 'com.android.library'
 apply plugin: 'org.robolectric'
 
-repositories {
-    mavenCentral()
-}
-
 dependencies {
-    compile project(':glide')
+    compile project(':library')
     compile "com.mcxiaoke.volley:library:${VOLLEY_VERSION}"
 
     testCompile project(":testutil")
@@ -35,4 +31,4 @@ android {
     }
 }
 
-apply from: "$rootProject.projectDir/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/volley/gradle.properties
+++ b/integration/volley/gradle.properties
@@ -9,7 +9,3 @@ VERSION_PATCH=0
 VERSION_CODE=8
 
 POM_DESCRIPTION=An integration library to use Volley to fetch data over http/https in Glide
-
-# Prefix and postfix for source and javadoc jars.
-JAR_PREFIX=glide-
-JAR_POSTFIX=-integration

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -132,3 +132,5 @@ afterEvaluate {
         }
     }
 }
+
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/library/gradle.properties
+++ b/library/gradle.properties
@@ -1,3 +1,7 @@
-POM_NAME=Glide Library
-POM_ARTIFACT_ID=library
+POM_NAME=Glide
+POM_ARTIFACT_ID=glide
 POM_PACKAGING=aar
+
+# Prefix and postfix for source and javadoc jars.
+JAR_PREFIX=glide-
+JAR_POSTFIX=

--- a/samples/svg/build.gradle
+++ b/samples/svg/build.gradle
@@ -1,7 +1,8 @@
 apply plugin: 'com.android.application'
 
-repositories {
-    mavenCentral()
+dependencies {
+    compile project(':library')
+    compile 'com.caverock:androidsvg:1.2.1'
 }
 
 android {
@@ -21,11 +22,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
-}
-
-dependencies {
-    compile project(':library')
-    compile 'com.caverock:androidsvg:1.2.1'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -15,6 +15,10 @@
  *
  *
  * Based on: https://github.com/mcxiaoke/gradle-mvn-push/blob/master/gradle-mvn-push.gradle.
+ * Local test with (..._REPOSITORY_URL properties must be full paths):
+ * gradlew clean buildArchives uploadArchives --stacktrace --info -PSNAPSHOT_REPOSITORY_URL=file://p:\projects\contrib\github-glide\repo-snapshot -PRELEASE_REPOSITORY_URL=file://p:\projects\contrib\github-glide\repo-release
+ * For faster runs add: -x check
+ * 
  */
 
 apply plugin: 'maven'
@@ -113,8 +117,6 @@ afterEvaluate { project ->
             it.buildType.name.equalsIgnoreCase('release')
         }
 
-        def androidSdkDirectory = project.android.sdkDirectory
-
         task androidJavadocs(type: Javadoc, dependsOn: compileReleaseJava) {
             source = releaseVariants.collect { it.javaCompile.source }
             classpath = files(releaseVariants.collect { files(it.javaCompile.classpath.files,
@@ -122,7 +124,7 @@ afterEvaluate { project ->
 
             options {
                 links('http://docs.oracle.com/javase/7/docs/api/')
-                linksOffline('http://d.android.com/reference', '${androidSdkDirectory}/docs/reference')
+                linksOffline('http://d.android.com/reference', "${android.sdkDirectory}/docs/reference")
             }
 
             exclude '**/BuildConfig.java'
@@ -141,9 +143,34 @@ afterEvaluate { project ->
             baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
         }
 
+        task androidLibraryJar(type: Jar, dependsOn: compileReleaseJava /* == variant.javaCompile */) {
+            from compileReleaseJava.destinationDir
+            exclude '**/R.class'
+            exclude '**/BuildConfig.class'
+            baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
+        }
+
         artifacts {
+            archives androidLibraryJar
             archives androidSourcesJar
             archives androidJavadocsJar
         }
+    } else if (project.plugins.hasPlugin('java')) {
+        task sourcesJar(type: Jar, dependsOn: classes) {
+            classifier = 'sources'
+            from sourceSets.main.allSource
+        }
+
+        task javadocsJar(type: Jar, dependsOn: javadoc) {
+            classifier = 'javadoc'
+            from javadoc.destinationDir
+        }
+
+        artifacts {
+            archives sourcesJar
+            archives javadocsJar
+        }
     }
+    logger.info("Published artifacts in ${configurations.archives}:")
+    configurations.archives.artifacts.files.files.each { logger.info("\t$it"); }
 }

--- a/third_party/gif_decoder/build.gradle
+++ b/third_party/gif_decoder/build.gradle
@@ -21,3 +21,5 @@ android {
         targetSdkVersion TARGET_SDK_VERSION as int
     }
 }
+
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/third_party/gif_decoder/gradle.properties
+++ b/third_party/gif_decoder/gradle.properties
@@ -1,0 +1,11 @@
+POM_NAME=Glide Gif Decoder Library
+POM_ARTIFACT_ID=gifdecoder
+POM_PACKAGING=aar
+
+VERSION_NAME=1.0.0-SNAPSHOT
+VERSION_MAJOR=1
+VERSION_MINOR=0
+VERSION_PATCH=0
+VERSION_CODE=1
+
+POM_DESCRIPTION=Implementation of GifDecoder that is more memory efficient to animate for Android devices.

--- a/third_party/gradle.properties
+++ b/third_party/gradle.properties
@@ -1,0 +1,3 @@
+# Prefix and postfix for source and javadoc jars.
+JAR_PREFIX=glide-
+JAR_POSTFIX=-thirdparty


### PR DESCRIPTION
Replacing PR #855.

In this PR (from commit message):
* Don't publish `:glide` as anything to Maven repos
* Build `:glide` as 'glide-full' to have a flat jar to be published on GitHub/releases
* Publish `:library` as 'group:glide' as AAR and JAR to Maven repos
* Make `:third_party:gif_decoder` and `:third_party:disklrucache` first-class published gradle dependencies
* Remove duplicated `repositories`, `VERSION_*`, `JAR_PREFIX`, `JAR_POSTFIX` declarations  
(pull constants up to `:integration` and `:third_party` level)
* Fix JavaDoc generation (Error reading file: `${androidSdkDirectory}\docs\reference\package-list`)  
* Move JAR generation to `upload.gradle` (from `integration/build.gradle`) so it's used by `:library` as well
* Add javadoc and sources JAR generation to upload.gradle for non-android `projects as well

This PR depends on sjudd/disklrucache#3

Before commit I tried with:

```
gradlew clean build assemble check buildArchives uploadArchives \
-PSNAPSHOT_REPOSITORY_URL=file://p:\projects\contrib\github-glide\repo-snapshot \
-PRELEASE_REPOSITORY_URL=file://p:\projects\contrib\github-glide\repo-release
```

and it compiled fine.

I got the following artifacts in repo-snapshot local Maven repository:
```java
com.github.bumptech.glide:glide:4.0.0-SNAPSHOT + aar (from :library)
com.github.bumptech.glide:disklrucache:1.0.0-SNAPSHOT (from :third_party)
com.github.bumptech.glide:gifdecoder:1.0.0-SNAPSHOT + aar (from :third_party)

com.github.bumptech.glide:volley-integration:2.0.0-SNAPSHOT + aar
com.github.bumptech.glide:okhttp-integration:2.0.0-SNAPSHOT + aar
com.github.bumptech.glide:okhttp3-integration:2.0.0-SNAPSHOT + aar
com.github.bumptech.glide:recyclerview-integration:2.0.0-SNAPSHOT + aar
com.github.bumptech.glide:gifencoder-integration:2.0.0-SNAPSHOT + aar
```

and `gradlew :glide:jar` gave the following artifacts:
```gradle
glide/build/libs/glide-full-4.0.0-SNAPSHOT.jar
```

Everything above includes the `-sources` and `-javadoc` classified JARs as well.