### PR TITLE
Fix bug when checking enough space to caching array

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
@@ -22,7 +22,7 @@ import java.util.List;
  */
 class EngineJob<R> implements DecodeJob.Callback<R>,
     Poolable {
-  private static final EngineResourceFactory DEFAULT_FACTORY = new EngineResourceFactory();
+  private static final EngineResourceFactory DEFAULT_FACTORY = new DefaultEngineResourceFactory();
   private static final Handler MAIN_THREAD_HANDLER =
       new Handler(Looper.getMainLooper(), new MainThreadCallback());
 
@@ -273,8 +273,12 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
     return stateVerifier;
   }
 
+  public interface EngineResourceFactory {
+    <R> EngineResource<R> build(Resource<R> resource, boolean isMemoryCacheable);
+  }
+
   // Visible for testing.
-  static class EngineResourceFactory {
+  static class DefaultEngineResourceFactory implements EngineResourceFactory {
     public <R> EngineResource<R> build(Resource<R> resource, boolean isMemoryCacheable) {
       return new EngineResource<>(resource, isMemoryCacheable);
     }


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->


1. Since the space in `LruArrayPool` are count by bytes, we should
pass the bytes of the to be cached array to `isSmallEnoughForReuse()`
2. If the `EngineReourceFactory` is a concrete class, there is not way to customize a new factory class, which makes the parameter `engineResourceFactor` of `EngineJob`'s ctor useless.
