### PR TITLE
Introduce issue templates "the right way"

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,31 +12,6 @@ When in doubt, file an issue. We'd rather close a few duplicate issues than let 
 Similarly if you support a particular feature request, feel free to let us know by commenting on the issue or [subscribing][6] to the issue.
 
 To file a new issue, please use our issue template and fill out the template as much as possible (remove irrelevant parts).
-
-<pre>**Glide Version**:
-**Integration libraries**:
-**Device/Android Version**:
-**Issue details / Repro steps / Use case background**:
-
-**Glide load line**:
-```java
-Glide.with(...).....load(...).....into(...);
-```
-
-**Layout XML**:
-```xml
-&lt;...Layout&gt;
-    &lt;ImageView android:scaleType="..." ... /&gt;
-&lt;/..Layout&gt;
-```
-
-**Stack trace / LogCat**:
-```ruby
-paste stack trace here
-```
-</pre>
-
-You can save [this as a bookmark or just click it][1] to create a new issue.
 The more information you can provide, the more likely we are to be able help.
 
 
@@ -65,7 +40,6 @@ Labels on issues are managed by contributors, you don't have to worry about them
 *bug + enhancement: feature that doesn't work, but it's an edge case that either has a workaround or doesn't affect many users*
 
 
-[1]: https://github.com/bumptech/glide/issues/new?body=**Glide%20Version**%3A%0A**Integration%20libraries**%3A%0A**Device/Android%20Version**%3A%0A**Issue%20details%20/%20Repro%20steps%20/%20Use%20case%20background**%3A%0A%0A**Glide%20load%20line**%3A%0A%60%60%60java%0AGlide.with%28...%29.....load%28...%29.....into%28...%29%3B%0A%60%60%60%0A%0A**Layout%20XML**%3A%0A%60%60%60xml%0A%3C...Layout%3E%0A%20%20%20%20%3CImageView%20android%3AscaleType%3D%22...%22%20...%20/%3E%0A%3C/..Layout%3E%0A%60%60%60%0A%0A**Stack%20trace%20/%20LogCat**%3A%0A%60%60%60ruby%0Apaste%20stack%20trace%20here%0A%60%60%60
 [2]: https://groups.google.com/forum/#!forum/glidelibrary
 [3]: http://webchat.freenode.net/?channels=glide-library
 [4]: https://developers.google.com/open-source/cla/individual

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,50 @@
+<!--
+Please fill in the below fields with some data to help us best diagnose the issue.
+The more specific you are, the better! You can help a lot by not making us ask these questions.
+Feel free to remove any irrelevant parts that you know are not related to the issue.
+Any HTML comment like this will be stripped when rendering markdown, no need to delete them.
+-->
+
+
+<!-- What version of Glide you're running, for example: 3.7.1 | 3.8.0-SNAPSHOT | 4.0.0-SNAPSHOT
+It's essentially the version number from your build.gradle: `dependencies { compile '...:x.y.z' }` -->
+**Glide Version**:
+
+<!-- Do you use any integration library, like OkHttp3 or Volley? For example:
+Fails to display with stock networking, but works with okhttp3-1.4.0 -->
+**Integration libraries**:
+
+<!-- What devices you managed to get the issue to come up on? For example:
+fails on Galaxy S4/GT-I9500 4.4.2, works fine on Nexus 6P 5.1 and Genymotion Nexus 5 5.0.1 -->
+**Device/Android Version**:
+
+<!-- Share the details of your issue in prose, detailing actual and expected behavior. It also helps if you give some info **why** you are trying to do something as opposed to **what** is not working. -->
+**Issue details / Repro steps / Use case background**: 
+
+<!-- How do you use Glide?
+Make sure you include everything as is in your app's code:
+Changing a single method parameter can yield totally different results.
+Please clarify any magic variables that appear in the code, for example: "// `this` is a Fragment"
+-->
+**Glide load line / `GlideModule` (if any) / list Adapter code (if any)**:
+```java
+Glide.with...
+```
+
+<!-- How does your app look like?
+We're most interested in the layout attributes and the hierarchy around the ImageView -->
+**Layout XML**:
+```xml
+<FrameLayout xmlns:android="...
+```
+
+<!--
+What is the error message that you got in the log?
+You can find some help on diagnosing issues here: https://github.com/bumptech/glide/wiki/Debugging-and-Error-Handling
+-->
+**Stack trace / LogCat**:
+```ruby
+paste stack trace and/or log here
+```
+
+<!-- Bonus points if you attach a relevant screenshot, screen recording or a small demo project -->

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,14 @@
+<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
+<!-- Don't forget that you can always force push to your private branches to make changes. -->
+<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
+<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->
+
+## Description
+<!-- Please describe the changes you made on a high level. -->
+<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
+
+## Motivation and Context
+<!-- Why is this change required? What problem does it solve? -->
+<!-- If it's fixing a bug reference it or provide repro steps. -->
+
+<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->

--- a/README.md
+++ b/README.md
@@ -2,7 +2,6 @@ Glide
 =====
 
 [![Build Status](https://travis-ci.org/bumptech/glide.svg?branch=master)](https://travis-ci.org/bumptech/glide)
-[Report an issue with Glide][5]
 
 Glide is a fast and efficient open source media management and image loading framework for Android that wraps media
 decoding, memory and disk caching, and resource pooling into a simple and easy to use interface.
@@ -158,7 +157,7 @@ To open the project in IntelliJ IDEA:
 Getting Help
 ------------
 To report a specific problem or feature request, [open a new issue on Github][5]. For questions, suggestions, or
-anything else, join or email [Glide's discussion group][6], or join our IRC channel: [irc.freenode.net#glide-library][13].
+anything else, email [Glide's discussion group][6], or join our IRC channel: [irc.freenode.net#glide-library][13].
 
 Contributing
 ------------


### PR DESCRIPTION
## Description
Re-fix #332 by adding a GitHub supported issue (and PR) template

## Motivation and Context
Finally GitHub has provided us way to force users to notice the issue template we have in place.
It was announced in https://github.com/blog/2111-issue-and-pull-request-templates


