### PR TITLE
Catch IllegalStateException in onAttach

### DIFF
--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
@@ -165,7 +165,7 @@ public class RequestManagerFragment extends Fragment {
     super.onAttach(activity);
     try {
       registerFragmentWithRoot(activity);
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       // OnAttach can be called after the activity is destroyed, see #497.
       if (Log.isLoggable(TAG, Log.WARN)) {
         Log.w(TAG, "Unable to register fragment with root", e);

--- a/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
@@ -154,7 +154,7 @@ public class SupportRequestManagerFragment extends Fragment {
     super.onAttach(activity);
     try {
       registerFragmentWithRoot(getActivity());
-    } catch (IllegalArgumentException e) {
+    } catch (IllegalStateException e) {
       // OnAttach can be called after the activity is destroyed, see #497.
       if (Log.isLoggable(TAG, Log.WARN)) {
         Log.w(TAG, "Unable to register fragment with root", e);


### PR DESCRIPTION
There has already been a fix for this crash but it does not look right to me : the error thrown when the RequestManagerFragment is attached at the wrong time is an IllegalStateException, not an IllegalArgumentException.

Fixes #497.