### PR TITLE
.asBitmap().crossFade()

### DIFF
--- a/library/src/androidTest/java/com/bumptech/glide/BitmapRequestBuilderTest.java
+++ b/library/src/androidTest/java/com/bumptech/glide/BitmapRequestBuilderTest.java
@@ -1,0 +1,148 @@
+package com.bumptech.glide;
+
+import static com.google.common.truth.Truth.assertThat;
+import static org.junit.Assert.fail;
+import static org.mockito.Mockito.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.withSettings;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.ColorDrawable;
+import android.graphics.drawable.Drawable;
+
+import com.bumptech.glide.load.resource.drawable.GlideDrawable;
+import com.bumptech.glide.provider.LoadProvider;
+import com.bumptech.glide.request.animation.GlideAnimationFactory;
+import com.bumptech.glide.tests.GlideShadowLooper;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.Collection;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, emulateSdk = 18, shadows = GlideShadowLooper.class)
+@SuppressWarnings({ "unchecked", "deprecation" })
+public class BitmapRequestBuilderTest {
+    private GenericRequestBuilder original;
+    private LoadProvider loadProvider;
+
+    @Before
+    public void setUp() {
+        Glide glide = mock(Glide.class);
+        original = new GenericRequestBuilder(Robolectric.application,
+                Object.class, mock(LoadProvider.class), null, glide, null, null);
+        loadProvider = mock(LoadProvider.class);
+    }
+
+    @After
+    public void tearDown() {
+        Glide.tearDown();
+    }
+
+    @Test
+    public void testCrossFadeAppliesToBitmap() {
+        testCrossFadeAppliesTo(new BitmapRequestBuilder(loadProvider, Bitmap.class, original));
+    }
+
+    @Test
+    public void testCrossFadeAppliesToDrawable() {
+        testCrossFadeAppliesTo(new BitmapRequestBuilder(loadProvider, Drawable.class, original));
+    }
+
+    @Test
+    public void testCrossFadeAppliesToGlideDrawable() {
+        testCrossFadeAppliesTo(new BitmapRequestBuilder(loadProvider, GlideDrawable.class, original));
+    }
+
+    @Test
+    public void testCrossFadeAppliesToCustomDrawable() {
+        class CustomDrawable extends ColorDrawable {
+        }
+        testCrossFadeAppliesTo(new BitmapRequestBuilder(loadProvider, CustomDrawable.class, original));
+    }
+
+
+    @Test
+    public void testCrossFadeNotAppliedToString() {
+        testCrossFadeNotAppliedTo(new BitmapRequestBuilder(loadProvider, String.class, original));
+    }
+
+    @Test
+    public void testCrossFadeNotAppliedToCustom() {
+        class Custom {
+        }
+        testCrossFadeNotAppliedTo(new BitmapRequestBuilder(loadProvider, Custom.class, original));
+    }
+
+    private void testCrossFadeAppliesTo(BitmapRequestBuilder builder) {
+        Collection<GlideAnimationFactory> previousValues = new ArrayList<GlideAnimationFactory>();
+        previousValues.add(null);
+
+        BitmapRequestBuilder paramless = spy(builder, "paramless");
+        paramless.crossFade();
+        verifyAnimateCalledWithNewValue(paramless, previousValues);
+
+        BitmapRequestBuilder duration = spy(builder, "duration");
+        duration.crossFade(0);
+        verifyAnimateCalledWithNewValue(duration, previousValues);
+
+        BitmapRequestBuilder withId = spy(builder, "withId");
+        withId.crossFade(0, 0);
+        verifyAnimateCalledWithNewValue(withId, previousValues);
+
+        BitmapRequestBuilder withAnim = spy(builder, "withAnim");
+        withAnim.crossFade(null, 0);
+        verifyAnimateCalledWithNewValue(withAnim, previousValues);
+    }
+
+    private BitmapRequestBuilder spy(BitmapRequestBuilder builder, String name) {
+        return mock(BitmapRequestBuilder.class, withSettings()
+                .name(name)
+                .spiedInstance(builder)
+                .defaultAnswer(CALLS_REAL_METHODS)
+        );
+    }
+
+    private void verifyAnimateCalledWithNewValue(
+            BitmapRequestBuilder builder, Collection<GlideAnimationFactory> previousValues) {
+        ArgumentCaptor<GlideAnimationFactory> captor = ArgumentCaptor.forClass(GlideAnimationFactory.class);
+        verify(builder).animate(captor.capture());
+        assertThat(previousValues).doesNotContain(captor.getValue());
+    }
+
+    private void testCrossFadeNotAppliedTo(BitmapRequestBuilder builder) {
+        try {
+            builder.crossFade();
+            fail("Expected an exception");
+        } catch (UnsupportedOperationException ignore) {
+            // pass
+        }
+        try {
+            builder.crossFade(0);
+            fail("Expected an exception");
+        } catch (UnsupportedOperationException ignore) {
+            // pass
+        }
+        try {
+            builder.crossFade(0, 0);
+            fail("Expected an exception");
+        } catch (UnsupportedOperationException ignore) {
+            // pass
+        }
+        try {
+            builder.crossFade(null, 0);
+            fail("Expected an exception");
+        } catch (UnsupportedOperationException ignore) {
+            // pass
+        }
+    }
+}

