### PR TITLE
Forward port GIF fixes

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -66,7 +66,7 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
       ArrayPool arrayPool,
       GifHeaderParserPool parserPool,
       GifDecoderFactory gifDecoderFactory) {
-    this.context = context;
+    this.context = context.getApplicationContext();
     this.bitmapPool = bitmapPool;
     this.gifDecoderFactory = gifDecoderFactory;
     this.provider = new GifBitmapProvider(bitmapPool, arrayPool);

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
@@ -33,7 +33,6 @@ public class GifHeader {
   int bgIndex;
   // Pixel aspect ratio.
   int pixelAspect;
-  //TODO: this is set both during reading the header and while decoding frames...
   int bgColor;
   int loopCount;
 

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -407,7 +407,19 @@ public class StandardGifDecoder implements GifDecoder {
           // drawing a transparent background means the GIF contains transparency.
           isFirstFrameTransparent = true;
         }
-        Arrays.fill(dest, c);
+        // The area used by the graphic must be restored to the background color.
+        int downsampledIH = previousFrame.ih / sampleSize;
+        int downsampledIY = previousFrame.iy / sampleSize;
+        int downsampledIW = previousFrame.iw / sampleSize;
+        int downsampledIX = previousFrame.ix / sampleSize;
+        int topLeft = downsampledIY * downsampledWidth + downsampledIX;
+        int bottomLeft = topLeft + downsampledIH * downsampledWidth;
+        for (int left = topLeft; left < bottomLeft; left += downsampledWidth) {
+          int right = left + downsampledIW;
+          for (int pointer = left; pointer < right; pointer++) {
+            dest[pointer] = c;
+          }
+        }
       } else if (previousFrame.dispose == DISPOSAL_PREVIOUS && previousImage != null) {
         // Start with the previous frame
         previousImage.getPixels(dest, 0, downsampledWidth, 0, 0, downsampledWidth,

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -81,7 +81,7 @@ public class StandardGifDecoder implements GifDecoder {
 
   private static final int INITIAL_FRAME_POINTER = -1;
 
-  private static final int BYTES_PER_INTEGER = 4;
+  private static final int BYTES_PER_INTEGER = Integer.SIZE / 8;
 
   // Global File Header values and parsing flags.
   // Active color table.
@@ -349,14 +349,13 @@ public class StandardGifDecoder implements GifDecoder {
     }
 
     this.sampleSize = sampleSize;
+    downsampledWidth = header.width / sampleSize;
+    downsampledHeight = header.height / sampleSize;
     // Now that we know the size, init scratch arrays.
     // TODO: Find a way to avoid this entirely or at least downsample it
     // (either should be possible).
     mainPixels = bitmapProvider.obtainByteArray(header.width * header.height);
-    mainScratch =
-        bitmapProvider.obtainIntArray((header.width / sampleSize) * (header.height / sampleSize));
-    downsampledWidth = header.width / sampleSize;
-    downsampledHeight = header.height / sampleSize;
+    mainScratch = bitmapProvider.obtainIntArray(downsampledWidth * downsampledHeight);
   }
 
   private GifHeaderParser getHeaderParser() {


### PR DESCRIPTION
## Description
 * Forward port PR #1281 which fixed #1277
 * Forward port PR #1090 which fixed #1068
 * Forward port PR #1093 which fixed #1059

## Motivation and Context
3.8.0 has better GIF support than 4.0, forward port fixes

---

@sjudd There's still an outstanding issue though: the transparency calculation based on first frame (`isFirstFrameTransparent`) just doesn't imply that the rest of the frames have the same transparency. For example, http://www.imagemagick.org/Usage/anim_basics/canvas_bgnd.gif starts with an opaque frame and then the others keep clearing to transparent color. Actually none of the frames in this GIF have transparency (in header), because the frames are just little square images, but the disposal is background which clears to transparent. You can find the description of this at http://www.imagemagick.org/Usage/anim_basics/#background. Incorrectly using 565 Bitmaps negates some of the fixes above. Not sure what to do with this.
You can find runnable examples with expectations in https://github.com/TWiStErRob/glide-support for #1094