### PR TITLE
Fill only the area that was modified by the previous GIF frame

### DIFF
--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
@@ -34,7 +34,6 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.nio.ByteBuffer;
 import java.nio.ByteOrder;
-import java.util.Arrays;
 
 /**
  * Reads frame data from a GIF image source and decodes it into individual frames
@@ -434,7 +433,15 @@ public class GifDecoder {
                         c = 0;
                     }
                 }
-                Arrays.fill(dest, c);
+                // The area used by the graphic must be restored to the background color.
+                int topLeft = previousFrame.iy * width + previousFrame.ix;
+                int bottomLeft = topLeft + previousFrame.ih * width;
+                for (int left = topLeft; left < bottomLeft; left += width) {
+                    int right = left + previousFrame.iw;
+                    for (int pointer = left; pointer < right; pointer++) {
+                        dest[pointer] = c;
+                    }
+                }
             } else if (previousFrame.dispose == DISPOSAL_PREVIOUS && previousImage != null) {
                 // Start with the previous frame
                 previousImage.getPixels(dest, 0, width, 0, 0, width, height);


### PR DESCRIPTION
## Description
As seen in #1059:
![flickering GIF animation](https://camo.githubusercontent.com/ef41a849b9296d956424ecb86450ef802f387fcc/687474703a2f2f692e696d6775722e636f6d2f384f344b6e36432e676966)

If you look closely you can see there are multiple different flickers:
 * one where the frame is partially shown
 * one where a single frame is almost fully transparent

This is how it should look like:
![original image](https://camo.githubusercontent.com/390c7c933d9cb508df8d81292ce4ffa7fca46694/687474703a2f2f66696c652e62616978696e672e6e65742f3230313531312f35396161306361306331643063333330393833613131306436303566663934302e676966)

This change achieves that by clearing only part of the frame when need to dispose to background.

## Motivation and Context
I sent the above image through http://ezgif.com/split ("Ignore optimizations") to see what how they look:
![image](https://cloud.githubusercontent.com/assets/2906988/14052276/3b4fdc04-f2c9-11e5-8c1a-fe7a1560db99.png)

As you can see there's an actual half-frame and there are many almost-empty frames, most importantly the one where there's a little pink on the left. These two frames cause the trouble. Their dispose is set to "background" which triggers a code block that fills the entire frame with `bgColor`. The problem is that the frame doesn't contain a full-sized image, just a partial one. This is also confirmed in debug (closed frames look identical to 0th frame): 
![image](https://cloud.githubusercontent.com/assets/2906988/14052330/b9da1292-f2c9-11e5-9bdd-894d43ccfac6.png)

I checked the GIF spec and it says:
>  iv) Disposal Method - Indicates the way in which the graphic is to be treated after being displayed.
>  2 -   Restore to background color. The **area used by the graphic** must be restored to the background color. -- [GIF89a](https://www.w3.org/Graphics/GIF/spec-gif89a.txt), emphasis mine

This means that when preparing the frame transition from 2 to 3, 2 wants it's partial area to be cleared as defined by the (ix,iy iw,ih) rect. I took a shot at implementing that, I went through these iterations to arrive at the code in the PR.

1. simple iteration with cached end values

	```java
	for (int y = previousFrame.iy, yEnd = y + previousFrame.ih; y < yEnd; y++) {
	    for (int x = previousFrame.ix, xEnd = x + previousFrame.iw; x < xEnd; x++) {
	        dest[y * width + x] = c;
	    }
	}
	```

2. pre-calculate values and name them

	```java
	int top = previousFrame.iy;
	int bottom = previousFrame.iy + previousFrame.ih;
	int left = previousFrame.ix;
	int right = previousFrame.ix + previousFrame.iw;
	for (int y = top; y < bottom; y++) {
	    for (int x = left; x < right; x++) {
	        dest[y * width + x] = c;
	    }
	}
	```

3. lift multiplication up

	```java
	int top = previousFrame.iy;
	int bottom = previousFrame.iy + previousFrame.ih;
	for (int y = top; y < bottom; y++) {
	    int left = y * width + previousFrame.ix;
	    int right = y * width + previousFrame.ix + previousFrame.iw;
	    for (int p = left; p < right; p++) {
	        dest[p] = c;
	    }
	}
	```

4. lift multiplication up again and rename variables

	```java
	int topLeft = previousFrame.iy * width + previousFrame.ix;
	int bottomLeft = topLeft + previousFrame.ih * width;
	for (int left = topLeft; left < bottomLeft; left += width) {
	    int right = left + previousFrame.iw;
	    for (int pointer = left; pointer < right; pointer++) {
	        dest[pointer] = c;
	    }
	}
	```

Not sure which one is best, I think the final version is readable enough and all multiplications are lifted outside, so it should be efficient as well.