--- a/library/src/main/java/com/bumptech/glide/BitmapRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/BitmapRequestBuilder.java
@@ -25,6 +25,9 @@ import com.bumptech.glide.load.resource.file.FileToStreamDecoder;
 import com.bumptech.glide.load.resource.transcode.ResourceTranscoder;
 import com.bumptech.glide.provider.LoadProvider;
 import com.bumptech.glide.request.RequestListener;
+import com.bumptech.glide.request.animation.BitmapCrossFadeFactory;
+import com.bumptech.glide.request.animation.DrawableCrossFadeFactory;
+import com.bumptech.glide.request.animation.GlideAnimationFactory;
 import com.bumptech.glide.request.animation.ViewPropertyAnimation;
 import com.bumptech.glide.request.target.Target;
 
@@ -43,8 +46,10 @@ import java.io.InputStream;
  * @param <ModelType> The type of model that will be loaded into the target.
  * @param <TranscodeType> The type of the transcoded resource that the target will receive
  */
+@SuppressWarnings("PMD.AvoidDuplicateLiterals")
 public class BitmapRequestBuilder<ModelType, TranscodeType>
-        extends GenericRequestBuilder<ModelType, ImageVideoWrapper, Bitmap, TranscodeType> implements BitmapOptions {
+        extends GenericRequestBuilder<ModelType, ImageVideoWrapper, Bitmap, TranscodeType>
+        implements BitmapOptions, DrawableOptions {
     private final BitmapPool bitmapPool;
 
     private Downsampler downsampler = Downsampler.AT_LEAST;
@@ -313,6 +318,80 @@ public class BitmapRequestBuilder<ModelType, TranscodeType>
         return this;
     }
 
+    private RuntimeException crossFadeNotSupported() {
+        String className = transcodeClass.getCanonicalName();
+        if (className == null) {
+            className = transcodeClass.toString();
+        }
+        return new UnsupportedOperationException(".crossFade() is not supported for " + className
+                + ", use .animate() to provide a compatible animation.");
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public final BitmapRequestBuilder<ModelType, TranscodeType> crossFade() {
+        if (Bitmap.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new BitmapCrossFadeFactory());
+        } else if (Drawable.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new DrawableCrossFadeFactory<Drawable>());
+        } else {
+            throw crossFadeNotSupported();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public BitmapRequestBuilder<ModelType, TranscodeType> crossFade(int duration) {
+        if (Bitmap.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new BitmapCrossFadeFactory(duration));
+        } else if (Drawable.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new DrawableCrossFadeFactory<Drawable>(duration));
+        } else {
+            throw crossFadeNotSupported();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Deprecated
+    @SuppressWarnings("unchecked")
+    public BitmapRequestBuilder<ModelType, TranscodeType> crossFade(Animation animation, int duration) {
+        if (Bitmap.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new BitmapCrossFadeFactory(animation, duration));
+        } else if (Drawable.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new DrawableCrossFadeFactory<Drawable>(animation, duration));
+        } else {
+            throw crossFadeNotSupported();
+        }
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @SuppressWarnings("unchecked")
+    public BitmapRequestBuilder<ModelType, TranscodeType> crossFade(int animationId, int duration) {
+        if (Bitmap.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new BitmapCrossFadeFactory(context, animationId, duration));
+        } else if (Drawable.class.isAssignableFrom(transcodeClass)) {
+            return animate((GlideAnimationFactory<TranscodeType>)
+                    new DrawableCrossFadeFactory<Drawable>(context, animationId, duration));
+        } else {
+            throw crossFadeNotSupported();
+        }
+    }
+
     /**
      * {@inheritDoc}
      */
