### PR TITLE
Forward port PR #1096: .asBitmap().transition(withCrossFade())

### DIFF
--- a/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
@@ -1,5 +1,8 @@
 package com.bumptech.glide;
 
+import com.bumptech.glide.request.transition.TransitionFactory;
+import com.bumptech.glide.request.transition.ViewPropertyTransition;
+
 /**
  * Implementation of {@link TransitionOptions} that exposes only generic methods that can be applied
  * to any resource type.
@@ -10,7 +13,42 @@ package com.bumptech.glide;
 public final class GenericTransitionOptions<TranscodeType> extends
   TransitionOptions<GenericTransitionOptions<TranscodeType>, TranscodeType> {
 
+  /**
+   * Removes any existing animation put on the builder.
+   *
+   * @see GenericTransitionOptions#dontTransition()
+   */
   public static <TranscodeType> GenericTransitionOptions<TranscodeType> withNoTransition() {
     return new GenericTransitionOptions<TranscodeType>().dontTransition();
+  }
+
+  /**
+   * Returns a typed {@link GenericTransitionOptions} object that uses the given view animation.
+   *
+   * @see GenericTransitionOptions#transition(int)
+   */
+  public static <TranscodeType> GenericTransitionOptions<TranscodeType> with(
+      int viewAnimationId) {
+    return new GenericTransitionOptions<TranscodeType>().transition(viewAnimationId);
+  }
+
+  /**
+   * Returns a typed {@link GenericTransitionOptions} object that uses the given animator.
+   *
+   * @see GenericTransitionOptions#transition(ViewPropertyTransition.Animator)
+   */
+  public static <TranscodeType> GenericTransitionOptions<TranscodeType> with(
+      ViewPropertyTransition.Animator animator) {
+    return new GenericTransitionOptions<TranscodeType>().transition(animator);
+  }
+
+  /**
+   * Returns a typed {@link GenericTransitionOptions} object that uses the given transition factory.
+   *
+   * @see GenericTransitionOptions#transition(TransitionFactory)
+   */
+  public static <TranscodeType> GenericTransitionOptions<TranscodeType> with(
+      TransitionFactory<? super TranscodeType> transitionFactory) {
+    return new GenericTransitionOptions<TranscodeType>().transition(transitionFactory);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
@@ -1,0 +1,144 @@
+package com.bumptech.glide.load.resource.bitmap;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+
+import com.bumptech.glide.TransitionOptions;
+import com.bumptech.glide.request.transition.BitmapTransitionFactory;
+import com.bumptech.glide.request.transition.DrawableCrossFadeFactory;
+import com.bumptech.glide.request.transition.TransitionFactory;
+
+/**
+ * Contains {@link Bitmap} specific animation options.
+ */
+public final class BitmapTransitionOptions extends
+    TransitionOptions<BitmapTransitionOptions, Bitmap> {
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a cross fade animation.
+   *
+   * @see #crossFade()
+   */
+  public static BitmapTransitionOptions withCrossFade() {
+    return new BitmapTransitionOptions().crossFade();
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a cross fade animation.
+   *
+   * @see #crossFade(int)
+   */
+  public static BitmapTransitionOptions withCrossFade(int duration) {
+    return new BitmapTransitionOptions().crossFade(duration);
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a cross fade animation.
+   *
+   * @see #crossFade(int, int)
+   */
+  public static BitmapTransitionOptions withCrossFade(int animationId, int duration) {
+    return new BitmapTransitionOptions().crossFade(animationId, duration);
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a cross fade animation.
+   *
+   * @see #crossFade(DrawableCrossFadeFactory)
+   */
+  public static BitmapTransitionOptions withCrossFade(
+      DrawableCrossFadeFactory drawableCrossFadeFactory) {
+    return new BitmapTransitionOptions().crossFade(drawableCrossFadeFactory);
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a cross fade animation.
+   *
+   * @see #crossFade(DrawableCrossFadeFactory.Builder)
+   */
+  public static BitmapTransitionOptions withCrossFade(
+      DrawableCrossFadeFactory.Builder builder) {
+    return new BitmapTransitionOptions().crossFade(builder);
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that enables a any animation
+   * that is possible on drawables.
+   *
+   * @see #transitionUsing(TransitionFactory)
+   */
+  public static BitmapTransitionOptions withWrapped(
+      TransitionFactory<Drawable> drawableCrossFadeFactory) {
+    return new BitmapTransitionOptions().transitionUsing(drawableCrossFadeFactory);
+  }
+
+  /**
+   * Returns a {@link BitmapTransitionOptions} object that uses the given transition factory.
+   *
+   * @see com.bumptech.glide.GenericTransitionOptions#with(TransitionFactory)
+   */
+  public static BitmapTransitionOptions with(
+      TransitionFactory<Bitmap> transitionFactory) {
+    return new BitmapTransitionOptions().transition(transitionFactory);
+  }
+
+  /**
+   * Enables a cross fade animation between both the placeholder and the first resource and between
+   * subsequent resources (if thumbnails are used).
+   */
+  public BitmapTransitionOptions crossFade() {
+    return crossFade(new DrawableCrossFadeFactory.Builder());
+  }
+
+  /**
+   * Enables a cross fade animation between both the placeholder and the first resource and between
+   * subsequent resources (if thumbnails are used).
+   *
+   * @param duration The duration of the animation, see
+   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   */
+  public BitmapTransitionOptions crossFade(int duration) {
+    return crossFade(new DrawableCrossFadeFactory.Builder(duration));
+  }
+
+  /**
+   * Enables a cross fade animation between both the placeholder and the first resource and between
+   * subsequent resources (if thumbnails are used).
+   *
+   * @param animationId The id of the animation to use if no placeholder or previous resource is
+   *     set, see {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
+   *     #setDefaultAnimationId(int)}.
+   * @param duration The duration of the cross fade, see
+   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   */
+  public BitmapTransitionOptions crossFade(int animationId, int duration) {
+    return crossFade(
+        new DrawableCrossFadeFactory.Builder(duration)
+            .setDefaultAnimationId(animationId));
+  }
+
+  /**
+   * Enables a cross fade animation between both the placeholder and the first resource and between
+   * subsequent resources (if thumbnails are used).
+   */
+  public BitmapTransitionOptions crossFade(DrawableCrossFadeFactory drawableCrossFadeFactory) {
+    return transitionUsing(drawableCrossFadeFactory);
+  }
+
+  /**
+   * Enables a any Drawable based animation to run on Bitmaps as well.
+   */
+  public BitmapTransitionOptions transitionUsing(
+      TransitionFactory<Drawable> drawableCrossFadeFactory) {
+    return transition(new BitmapTransitionFactory(drawableCrossFadeFactory));
+  }
+
+  /**
+   * Enables a cross fade animation between both the placeholder and the first resource and between
+   * subsequent resources (if thumbnails are used).
+   */
+  public BitmapTransitionOptions crossFade(DrawableCrossFadeFactory.Builder builder) {
+    return transitionUsing(builder.build());
+  }
+}
+

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
@@ -4,6 +4,7 @@ import android.graphics.drawable.Drawable;
 
 import com.bumptech.glide.TransitionOptions;
 import com.bumptech.glide.request.transition.DrawableCrossFadeFactory;
+import com.bumptech.glide.request.transition.TransitionFactory;
 
 /**
  * Contains {@link Drawable} specific animation options.
@@ -14,7 +15,7 @@ public final class DrawableTransitionOptions extends
   /**
    * Returns a {@link DrawableTransitionOptions} object that enables a cross fade animation.
    *
-   * @see #crossFade().
+   * @see #crossFade()
    */
   public static DrawableTransitionOptions withCrossFade() {
     return new DrawableTransitionOptions().crossFade();
@@ -23,7 +24,7 @@ public final class DrawableTransitionOptions extends
   /**
    * Returns a {@link DrawableTransitionOptions} object that enables a cross fade animation.
    *
-   * @see #crossFade(int).
+   * @see #crossFade(int)
    */
   public static DrawableTransitionOptions withCrossFade(int duration) {
     return new DrawableTransitionOptions().crossFade(duration);
@@ -32,7 +33,7 @@ public final class DrawableTransitionOptions extends
   /**
    * Returns a {@link DrawableTransitionOptions} object that enables a cross fade animation.
    *
-   * @see #crossFade(int, int).
+   * @see #crossFade(int, int)
    */
   public static DrawableTransitionOptions withCrossFade(int animationId, int duration) {
     return new DrawableTransitionOptions().crossFade(animationId, duration);
@@ -41,7 +42,7 @@ public final class DrawableTransitionOptions extends
   /**
    * Returns a {@link DrawableTransitionOptions} object that enables a cross fade animation.
    *
-   * @see #crossFade(DrawableCrossFadeFactory).
+   * @see #crossFade(DrawableCrossFadeFactory)
    */
   public static DrawableTransitionOptions withCrossFade(
       DrawableCrossFadeFactory drawableCrossFadeFactory) {
@@ -51,11 +52,21 @@ public final class DrawableTransitionOptions extends
   /**
    * Returns a {@link DrawableTransitionOptions} object that enables a cross fade animation.
    *
-   * @see #crossFade(DrawableCrossFadeFactory.Builder).
+   * @see #crossFade(DrawableCrossFadeFactory.Builder)
    */
   public static DrawableTransitionOptions withCrossFade(
       DrawableCrossFadeFactory.Builder builder) {
     return new DrawableTransitionOptions().crossFade(builder);
+  }
+
+  /**
+   * Returns a {@link DrawableTransitionOptions} object that uses the given transition factory.
+   *
+   * @see com.bumptech.glide.GenericTransitionOptions#with(TransitionFactory)
+   */
+  public static DrawableTransitionOptions with(
+      TransitionFactory<Drawable> transitionFactory) {
+    return new DrawableTransitionOptions().transition(transitionFactory);
   }
 
   /**
@@ -84,7 +95,7 @@ public final class DrawableTransitionOptions extends
    * @param animationId The id of the animation to use if no placeholder or previous resource is
    *     set, see {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
    *     #setDefaultAnimationId(int)}.
-   * @param duration The duration of the animation, see
+   * @param duration The duration of the cross fade, see
    *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
    */
   public DrawableTransitionOptions crossFade(int animationId, int duration) {

--- a/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
@@ -1,0 +1,55 @@
+package com.bumptech.glide.request.transition;
+
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+
+import com.bumptech.glide.load.DataSource;
+
+/**
+ * A {@link TransitionFactory} for complex types that have a {@link android.graphics.Bitmap} inside.
+ * The transitioning bitmap is wrapped in a {@link android.graphics.drawable.BitmapDrawable}.
+ * Most commonly used with {@link DrawableCrossFadeFactory}.
+ *
+ *  @param <R> The type of the composite object that contains the {@link android.graphics.Bitmap} to
+ *            be transitioned.
+ */
+public abstract class BitmapContainerTransitionFactory<R> implements TransitionFactory<R> {
+  private final TransitionFactory<Drawable> realFactory;
+
+  public BitmapContainerTransitionFactory(TransitionFactory<Drawable> realFactory) {
+    this.realFactory = realFactory;
+  }
+
+  @Override
+  public Transition<R> build(DataSource dataSource, boolean isFirstResource) {
+    Transition<Drawable> transition = realFactory.build(dataSource, isFirstResource);
+    return new BitmapGlideAnimation(transition);
+  }
+
+  /**
+   * Retrieve the Bitmap from a composite object.
+   * <br>
+   * <b>Warning:</b> Do not convert any arbitrary object to Bitmap via expensive drawing here.
+   *
+   * @param current composite object containing a Bitmap and some other information
+   * @return the Bitmap contained within {@code current}
+   */
+  protected abstract Bitmap getBitmap(R current);
+
+  private class BitmapGlideAnimation implements Transition<R> {
+    private final Transition<Drawable> transition;
+
+    public BitmapGlideAnimation(Transition<Drawable> transition) {
+      this.transition = transition;
+    }
+
+    @Override
+    public boolean transition(R current, ViewAdapter adapter) {
+      Resources resources = adapter.getView().getResources();
+      Drawable currentBitmap = new BitmapDrawable(resources, getBitmap(current));
+      return transition.transition(currentBitmap, adapter);
+    }
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/request/transition/BitmapTransitionFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/transition/BitmapTransitionFactory.java
@@ -1,0 +1,23 @@
+package com.bumptech.glide.request.transition;
+
+import android.graphics.Bitmap;
+import android.graphics.drawable.Drawable;
+import android.support.annotation.NonNull;
+
+/**
+ * A {@link TransitionFactory} for {@link android.graphics.Bitmap}s that uses a Drawable transition
+ * factory to transition from an existing drawable already visible on the target to the new bitmap.
+ *
+ * @see BitmapContainerTransitionFactory
+ */
+public class BitmapTransitionFactory extends BitmapContainerTransitionFactory<Bitmap> {
+  public BitmapTransitionFactory(@NonNull TransitionFactory<Drawable> realFactory) {
+    super(realFactory);
+  }
+
+  @Override
+  @NonNull
+  protected Bitmap getBitmap(@NonNull Bitmap current) {
+    return current;
+  }
+}


### PR DESCRIPTION
Forward port PR #1096 which fixes #840.

The v4 port contains less tricks than the v3 version due to simplified request builders.
The Bitmap related TransitionFactory classes also got cleaner responsibilities (fully decoupled from crossfade).
`animate(GlideAnimationFactory)`, or as it's called in v4: `TransitionOptions.transition(TransitionFactory)` was already public.

Here's a demo of new methods introduced. Irrelevant parts (`load`/`into`/etc.) are omitted for brevity.
The class names are pulled to comments to show how it would look like with static imports.

```java
DrawableCrossFadeFactory.Builder fadeOver = new DrawableCrossFadeFactory.Builder()
    .setCrossFadeEnabled(false);

// mirrored convenience methods from DrawableTransitionOptions
Glide.with(this).asBitmap()
    .transition(withCrossFade(3000)) // BitmapTransitionOptions
;
// mirrored convenience methods from DrawableTransitionOptions 
Glide.with(this).asBitmap()
    .transition(withCrossFade(android.R.anim.fade_in, 3000)) // BitmapTransitionOptions
;
// wrap Drawable crossFade over a Bitmap
Glide.with(this).asBitmap()
    .transition(withCrossFade(fadeOver.build())) // // BitmapTransitionOptions 
;
// wrap Drawable transition over a Bitmap (not necessarily a DrawableCrossFadeFactory)
Glide.with(this).asBitmap()
    .transition(withWrapped(new ViewAnimationFactory<Drawable>(android.R.anim.fade_in))) // BitmapTransitionOptions
;
// factories for custom TransitionOptions.transition(*)
Glide.with(this)
    .as(PaletteBitmap.class)
    .transition(with(new PaletteBitmapTransitionFactory(fadeOver.build()))) // GenericTransitionOptions
;
// mirrored typed factory for custom TransitionOptions.transition(*)
Glide.with(this)
    .asBitmap()
    .transition(with(new ViewAnimationFactory<Bitmap>(android.R.anim.fade_in))) // BitmapTransitionOptions
;
// mirrored typed factory for custom TransitionOptions.transition(*)
Glide.with(this)
    .asDrawable()
    .transition(with(new ViewAnimationFactory<Drawable>(android.R.anim.fade_in))) // DrawableTransitionOptions
;
```

Idea nicely finds all the factory methods, all the user has to remember is `transition(with|)` and press Ctrl+Space twice in AS/IDEA to get method suggestions:
![image](https://cloud.githubusercontent.com/assets/2906988/16714977/a9d6f3fc-46d3-11e6-85d8-a2b35bf7fe72.png)
