### PR TITLE
Fix breaking build for SNAPSHOT users

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -136,3 +136,13 @@ afterEvaluate {
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"
+// exclude <dependency> tag for android support-v4 library from :glide's pom
+// this will ensure that this warning will not prevent the build from completing:
+// Module 'com.github.bumptech.glide:glide:4.0.0-SNAPSHOT' depends on one or more Android Libraries but is a jar
+// most users will need to override support-v4 version anyway if a newer version is available
+// TODO make support-v4 a <scope>runtime</scope> dependency in pom.xml
+afterEvaluate {
+    uploadArchives.repositories.mavenDeployer.pom.whenConfigured { p ->
+        p.dependencies = p.dependencies.findAll { dep -> dep.artifactId != "support-v4" }
+    }
+}

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -55,6 +55,11 @@ afterEvaluate { project ->
     uploadArchives {
         repositories {
             mavenDeployer {
+                // allow uploading through FTP protocol with the following command:
+                // gradle uploadArchives -PSNAPSHOT_REPOSITORY_URL=ftp://host/repo/path -PUSERNAME=uname -PPASSWORD=passwd
+                configuration = configurations.create('deployerJars')
+                configuration.dependencies.add dependencies.create('org.apache.maven.wagon:wagon-ftp:2.2')
+
                 beforeDeployment { MavenDeployment deployment -> signing.signPom(deployment) }
 
                 pom.groupId = GROUP

--- a/third_party/gif_decoder/build.gradle
+++ b/third_party/gif_decoder/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 apply plugin: 'org.robolectric'
 
 dependencies {
-    compile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"
+    compile "com.android.support:support-annotations:${SUPPORT_V4_VERSION}"
 
     testCompile project(':testutil')
     testCompile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"


### PR DESCRIPTION
#874 broke the build for users that depend on `4.0.0-SNAPSHOT` because it displayed
```
WARNING: Module 'com.github.bumptech.glide:gifdecoder:1.0.0-SNAPSHOT' depends on one or more Android Libraries but is a jar
WARNING: Module 'com.github.bumptech.glide:glide:4.0.0-SNAPSHOT' depends on one or more Android Libraries but is a jar
:app:prepareDebugDependencies FAILED
...
* Exception is:
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':app:prepareDebugDependencies'.
...
Caused by: org.gradle.api.GradleException: Dependency Error. See console for details
        at com.android.build.gradle.internal.tasks.PrepareDependenciesTask.prepare(PrepareDependenciesTask.groovy:69)
```

This is for two reasons:
 * `:third_party:gif_decoder` depended on support-v4 to pull in the annotations. This means that it cannot be referenced as a JAR, because it depends on an AAR (support-v4 is only available as AAR since 20.0.0).
 * `:library` depends on `support-v4`, which is still needed. We can however trick Gradle into accepting the JAR file by removing the `<dependency>` from the `pom.xml`. It should be `<scope>runtime</scope>`, but I couldn't figure out yet how to do it.

The build may continue to break for those users who only depend on `:glide` and rely on that dependency to transitively pull in `support-v4`, but the error message and the fix should be trivial and hopefully there aren't many out there who don't include `support-v4` to have latest version included in the APK.