@@ -348,6 +427,17 @@ public class BitmapRequestBuilder<ModelType, TranscodeType>
     @Override
     public BitmapRequestBuilder<ModelType, TranscodeType> animate(ViewPropertyAnimation.Animator animator) {
         super.animate(animator);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     * @see com.bumptech.glide.request.animation.BitmapContainerCrossFadeFactory
+     */
+    @Override
+    public BitmapRequestBuilder<ModelType, TranscodeType> animate(
+            GlideAnimationFactory<TranscodeType> animationFactory) {
+        super.animate(animationFactory);
         return this;
     }
 

--- a/library/src/main/java/com/bumptech/glide/DrawableRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/DrawableRequestBuilder.java
@@ -23,6 +23,7 @@ import com.bumptech.glide.manager.RequestTracker;
 import com.bumptech.glide.provider.LoadProvider;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.animation.DrawableCrossFadeFactory;
+import com.bumptech.glide.request.animation.GlideAnimationFactory;
 import com.bumptech.glide.request.animation.ViewPropertyAnimation;
 import com.bumptech.glide.request.target.Target;
 
@@ -268,8 +269,7 @@ public class DrawableRequestBuilder<ModelType>
      * {@inheritDoc}
      */
     public DrawableRequestBuilder<ModelType> crossFade(int animationId, int duration) {
-        super.animate(new DrawableCrossFadeFactory<GlideDrawable>(context, animationId,
-                duration));
+        super.animate(new DrawableCrossFadeFactory<GlideDrawable>(context, animationId, duration));
         return this;
     }
 
@@ -288,6 +288,15 @@ public class DrawableRequestBuilder<ModelType>
     @Override
     public DrawableRequestBuilder<ModelType> animate(ViewPropertyAnimation.Animator animator) {
         super.animate(animator);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public DrawableRequestBuilder<ModelType> animate(GlideAnimationFactory<GlideDrawable> animationFactory) {
+        super.animate(animationFactory);
         return this;
     }
 

--- a/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GenericRequestBuilder.java
@@ -412,7 +412,14 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
         return animate(new ViewPropertyAnimationFactory<TranscodeType>(animator));
     }
 
-    GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeType> animate(
+    /**
+     * Sets a factory which will create a transition to run on a view that the target may be wrapping when a resource
+     * load finishes. Will only be run if the load was loaded asynchronously (ie was not in the memory cache).
+     *
+     * @param animationFactory Animation factory which creates compatible animations.
+     * @return This request builder.
+     */
+    public GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeType> animate(
             GlideAnimationFactory<TranscodeType> animationFactory) {
         if (animationFactory == null) {
             throw new NullPointerException("Animation factory must not be null!");
@@ -423,7 +430,7 @@ public class GenericRequestBuilder<ModelType, DataType, ResourceType, TranscodeT
     }
 
     /**
-     * Sets an Android resource id for a {@link android.graphics.drawable.Drawable} resourceto display while a resource
+     * Sets an Android resource id for a {@link android.graphics.drawable.Drawable} resource to display while a resource
      * is loading.
      *
      * @param resourceId The id of the resource to use as a placeholder

--- a/library/src/main/java/com/bumptech/glide/GifRequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GifRequestBuilder.java
@@ -17,6 +17,7 @@ import com.bumptech.glide.load.resource.transcode.ResourceTranscoder;
 import com.bumptech.glide.provider.LoadProvider;
 import com.bumptech.glide.request.RequestListener;
 import com.bumptech.glide.request.animation.DrawableCrossFadeFactory;
+import com.bumptech.glide.request.animation.GlideAnimationFactory;
 import com.bumptech.glide.request.animation.ViewPropertyAnimation;
 
 import java.io.File;
@@ -258,8 +259,7 @@ public class GifRequestBuilder<ModelType>
      */
     @Override
     public GifRequestBuilder<ModelType> crossFade(int animationId, int duration) {
-        super.animate(new DrawableCrossFadeFactory<GifDrawable>(context, animationId,
-                duration));
+        super.animate(new DrawableCrossFadeFactory<GifDrawable>(context, animationId, duration));
         return this;
     }
 
@@ -298,6 +298,15 @@ public class GifRequestBuilder<ModelType>
     @Override
     public GifRequestBuilder<ModelType> animate(ViewPropertyAnimation.Animator animator) {
         super.animate(animator);
+        return this;
+    }
+
+    /**
+     * {@inheritDoc}
+     */
+    @Override
+    public GifRequestBuilder<ModelType> animate(GlideAnimationFactory<GifDrawable> animationFactory) {
+        super.animate(animationFactory);
         return this;
     }
 

--- a/library/src/main/java/com/bumptech/glide/request/animation/BitmapContainerCrossFadeFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/animation/BitmapContainerCrossFadeFactory.java
@@ -1,0 +1,72 @@
+package com.bumptech.glide.request.animation;
+
+import android.content.Context;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.view.animation.Animation;
+
+/**
+ * A cross fade {@link GlideAnimation} for complex types that have a {@link android.graphics.Bitmap} inside
+ * that uses an {@link android.graphics.drawable.TransitionDrawable} to transition from an existing drawable
+ * already visible on the target to the new bitmap. If no existing drawable exists, this class can
+ * instead fall back to a default animation that doesn't rely on {@link android.graphics.drawable.TransitionDrawable}.
+ * The new bitmap queried from the complex type is wrapped in a {@link android.graphics.drawable.BitmapDrawable}.
+ *
+ * @param <T> The type of the composite object that contains the {@link android.graphics.Bitmap} to be animated.
+ */
+public abstract class BitmapContainerCrossFadeFactory<T> implements GlideAnimationFactory<T> {
+    private final GlideAnimationFactory<Drawable> realFactory;
+
+    public BitmapContainerCrossFadeFactory() {
+        this(new DrawableCrossFadeFactory<Drawable>());
+    }
+
+    public BitmapContainerCrossFadeFactory(int duration) {
+        this(new DrawableCrossFadeFactory<Drawable>(duration));
+    }
+
+    public BitmapContainerCrossFadeFactory(Context context, int defaultAnimationId, int duration) {
+        this(new DrawableCrossFadeFactory<Drawable>(context, defaultAnimationId, duration));
+    }
+
+    public BitmapContainerCrossFadeFactory(Animation defaultAnimation, int duration) {
+        this(new DrawableCrossFadeFactory<Drawable>(defaultAnimation, duration));
+    }
+
+    public BitmapContainerCrossFadeFactory(GlideAnimationFactory<Drawable> realFactory) {
+        this.realFactory = realFactory;
+    }
+
+    @Override
+    public GlideAnimation<T> build(boolean isFromMemoryCache, boolean isFirstResource) {
+        GlideAnimation<Drawable> transition = realFactory.build(isFromMemoryCache, isFirstResource);
+        return new BitmapGlideAnimation(transition);
+    }
+
+    /**
+     * Retrieve the Bitmap from a composite object.
+     * <br>
+     * <b>Warning:</b> Do not convert any arbitrary object to Bitmap via expensive drawing here.
+     *
+     * @param current composite object containing a Bitmap and some other information
+     * @return the Bitmap contained within {@code current}
+     */
+    protected abstract Bitmap getBitmap(T current);
+
+    private class BitmapGlideAnimation implements GlideAnimation<T> {
+        private final GlideAnimation<Drawable> transition;
+
+        public BitmapGlideAnimation(GlideAnimation<Drawable> transition) {
+            this.transition = transition;
+        }
+
+        @Override
+        public boolean animate(T current, ViewAdapter adapter) {
+            Resources resources = adapter.getView().getResources();
+            Drawable currentBitmap = new BitmapDrawable(resources, getBitmap(current));
+            return transition.animate(currentBitmap, adapter);
+        }
+    }
+}

--- a/library/src/main/java/com/bumptech/glide/request/animation/BitmapCrossFadeFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/animation/BitmapCrossFadeFactory.java
@@ -1,0 +1,40 @@
+package com.bumptech.glide.request.animation;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.view.animation.Animation;
+
+/**
+ * A cross fade {@link GlideAnimation} for {@link android.graphics.Bitmap}s
+ * that uses an {@link android.graphics.drawable.TransitionDrawable} to transition from an existing drawable
+ * already visible on the target to the new bitmap. If no existing drawable exists, this class can
+ * instead fall back to a default animation that doesn't rely on {@link android.graphics.drawable.TransitionDrawable}.
+ * The new bitmap is wrapped in a {@link android.graphics.drawable.BitmapDrawable}.
+ */
+public class BitmapCrossFadeFactory extends BitmapContainerCrossFadeFactory<Bitmap> {
+    public BitmapCrossFadeFactory() {
+        super();
+    }
+
+    public BitmapCrossFadeFactory(int duration) {
+        super(duration);
+    }
+
+    public BitmapCrossFadeFactory(Context context, int defaultAnimationId, int duration) {
+        super(context, defaultAnimationId, duration);
+    }
+
+    public BitmapCrossFadeFactory(Animation defaultAnimation, int duration) {
+        super(defaultAnimation, duration);
+    }
+
+    public BitmapCrossFadeFactory(GlideAnimationFactory<Drawable> realFactory) {
+        super(realFactory);
+    }
+
+    @Override
+    protected Bitmap getBitmap(Bitmap current) {
+        return current;
+    }
+}


### PR DESCRIPTION
## Description
Allow `.animate(factory)`, `.asBitmap().crossFade()`, `.asBitmap().transcode(...).crossFade()`.
This opens up the API to allow custom transformations via factory (e.g. `PaletteBitmap`), as well as stock usage of `.crossFade()` in most cases: now default, `asGif` and `asBitmap` all allow cross-fading.
Closes #1007 (v4 already done that) and fixes #840 for v3 (v4 TODO)

## Motivation and Context
It has been asked many times (#840, #605, #903, #847, #1007, #63, #155, #261, #362, #405, #749, #1083, [UPq4H4009OY](https://groups.google.com/d/msg/glidelibrary/UPq4H4009OY/v84MFKD7yYsJ)) how to do this and I figured out a few workarounds, this incorporates those into a builtin method to ease use while also allowing more customization.

---
Questions to @sjudd:
* should I squash?
* should we set .crossFade() as default for .asBitmap() like it is for drawables?