### PR TITLE
Get frame delay before advancing to show the current frame for the correct amount of time

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
@@ -97,8 +97,8 @@ class GifFrameLoader {
         }
         isLoadPending = true;
 
-        gifDecoder.advance();
         long targetTime = SystemClock.uptimeMillis() + gifDecoder.getNextDelay();
+        gifDecoder.advance();
         DelayTarget next = new DelayTarget(handler, gifDecoder.getCurrentFrameIndex(), targetTime);
         requestBuilder
                 .signature(new FrameSignature())


### PR DESCRIPTION
See https://github.com/bumptech/glide/issues/1060#issuecomment-201023023
Confirmed working by manually testing with the image I created from the original.