### PR TITLE
add OkHttpUrlLoader.Factory.setInternalClient()

### DIFF
--- a/integration/okhttp3/src/main/java/com/bumptech/glide/integration/okhttp3/OkHttpUrlLoader.java
+++ b/integration/okhttp3/src/main/java/com/bumptech/glide/integration/okhttp3/OkHttpUrlLoader.java
@@ -13,7 +13,9 @@ import okhttp3.OkHttpClient;
 import java.io.InputStream;
 
 /**
- * A simple model loader for fetching media over http/https using OkHttp.
+ * <p>A simple model loader for fetching media over http/https using OkHttp.</p>
+ * <p>Use {@link Factory#setInternalClient(Call.Factory)} to set the {@link OkHttpClient}
+ * instance.</p>
  */
 public class OkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
 
@@ -41,7 +43,11 @@ public class OkHttpUrlLoader implements ModelLoader<GlideUrl, InputStream> {
     private static volatile Call.Factory internalClient;
     private Call.Factory client;
 
-    private static Call.Factory getInternalClient() {
+    public static void setInternalClient(Call.Factory okHttpClient) {
+      internalClient = okHttpClient;
+    }
+
+    public static Call.Factory getInternalClient() {
       if (internalClient == null) {
         synchronized (Factory.class) {
           if (internalClient == null) {


### PR DESCRIPTION
## Description

This pull-request adds `OkHttpUrlLoader.Factory.setInternalClient()` to okhttp3-integration in order give it with a custom OkHttpClient instance.

## Motivation and Context

To customize OkHttpClient: set HTTP headers (user-agent, api token, ...), Interceptor, and so on.