### PR TITLE
Fix thread-unsafe behaviours in GifDecoder

### DIFF
--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
@@ -32,7 +32,6 @@ public class GifHeader {
     int bgIndex;
     // Pixel aspect ratio.
     int pixelAspect;
-    //TODO: this is set both during reading the header and while decoding frames...
     int bgColor;
     int loopCount;
 


### PR DESCRIPTION
 * use a local copy of `act`: fixes #1068  
See investigation below https://github.com/bumptech/glide/issues/1068#issuecomment-199776115
 * don't modify `bgColor` unnecessarily  
There was a TODO in `GifHeader` and it coincided with the code I'm modifying. I also checked all other `GifHeader` and `GifFrame` fields, after this change all of them are used read-only. Please double-check that this move doesn't modify the behavior (note: `bgColor` is only used in this single place)

Tested in Glide Support with #1062's example:
https://github.com/TWiStErRob/glide-support/tree/c3de297d0daec8d2650a3a640c0404c35b937a30/src/glide3/java/com/bumptech/glide/supportapp/github/_1062_html_gif_spans