### PR TITLE
cleans up Memory leak, because raw data was not released

### DIFF
--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
@@ -352,6 +352,7 @@ public class GifDecoder {
             bitmapProvider.release(previousImage);
         }
         previousImage = null;
+        rawData = null;
     }
 
     public void setData(GifHeader header, byte[] data) {


### PR DESCRIPTION
We had large memory leaks with gifs. After investigating the memory we found the problem in the "raw_data" of the released gif decoder, which was in the pool.