### PR TITLE
Use application Context in GifResourceDecoder

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifResourceDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifResourceDecoder.java
@@ -45,7 +45,7 @@ public class GifResourceDecoder implements ResourceDecoder<InputStream, GifDrawa
     // Visible for testing.
     GifResourceDecoder(Context context, BitmapPool bitmapPool, GifHeaderParserPool parserPool,
             GifDecoderPool decoderPool) {
-        this.context = context;
+        this.context = context.getApplicationContext();
         this.bitmapPool = bitmapPool;
         this.decoderPool = decoderPool;
         this.provider = new GifBitmapProvider(bitmapPool);


### PR DESCRIPTION
Very quick fix for #1277
This fixes a memory leak which causes `GifResourceDecoder` to leak `Activity` context once in memory cache. The solution is to save the application context instead when initializing the decoder.
