### PR TITLE
Spring Cleaning

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,9 +50,9 @@ Or Maven:
 
 For info on using the bleeding edge, see the [Snapshots][17] wiki page.
 
-Proguard
+ProGuard
 --------
-Depending on your proguard config and usage, you may need to include the following lines in your proguard.cfg:
+Depending on your ProGuard (DexGuard) config and usage, you may need to include the following lines in your proguard.cfg (see [Configuration wiki](https://github.com/bumptech/glide/wiki/Configuration#keeping-a-glidemodule) for more details):
 
 ```pro
 -keep public class * implements com.bumptech.glide.module.GlideModule
@@ -60,6 +60,7 @@ Depending on your proguard config and usage, you may need to include the followi
   **[] $VALUES;
   public *;
 }
+-keepresourcexmlelements manifest/application/meta-data@value=GlideModule
 ```
 
 How do I use Glide?
@@ -98,7 +99,6 @@ Simple use cases will look something like this:
 
   return myImageView;
 }
-
 ```
 
 Status
@@ -167,7 +167,7 @@ Before submitting pull requests, contributors must sign Google's [individual con
 Thanks
 ------
 * The **Android team** and **Jake Wharton** for the [disk cache implementation][8] Glide's disk cache is based on.
-* **Dave Smith** for the [gif decoder gist][9] Glide's gif decoder is based on.
+* **Dave Smith** for the [GIF decoder gist][9] Glide's GIF decoder is based on.
 * **Chris Banes** for his [gradle-mvn-push][10] script.
 * **Corey Hall** for Glide's [amazing logo][11].
 * Everyone who has contributed code and reported issues!

--- a/build.gradle
+++ b/build.gradle
@@ -65,9 +65,7 @@ subprojects { project ->
 
     gradle.projectsEvaluated {
         tasks.withType(JavaCompile) {
-            if (!name.contains('Test')) {
-                options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
-            }
+            options.compilerArgs << '-Xlint:unchecked' << '-Xlint:deprecation'
         }
     }
 }

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -59,7 +59,7 @@ project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"
         classpath = files(getAndroidLibraryVariants(variantName).collect {
             files(it.javaCompile.classpath.files, getAndroidJar())
         })
-        classpath += getInternalJavaProjects().collect { files(it.configurations.compile) }
+        classpath += getInternalJavaProjects().collect { files(it.configurations.compile) }.sum()
 
         options {
             links("http://docs.oracle.com/javase/7/docs/api/")

--- a/integration/gifencoder/src/main/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoder.java
+++ b/integration/gifencoder/src/main/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoder.java
@@ -116,7 +116,7 @@ public class ReEncodingGifResourceEncoder implements ResourceEncoder<GifDrawable
 
     }
     if (Log.isLoggable(TAG, Log.VERBOSE)) {
-      Log.v(TAG, "Re-encoded gif with " + drawable.getFrameCount() + " frames and "
+      Log.v(TAG, "Re-encoded GIF with " + drawable.getFrameCount() + " frames and "
           + drawable.getBuffer().limit() + " bytes in " + LogTime.getElapsedMillis(startTime)
           + " ms");
     }
@@ -158,7 +158,7 @@ public class ReEncodingGifResourceEncoder implements ResourceEncoder<GifDrawable
       ByteBufferUtil.toFile(data, file);
     } catch (IOException e) {
       if (Log.isLoggable(TAG, Log.WARN)) {
-        Log.w(TAG, "Failed to write gif data", e);
+        Log.w(TAG, "Failed to write GIF data", e);
       }
       return false;
     }

--- a/integration/gifencoder/src/test/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoderTest.java
+++ b/integration/gifencoder/src/test/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoderTest.java
@@ -75,6 +75,7 @@ public class ReEncodingGifResourceEncoderTest {
     when(factory.buildFrameResource(any(Bitmap.class), any(BitmapPool.class)))
         .thenReturn(frameResource);
 
+    // TODO Util.anyResource once Util is moved to testutil module (remove unchecked above!)
     when(frameTransformation.transform(any(Resource.class), anyInt(), anyInt()))
         .thenReturn(frameResource);
 

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -34,7 +34,10 @@ dependencies {
 android.testOptions.unitTests.all {
     // configure max heap size of the test JVM
     maxHeapSize = '2048m'
-    jvmArgs '-XX:MaxPermSize=2048m'
+    if (JavaVersion.current() <= JavaVersion.VERSION_1_7) {
+        // Java HotSpot(TM) 64-Bit Server VM warning: ignoring option MaxPermSize=2048m; support was removed in 8.0
+        jvmArgs '-XX:MaxPermSize=2048m'
+    }
 }
 
 android {

--- a/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
@@ -11,8 +11,7 @@ import com.bumptech.glide.request.transition.ViewPropertyTransition;
  */
 @SuppressWarnings("PMD.UseUtilityClass")
 public final class GenericTransitionOptions<TranscodeType> extends
-  TransitionOptions<GenericTransitionOptions<TranscodeType>, TranscodeType> {
-
+    TransitionOptions<GenericTransitionOptions<TranscodeType>, TranscodeType> {
   /**
    * Removes any existing animation put on the builder.
    *

--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -213,12 +213,12 @@ public class Glide implements ComponentCallbacks2 {
         .append(ParcelFileDescriptor.class, BitmapDrawable.class,
             new BitmapDrawableDecoder<>(resources, bitmapPool, new VideoBitmapDecoder(bitmapPool)))
         .register(BitmapDrawable.class, new BitmapDrawableEncoder(bitmapPool, new BitmapEncoder()))
-        /* Gifs */
+        /* GIFs */
         .prepend(InputStream.class, GifDrawable.class,
             new StreamGifDecoder(byteBufferGifDecoder, arrayPool))
         .prepend(ByteBuffer.class, GifDrawable.class, byteBufferGifDecoder)
         .register(GifDrawable.class, new GifDrawableEncoder())
-        /* Gif Frames */
+        /* GIF Frames */
         .append(GifDecoder.class, GifDecoder.class, new UnitModelLoader.Factory<GifDecoder>())
         .append(GifDecoder.class, Bitmap.class, new GifFrameResourceDecoder(bitmapPool))
         /* Files */

--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -179,7 +179,7 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
   private void preloadItem(T item, int position, int i) {
     final int[] dimensions = this.preloadDimensionProvider.getPreloadSize(item, position, i);
     if (dimensions != null) {
-      RequestBuilder preloadRequestBuilder =
+      RequestBuilder<Object> preloadRequestBuilder =
           this.preloadModelProvider.getPreloadRequestBuilder(item);
       preloadRequestBuilder.into(preloadTargetQueue.next(dimensions[0], dimensions[1]));
     }

--- a/library/src/main/java/com/bumptech/glide/Registry.java
+++ b/library/src/main/java/com/bumptech/glide/Registry.java
@@ -231,7 +231,7 @@ public class Registry {
       super("Failed to find any ModelLoaders for model: " + model);
     }
 
-    public NoModelLoaderAvailableException(Class modelClass, Class dataClass) {
+    public NoModelLoaderAvailableException(Class<?> modelClass, Class<?> dataClass) {
       super("Failed to find any ModelLoaders for model: " + modelClass + " and data: " + dataClass);
     }
   }

--- a/library/src/main/java/com/bumptech/glide/RequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/RequestBuilder.java
@@ -146,8 +146,8 @@ public class RequestBuilder<TranscodeType> implements Cloneable {
 
   /**
    * Loads a resource in an identical manner to this request except with the dimensions of the
-   * target multiplied by the given size multiplier. If the thumbnail load completes before the
-   * fullsize load, the thumbnail will be shown. If the thumbnail load completes after the fullsize
+   * target multiplied by the given size multiplier. If the thumbnail load completes before the full
+   * size load, the thumbnail will be shown. If the thumbnail load completes after the full size
    * load, the thumbnail will not be shown.
    *
    * <p> Note - The thumbnail resource will be smaller than the size requested so the target (or
@@ -159,7 +159,7 @@ public class RequestBuilder<TranscodeType> implements Cloneable {
    * and {@link com.bumptech.glide.load.Transformation}s. However,
    * {@link com.bumptech.glide.request.BaseRequestOptions#placeholder(int)} and
    * {@link com.bumptech.glide.request.BaseRequestOptions#error(int)}, and
-   * {@link #listener(RequestListener)} will only be used on the fullsize load and will not be
+   * {@link #listener(RequestListener)} will only be used on the full size load and will not be
    * copied for the thumbnail load. </p>
    *
    * <p> Recursive calls to thumbnail are supported. </p>
@@ -431,7 +431,7 @@ public class RequestBuilder<TranscodeType> implements Cloneable {
    * Returns a future that can be used to do a blocking get on a background thread.
    *
    * <p>This method defaults to {@link Target#SIZE_ORIGINAL} for the width and the height. However,
-   * since the width and height will be overriden by values passed to {@link
+   * since the width and height will be overridden by values passed to {@link
    * RequestOptions#override(int, int)}, this method can be used whenever {@link RequestOptions}
    * with override values are applied, or whenever you want to retrieve the image in its original
    * size.

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -390,7 +390,7 @@ public class RequestManager implements LifecycleListener {
    * @param view The view to cancel loads and free resources for.
    * @throws IllegalArgumentException if an object other than Glide's metadata is put as the view's
    *                                  tag.
-   * @see #clear(Target).
+   * @see #clear(Target)
    */
   public void clear(View view) {
     clear(new ClearTarget(view));

--- a/library/src/main/java/com/bumptech/glide/TransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/TransitionOptions.java
@@ -28,9 +28,9 @@ public abstract class TransitionOptions<CHILD extends TransitionOptions<CHILD, T
   }
 
   /**
-   * Sets a {@link android.view.animation} to run on the wrapped target when an resource load
-   * finishes. Will only be run if the resource was loaded asynchronously (ie was not in the memory
-   * cache)
+   * Sets an {@link android.view.animation.Animation} to run on the wrapped target when an resource
+   * load finishes.
+   * Will only be run if the resource was loaded asynchronously (i.e. was not in the memory cache).
    *
    * @param viewAnimationId The resource id of the {@link android.view.animation} to use as the
    *                        transition.
@@ -42,8 +42,8 @@ public abstract class TransitionOptions<CHILD extends TransitionOptions<CHILD, T
 
   /**
    * Sets an animator to run a {@link android.view.ViewPropertyAnimator} on a view that the target
-   * may be wrapping when a resource load finishes. Will only be run if the load was loaded
-   * asynchronously (ie was not in the memory cache).
+   * may be wrapping when a resource load finishes.
+   * Will only be run if the load was loaded asynchronously (i.e. was not in the memory cache).
    *
    * @param animator The {@link com.bumptech.glide.request.transition.ViewPropertyTransition
    *                 .Animator} to run.

--- a/library/src/main/java/com/bumptech/glide/load/ResourceDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/ResourceDecoder.java
@@ -21,7 +21,7 @@ public interface ResourceDecoder<T, Z> {
    * <p> Decoders should make a best effort attempt to quickly determine if they are likely to be
    * able to decode data, but should not attempt to completely read the given data. A typical
    * implementation would check the file headers verify they match content the decoder expects to
-   * handle (ie a GIF decoder should verify that the image contains the GIF header block. </p>
+   * handle (i.e. a GIF decoder should verify that the image contains the GIF header block. </p>
    *
    * <p> Decoders that return {@code true} from {@link #handles(Object, Options)} may still
    * return {@code null} from {@link #decode(Object, int, int, Options)} if the data is

--- a/library/src/main/java/com/bumptech/glide/load/data/DataFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/DataFetcher.java
@@ -35,6 +35,7 @@ public interface DataFetcher<T> {
 
     /**
      * Called when the load fails.
+     *
      * @param e a non-null {@link Exception} indicating why the load failed.
      */
     void onLoadFailed(Exception e);

--- a/library/src/main/java/com/bumptech/glide/load/data/DataRewinderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/DataRewinderRegistry.java
@@ -7,41 +7,42 @@ import java.util.Map;
 
 /**
  * Stores a mapping of data class to {@link com.bumptech.glide.load.data.DataRewinder.Factory} and
- * allows  registation of new types and factories.
+ * allows registration of new types and factories.
  */
 public class DataRewinderRegistry {
-  private final Map<Class, DataRewinder.Factory> rewinders = new HashMap<>();
-  private static final DataRewinder.Factory DEFAULT_FACTORY = new DataRewinder.Factory<Object>() {
-    @Override
-    public DataRewinder<Object> build(Object data) {
-      return new DefaultRewinder(data);
-    }
+  private final Map<Class<?>, DataRewinder.Factory<?>> rewinders = new HashMap<>();
+  private static final DataRewinder.Factory<?> DEFAULT_FACTORY =
+      new DataRewinder.Factory<Object>() {
+        @Override
+        public DataRewinder<Object> build(Object data) {
+          return new DefaultRewinder(data);
+        }
 
-    @Override
-    public Class<Object> getDataClass() {
-      throw new UnsupportedOperationException("Not implemented");
-    }
-  };
+        @Override
+        public Class<Object> getDataClass() {
+          throw new UnsupportedOperationException("Not implemented");
+        }
+      };
 
-  public synchronized void register(DataRewinder.Factory factory) {
+  public synchronized void register(DataRewinder.Factory<?> factory) {
     rewinders.put(factory.getDataClass(), factory);
   }
 
   @SuppressWarnings("unchecked")
   public synchronized <T> DataRewinder<T> build(T data) {
     Preconditions.checkNotNull(data);
-    DataRewinder.Factory result = rewinders.get(data.getClass());
+    DataRewinder.Factory<T> result = (DataRewinder.Factory<T>) rewinders.get(data.getClass());
     if (result == null) {
       for (DataRewinder.Factory<?> registeredFactory : rewinders.values()) {
         if (registeredFactory.getDataClass().isAssignableFrom(data.getClass())) {
-          result = registeredFactory;
+          result = (DataRewinder.Factory<T>) registeredFactory;
           break;
         }
       }
     }
 
     if (result == null) {
-      result = DEFAULT_FACTORY;
+      result = (DataRewinder.Factory<T>) DEFAULT_FACTORY;
     }
     return result.build(data);
   }

--- a/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
@@ -142,7 +142,7 @@ class DecodeJob<R> implements DataFetcherGenerator.FetcherReadyCallback,
   }
 
   /**
-   * Called when we've finished encoding (either becasue the encode process is complete, or because
+   * Called when we've finished encoding (either because the encode process is complete, or because
    * we don't have anything to encode).
    */
   private void onEncodeComplete() {

--- a/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
@@ -33,7 +33,7 @@ public class Engine implements EngineJobListener,
     EngineResource.ResourceListener {
   private static final String TAG = "Engine";
   private static final int JOB_POOL_SIZE = 150;
-  private final Map<Key, EngineJob> jobs;
+  private final Map<Key, EngineJob<?>> jobs;
   private final EngineKeyFactory keyFactory;
   private final MemoryCache cache;
   private final EngineJobFactory engineJobFactory;
@@ -50,10 +50,10 @@ public class Engine implements EngineJobListener,
    * Allows a request to indicate it no longer is interested in a given load.
    */
   public static class LoadStatus {
-    private final EngineJob engineJob;
+    private final EngineJob<?> engineJob;
     private final ResourceCallback cb;
 
-    public LoadStatus(ResourceCallback cb, EngineJob engineJob) {
+    public LoadStatus(ResourceCallback cb, EngineJob<?> engineJob) {
       this.cb = cb;
       this.engineJob = engineJob;
     }
@@ -63,18 +63,26 @@ public class Engine implements EngineJobListener,
     }
   }
 
-  public Engine(MemoryCache memoryCache, DiskCache.Factory diskCacheFactory,
-      GlideExecutor diskCacheExecutor, GlideExecutor sourceExecutor,
+  public Engine(MemoryCache memoryCache,
+      DiskCache.Factory diskCacheFactory,
+      GlideExecutor diskCacheExecutor,
+      GlideExecutor sourceExecutor,
       GlideExecutor sourceUnlimitedExecutor) {
     this(memoryCache, diskCacheFactory, diskCacheExecutor, sourceExecutor, sourceUnlimitedExecutor,
         null, null, null, null, null, null);
   }
 
   // Visible for testing.
-  Engine(MemoryCache cache, DiskCache.Factory diskCacheFactory, GlideExecutor diskCacheExecutor,
-      GlideExecutor sourceExecutor, GlideExecutor sourceUnlimitedExecutor, Map<Key, EngineJob> jobs,
-      EngineKeyFactory keyFactory, Map<Key, WeakReference<EngineResource<?>>> activeResources,
-      EngineJobFactory engineJobFactory, DecodeJobFactory decodeJobFactory,
+  Engine(MemoryCache cache,
+      DiskCache.Factory diskCacheFactory,
+      GlideExecutor diskCacheExecutor,
+      GlideExecutor sourceExecutor,
+      GlideExecutor sourceUnlimitedExecutor,
+      Map<Key, EngineJob<?>> jobs,
+      EngineKeyFactory keyFactory,
+      Map<Key, WeakReference<EngineResource<?>>> activeResources,
+      EngineJobFactory engineJobFactory,
+      DecodeJobFactory decodeJobFactory,
       ResourceRecycler resourceRecycler) {
     this.cache = cache;
     this.diskCacheProvider = new LazyDiskCacheProvider(diskCacheFactory);
@@ -172,7 +180,7 @@ public class Engine implements EngineJobListener,
       return null;
     }
 
-    EngineJob current = jobs.get(key);
+    EngineJob<?> current = jobs.get(key);
     if (current != null) {
       current.addCallback(cb);
       if (Log.isLoggable(TAG, Log.VERBOSE)) {
@@ -248,22 +256,22 @@ public class Engine implements EngineJobListener,
   private EngineResource<?> getEngineResourceFromCache(Key key) {
     Resource<?> cached = cache.remove(key);
 
-    final EngineResource result;
+    final EngineResource<?> result;
     if (cached == null) {
       result = null;
     } else if (cached instanceof EngineResource) {
       // Save an object allocation if we've cached an EngineResource (the typical case).
-      result = (EngineResource) cached;
+      result = (EngineResource<?>) cached;
     } else {
-      result = new EngineResource(cached, true /*isMemoryCacheable*/);
+      result = new EngineResource<>(cached, true /*isMemoryCacheable*/);
     }
     return result;
   }
 
-  public void release(Resource resource) {
+  public void release(Resource<?> resource) {
     Util.assertMainThread();
     if (resource instanceof EngineResource) {
-      ((EngineResource) resource).release();
+      ((EngineResource<?>) resource).release();
     } else {
       throw new IllegalArgumentException("Cannot release anything but an EngineResource");
     }
@@ -288,7 +296,7 @@ public class Engine implements EngineJobListener,
   @Override
   public void onEngineJobCancelled(EngineJob engineJob, Key key) {
     Util.assertMainThread();
-    EngineJob current = jobs.get(key);
+    EngineJob<?> current = jobs.get(key);
     if (engineJob.equals(current)) {
       jobs.remove(key);
     }

--- a/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
@@ -284,7 +284,7 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
 
     @Override
     public boolean handleMessage(Message message) {
-      EngineJob job = (EngineJob) message.obj;
+      EngineJob<?> job = (EngineJob<?>) message.obj;
       switch (message.what) {
         case MSG_COMPLETE:
           job.handleResultOnMainThread();

--- a/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
@@ -59,10 +59,10 @@ public final class GlideException extends Exception {
   /**
    * Returns a list of causes that are immediate children of this exception.
    *
-   * @see #getRootCauses().
-   *
    * <p>Causes may or may not be {@link GlideException GlideExceptions}. Causes may also not be root
-   * causes, and in turn my have been caused by other failures.
+   * causes, and in turn my have been caused by other failures.</p>
+   *
+   * @see #getRootCauses()
    */
   public List<Exception> getCauses() {
     return causes;

--- a/library/src/main/java/com/bumptech/glide/load/engine/ResourceRecycler.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/ResourceRecycler.java
@@ -36,7 +36,7 @@ class ResourceRecycler {
     @Override
     public boolean handleMessage(Message message) {
       if (message.what == RECYCLE_RESOURCE) {
-        Resource resource = (Resource) message.obj;
+        Resource<?> resource = (Resource<?>) message.obj;
         resource.recycle();
         return true;
       }

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/ArrayAdapterInterface.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/ArrayAdapterInterface.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 /**
  * Interface for handling operations on a primitive array type.
- * @param <T> Array type (eg byte[], int[])
+ * @param <T> Array type (e.g. byte[], int[])
  */
 public interface ArrayAdapterInterface<T> {
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
@@ -29,8 +29,8 @@ public final class LruArrayPool implements ArrayPool {
 
   private final GroupedLinkedMap<Key, Object> groupedMap = new GroupedLinkedMap<>();
   private final KeyPool keyPool = new KeyPool();
-  private final Map<Class, NavigableMap<Integer, Integer>> sortedSizes = new HashMap<>();
-  private final Map<Class, ArrayAdapterInterface> adapters = new HashMap<>();
+  private final Map<Class<?>, NavigableMap<Integer, Integer>> sortedSizes = new HashMap<>();
+  private final Map<Class<?>, ArrayAdapterInterface<?>> adapters = new HashMap<>();
   private final int maxSize;
   private int currentSize;
 
@@ -177,7 +177,7 @@ public final class LruArrayPool implements ArrayPool {
 
   @SuppressWarnings("unchecked")
   private <T> ArrayAdapterInterface<T> getAdapterFromType(Class<T> arrayPoolClass) {
-    ArrayAdapterInterface adapter = adapters.get(arrayPoolClass);
+    ArrayAdapterInterface<?> adapter = adapters.get(arrayPoolClass);
     if (adapter == null) {
       if (arrayPoolClass.equals(int[].class)) {
         adapter = new IntegerArrayAdapter();
@@ -189,7 +189,7 @@ public final class LruArrayPool implements ArrayPool {
       }
       adapters.put(arrayPoolClass, adapter);
     }
-    return adapter;
+    return (ArrayAdapterInterface<T>) adapter;
   }
 
   // VisibleForTesting
@@ -206,7 +206,7 @@ public final class LruArrayPool implements ArrayPool {
 
   private static final class KeyPool extends BaseKeyPool<Key> {
 
-    Key get(int size, Class arrayClass) {
+    Key get(int size, Class<?> arrayClass) {
       Key result = get();
       result.init(size, arrayClass);
       return result;
@@ -221,13 +221,13 @@ public final class LruArrayPool implements ArrayPool {
   private static final class Key implements Poolable {
     private final KeyPool pool;
     private int size;
-    private Class arrayClass;
+    private Class<?> arrayClass;
 
     Key(KeyPool pool) {
       this.pool = pool;
     }
 
-    void init(int length, Class arrayClass) {
+    void init(int length, Class<?> arrayClass) {
       this.size = length;
       this.arrayClass = arrayClass;
     }

--- a/library/src/main/java/com/bumptech/glide/load/model/DataUrlLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/DataUrlLoader.java
@@ -19,7 +19,7 @@ import java.io.InputStream;
  *
  * <p>See http://www.ietf.org/rfc/rfc2397.txt  for a complete description of the 'data' URL scheme.
  *
- * <p>Briefly, a 'data' URL has the form: <pre>data:[mediatype][;base64],somedata"</pre>
+ * <p>Briefly, a 'data' URL has the form: <pre>data:[mediatype][;base64],some_data</pre>
  *
  * @param <Data> The type of data that can be opened.
  */

--- a/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
@@ -131,7 +131,7 @@ public final class LazyHeaders implements Headers {
      * Adds a value for the given header and returns this builder.
      *
      * <p> Use {@link #addHeader(String, LazyHeaderFactory)} if obtaining the value requires I/O
-     * (ie an oauth token). </p>
+     * (i.e. an OAuth token). </p>
      *
      * @see #addHeader(String, LazyHeaderFactory)
 
@@ -168,7 +168,7 @@ public final class LazyHeaders implements Headers {
      * <p> If the given value is {@code null}, the header at the given key will be removed. </p>
      *
      * <p> Use {@link #setHeader(String, LazyHeaderFactory)} if obtaining the value requires I/O
-     * (ie an oauth token). </p>
+     * (i.e. an OAuth token). </p>
      */
     public Builder setHeader(String key, String value) {
       return setHeader(key, value == null ? null : new StringHeaderFactory(value));

--- a/library/src/main/java/com/bumptech/glide/load/model/ModelCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ModelCache.java
@@ -110,7 +110,7 @@ public class ModelCache<A, B> {
     @Override
     public boolean equals(Object o) {
       if (o instanceof ModelKey) {
-        ModelKey other = (ModelKey) o;
+        @SuppressWarnings("unchecked") ModelKey<A> other = (ModelKey<A>) o;
         return width == other.width && height == other.height && model.equals(other.model);
       }
       return false;

--- a/library/src/main/java/com/bumptech/glide/load/model/ModelLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ModelLoader.java
@@ -23,7 +23,7 @@ import java.util.List;
  *
  * This not only avoids having to duplicate dimensions in xml and in your code in order to determine
  * the size of a view on devices with different densities, but also allows you to use layout weights
- * or otherwise programatically put the dimensions of the view without forcing you to fetch a
+ * or otherwise programmatically put the dimensions of the view without forcing you to fetch a
  * generic resource size.
  *
  * The smaller the resource you fetch, the less bandwidth and battery life you use, and the lower

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
@@ -109,7 +109,7 @@ public abstract class BitmapTransformation implements Transformation<Bitmap> {
    * @param toTransform The {@link android.graphics.Bitmap} to transform.
    * @param outWidth    The ideal width of the transformed bitmap (the transformed width does not
    *                    need to match exactly).
-   * @param outHeight   The ideal height of the transformed bitmap (the transformed heightdoes not
+   * @param outHeight   The ideal height of the transformed bitmap (the transformed height does not
    *                    need to match exactly).
    */
   protected abstract Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform,

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
@@ -95,7 +95,8 @@ public final class BitmapTransitionOptions extends
    * subsequent resources (if thumbnails are used).
    *
    * @param duration The duration of the animation, see
-   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   *     {@code DrawableCrossFadeFactory.Builder(int)}.
+   * @see com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
    */
   public BitmapTransitionOptions crossFade(int duration) {
     return crossFade(new DrawableCrossFadeFactory.Builder(duration));
@@ -106,10 +107,10 @@ public final class BitmapTransitionOptions extends
    * subsequent resources (if thumbnails are used).
    *
    * @param animationId The id of the animation to use if no placeholder or previous resource is
-   *     set, see {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
-   *     #setDefaultAnimationId(int)}.
+   *     set, see {@code DrawableCrossFadeFactory.Builder#setDefaultAnimationId(int)}.
    * @param duration The duration of the cross fade, see
-   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   *     {@code DrawableCrossFadeFactory.Builder(int)}.
+   * @see com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
    */
   public BitmapTransitionOptions crossFade(int animationId, int duration) {
     return crossFade(

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.load.resource.bitmap;
 
 import android.content.Context;
 import android.graphics.Bitmap;
+import android.support.annotation.NonNull;
 
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.util.Preconditions;
@@ -39,7 +40,8 @@ public final class RoundedCorners extends BitmapTransformation {
   }
 
   @Override
-  protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+  protected Bitmap transform(
+      @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
     return TransformationUtils.roundedCorners(pool, toTransform, outWidth, outHeight,
         roundingRadius);
   }

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableResource.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableResource.java
@@ -6,9 +6,9 @@ import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.util.Preconditions;
 
 /**
- * Simple wrapper for an Android {@link Drawable} which returns a {@link
- * android.graphics.drawable.Drawable.ConstantState#newDrawable() new drawable} based on it's {@link
- * android.graphics.drawable.Drawable.ConstantState state}.
+ * Simple wrapper for an Android {@link Drawable} which returns a
+ * {@link android.graphics.drawable.Drawable.ConstantState#newDrawable() new drawable}
+ * based on it's {@link android.graphics.drawable.Drawable.ConstantState state}.
  *
  * <b>Suggested usages only include {@code T}s where the new drawable is of the same or descendant
  * class.</b>
@@ -25,10 +25,9 @@ public abstract class DrawableResource<T extends Drawable> implements Resource<T
   @SuppressWarnings("unchecked")
   @Override
   public final T get() {
-    // Drawables contain temporary state related to how they're being displayed (alpha, color
-    // filter etc), so
-    // return a new copy each time. If we ever return the original drawable, it's temporary state
-    // may be changed
+    // Drawables contain temporary state related to how they're being displayed
+    // (alpha, color filter etc), so return a new copy each time.
+    // If we ever return the original drawable, it's temporary state may be changed
     // and subsequent copies may end up with that temporary state. See #276.
     return (T) drawable.getConstantState().newDrawable();
   }

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
@@ -82,7 +82,8 @@ public final class DrawableTransitionOptions extends
    * subsequent resources (if thumbnails are used).
    *
    * @param duration The duration of the animation, see
-   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   *     {@code DrawableCrossFadeFactory.Builder(int)}
+   * @see com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
    */
   public DrawableTransitionOptions crossFade(int duration) {
     return crossFade(new DrawableCrossFadeFactory.Builder(duration));
@@ -93,10 +94,10 @@ public final class DrawableTransitionOptions extends
    * subsequent resources (if thumbnails are used).
    *
    * @param animationId The id of the animation to use if no placeholder or previous resource is
-   *     set, see {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
-   *     #setDefaultAnimationId(int)}.
+   *     set, see {@code DrawableCrossFadeFactory.Builder#setDefaultAnimationId(int)}.
    * @param duration The duration of the cross fade, see
-   *     {@link com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder(int)}
+   *     {@code DrawableCrossFadeFactory.Builder(int)}
+   * @see com.bumptech.glide.request.transition.DrawableCrossFadeFactory.Builder
    */
   public DrawableTransitionOptions crossFade(int animationId, int duration) {
     return crossFade(

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -115,7 +115,7 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
             firstFrame);
 
     if (Log.isLoggable(TAG, Log.VERBOSE)) {
-      Log.v(TAG, "Decoded gif from stream in " + LogTime.getElapsedMillis(startTime));
+      Log.v(TAG, "Decoded GIF from stream in " + LogTime.getElapsedMillis(startTime));
     }
 
     return new GifDrawableResource(gifDrawable);
@@ -129,7 +129,7 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
     // than 0.
     int sampleSize = Math.max(1, powerOfTwoSampleSize);
     if (Log.isLoggable(TAG, Log.VERBOSE)) {
-      Log.v(TAG, "Downsampling gif"
+      Log.v(TAG, "Downsampling GIF"
           + ", sampleSize: " + sampleSize
           + ", target dimens: [" + targetWidth + "x" + targetHeight + "]"
           + ", actual dimens: [" + gifHeader.getWidth() + "x" + gifHeader.getHeight() + "]");

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -60,11 +60,11 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
    */
   private boolean isVisible = true;
   /**
-   * The number of times we've looped over all the frames in the gif.
+   * The number of times we've looped over all the frames in the GIF.
    */
   private int loopCount;
   /**
-   * The number of times to loop through the gif animation.
+   * The number of times to loop through the GIF animation.
    */
   private int maxLoopCount = LOOP_FOREVER;
 
@@ -89,8 +89,8 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
    *                            height of the view or
    *                            {@link com.bumptech.glide.request.target.Target}
    *                            this drawable is being loaded into).
-   * @param gifDecoder          The decoder to use to decode gif data.
-   * @param firstFrame          The decoded and transformed first frame of this gif.
+   * @param gifDecoder          The decoder to use to decode GIF data.
+   * @param firstFrame          The decoded and transformed first frame of this GIF.
    * @see #setFrameTransformation(com.bumptech.glide.load.Transformation, android.graphics.Bitmap)
    */
   public GifDrawable(Context context, GifDecoder gifDecoder, BitmapPool bitmapPool,

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableEncoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableEncoder.java
@@ -32,7 +32,7 @@ public class GifDrawableEncoder implements ResourceEncoder<GifDrawable> {
       success = true;
     } catch (IOException e) {
       if (Log.isLoggable(TAG, Log.WARN)) {
-        Log.w(TAG, "Failed to encode gif drawable data", e);
+        Log.w(TAG, "Failed to encode GIF drawable data", e);
       }
     }
     return success;

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformation.java
@@ -37,7 +37,7 @@ public class GifDrawableTransformation implements Transformation<GifDrawable> {
 
     // The drawable needs to be initialized with the correct width and height in order for a view
     // displaying it to end up with the right dimensions. Since our transformations may arbitrarily
-    // modify the dimensions of our gif, here we create a stand in for a frame and pass it to the
+    // modify the dimensions of our GIF, here we create a stand in for a frame and pass it to the
     // transformation to see what the final transformed dimensions will be so that our drawable can
     // report the correct intrinsic width and height.
     Bitmap firstFrame = drawable.getFirstFrame();

--- a/library/src/main/java/com/bumptech/glide/provider/ResourceDecoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/provider/ResourceDecoderRegistry.java
@@ -7,7 +7,7 @@ import java.util.List;
 
 /**
  * Contains an ordered list of {@link ResourceDecoder}s capable of decoding arbitrary data types
- * into arbitrary resource types from highest priority decoders to loweset priority decoders.
+ * into arbitrary resource types from highest priority decoders to lowest priority decoders.
  */
 @SuppressWarnings("rawtypes")
 public class ResourceDecoderRegistry {

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -365,7 +365,7 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param signature A unique non-null {@link com.bumptech.glide.load.Key} representing the current
    *                  state of the model that will be mixed in to the cache key.
    * @return This request builder.
-   * @see com.bumptech.glide.signature.StringSignature
+   * @see com.bumptech.glide.signature.ObjectKey
    */
   public final CHILD signature(@NonNull Key signature) {
     if (isAutoCloneEnabled) {
@@ -461,7 +461,7 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * <p>{@link DecodeFormat} is a request, not a requirement. It's possible the resource will be
    * decoded using a decoder that cannot control the format
    * ({@link android.media.MediaMetadataRetriever} for example), or that the decoder may choose to
-   * ignore the requested format if it can't display the image (ie RGB_565 is requested, but the
+   * ignore the requested format if it can't display the image (i.e. RGB_565 is requested, but the
    * image has alpha).
    */
   public CHILD format(@NonNull DecodeFormat format) {

--- a/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
+++ b/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
@@ -281,7 +281,7 @@ public final class SingleRequest<R> implements Request,
     status = Status.PAUSED;
   }
 
-  private void releaseResource(Resource resource) {
+  private void releaseResource(Resource<?> resource) {
     engine.release(resource);
     this.resource = null;
   }

--- a/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
+++ b/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
@@ -27,7 +27,7 @@ public class ThumbnailRequestCoordinator implements RequestCoordinator,
   }
 
   /**
-   * Returns true if the request is either the request loading the fullsize image or if the request
+   * Returns true if the request is either the request loading the full size image or if the request
    * loading the full size image has not yet completed.
    *
    * @param request {@inheritDoc}
@@ -42,7 +42,7 @@ public class ThumbnailRequestCoordinator implements RequestCoordinator,
   }
 
   /**
-   * Returns true if the request is the request loading the fullsize image and if neither the full
+   * Returns true if the request is the request loading the full size image and if neither the full
    * nor the thumbnail image have completed successfully.
    *
    * @param request {@inheritDoc}.

--- a/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
@@ -12,7 +12,7 @@ import com.bumptech.glide.load.DataSource;
  * The transitioning bitmap is wrapped in a {@link android.graphics.drawable.BitmapDrawable}.
  * Most commonly used with {@link DrawableCrossFadeFactory}.
  *
- *  @param <R> The type of the composite object that contains the {@link android.graphics.Bitmap} to
+ * @param <R> The type of the composite object that contains the {@link android.graphics.Bitmap} to
  *            be transitioned.
  */
 public abstract class BitmapContainerTransitionFactory<R> implements TransitionFactory<R> {
@@ -30,8 +30,8 @@ public abstract class BitmapContainerTransitionFactory<R> implements TransitionF
 
   /**
    * Retrieve the Bitmap from a composite object.
-   * <br>
-   * <b>Warning:</b> Do not convert any arbitrary object to Bitmap via expensive drawing here.
+   * <p><b>Warning:</b> Do not convert any arbitrary object to Bitmap
+   * via expensive drawing here, this method is called on the UI thread.</p>
    *
    * @param current composite object containing a Bitmap and some other information
    * @return the Bitmap contained within {@code current}

--- a/library/src/main/java/com/bumptech/glide/signature/ObjectKey.java
+++ b/library/src/main/java/com/bumptech/glide/signature/ObjectKey.java
@@ -11,8 +11,8 @@ import java.security.MessageDigest;
  * method to the {@link java.security.MessageDigest} in
  * {@link #updateDiskCacheKey(java.security.MessageDigest)}.
  *
- * <p> The Object's {@link #toString()} method must be unique and suitable for use as a disk cache
- * key. </p>
+ * <p>The Object's {@link #toString()} method must be unique and suitable for use as a disk cache
+ * key.</p>
  */
 public final class ObjectKey implements Key {
   private final Object object;

--- a/library/src/main/java/com/bumptech/glide/util/Util.java
+++ b/library/src/main/java/com/bumptech/glide/util/Util.java
@@ -92,7 +92,7 @@ public final class Util {
   }
 
   private static int getBytesPerPixel(Bitmap.Config config) {
-    // A bitmap by decoding a gif has null "config" in certain environments.
+    // A bitmap by decoding a GIF has null "config" in certain environments.
     if (config == null) {
       config = Bitmap.Config.ARGB_8888;
     }
@@ -172,13 +172,13 @@ public final class Util {
    * <p> See #303 and #375. </p>
    */
   public static <T> List<T> getSnapshot(Collection<T> other) {
-      // toArray creates a new ArrayList internally and this way we can guarantee entries will not
-      // be null. See #322.
-      List<T> result = new ArrayList<T>(other.size());
-      for (T item : other) {
-          result.add(item);
-      }
-      return result;
+    // toArray creates a new ArrayList internally and this way we can guarantee entries will not
+    // be null. See #322.
+    List<T> result = new ArrayList<T>(other.size());
+    for (T item : other) {
+      result.add(item);
+    }
+    return result;
   }
 
   /**

--- a/library/src/main/java/com/bumptech/glide/util/ViewPreloadSizeProvider.java
+++ b/library/src/main/java/com/bumptech/glide/util/ViewPreloadSizeProvider.java
@@ -75,14 +75,13 @@ public class ViewPreloadSizeProvider<T> implements ListPreloader.PreloadSizeProv
   }
 
   private static final class SizeViewTarget extends ViewTarget<View, Object> {
-
     public SizeViewTarget(View view, SizeReadyCallback callback) {
       super(view);
       getSize(callback);
     }
 
     @Override
-    public void onResourceReady(Object resource, Transition transition) {
+    public void onResourceReady(Object resource, Transition<? super Object> transition) {
       // Do nothing
     }
   }

--- a/library/src/main/java/com/bumptech/glide/util/pool/StateVerifier.java
+++ b/library/src/main/java/com/bumptech/glide/util/pool/StateVerifier.java
@@ -20,7 +20,7 @@ public abstract class StateVerifier {
   private StateVerifier() { }
 
   /**
-   * Throws an exception if we believe our object is recycled and inactive (ie is currently in an
+   * Throws an exception if we believe our object is recycled and inactive (i.e. is currently in an
    * object pool).
    */
   public abstract void throwIfRecycled();

--- a/library/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/src/test/java/com/bumptech/glide/GlideTest.java
@@ -92,7 +92,9 @@ import java.util.Map;
     GlideTest.ShadowFileDescriptorContentResolver.class,
     GlideTest.ShadowMediaMetadataRetriever.class, GlideShadowLooper.class,
     GlideTest.MutableShadowBitmap.class })
+@SuppressWarnings("unchecked")
 public class GlideTest {
+  @SuppressWarnings("rawtypes")
   private Target target = null;
   private ImageView imageView;
   private RequestManager requestManager;
@@ -329,13 +331,13 @@ public class GlideTest {
   private void runTestStringDefaultLoader(String string) {
     requestManager.load(string).listener(new RequestListener<Drawable>() {
       @Override
-      public boolean onLoadFailed(GlideException e, Object model, Target target,
+      public boolean onLoadFailed(GlideException e, Object model, Target<Drawable> target,
           boolean isFirstResource) {
         throw new RuntimeException("Load failed");
       }
 
       @Override
-      public boolean onResourceReady(Drawable resource, Object model, Target target,
+      public boolean onResourceReady(Drawable resource, Object model, Target<Drawable> target,
           DataSource dataSource, boolean isFirstResource) {
         return false;
       }
@@ -531,9 +533,9 @@ public class GlideTest {
 
   @Test
   public void testClone() throws IOException {
-    Target firstTarget = mock(Target.class);
+    Target<Drawable> firstTarget = mock(Target.class);
     doAnswer(new CallSizeReady(100, 100)).when(firstTarget).getSize(isA(SizeReadyCallback.class));
-    Target secondTarget = mock(Target.class);
+    Target<Drawable> secondTarget = mock(Target.class);
     doAnswer(new CallSizeReady(100, 100)).when(secondTarget).getSize(isA(SizeReadyCallback.class));
     RequestBuilder<Drawable> firstRequest = requestManager
         .load(mockUri("content://first"));
@@ -545,14 +547,14 @@ public class GlideTest {
         .into(secondTarget);
 
     verify(firstTarget).onResourceReady(isA(Drawable.class), isA(Transition.class));
-    verify(secondTarget).onResourceReady(notNull(), isA(Transition.class));
+    verify(secondTarget).onResourceReady(notNull(Drawable.class), isA(Transition.class));
   }
 
   @SuppressWarnings("unchecked")
   private <T, Z> void registerFailFactory(Class<T> failModel, Class<Z> failResource)
       throws Exception {
     DataFetcher<Z> failFetcher = mock(DataFetcher.class);
-    doAnswer(new Util.CallDataReady(null))
+    doAnswer(new Util.CallDataReady<>(null))
         .when(failFetcher)
         .loadData(isA(Priority.class), isA(DataFetcher.DataCallback.class));
     when(failFetcher.getDataClass()).thenReturn(failResource);
@@ -610,7 +612,7 @@ public class GlideTest {
     ModelLoader<T, InputStream> modelLoader = mock(ModelLoader.class);
     DataFetcher<InputStream> fetcher = mock(DataFetcher.class);
     try {
-      doAnswer(new Util.CallDataReady(new ByteArrayInputStream(new byte[0]))).when(fetcher)
+      doAnswer(new Util.CallDataReady<>(new ByteArrayInputStream(new byte[0]))).when(fetcher)
           .loadData(isA(Priority.class), isA(DataFetcher.DataCallback.class));
     } catch (Exception e) {
       // Do nothing.
@@ -702,6 +704,7 @@ public class GlideTest {
   // a different part of the test. Each one ends up with different registered uris, which causes
   // tests to fail. We shouldn't need to do this, but using static maps seems to fix the issue.
   @Implements(value = ContentResolver.class)
+  @SuppressWarnings("unused")
   public static class ShadowFileDescriptorContentResolver {
     private static final Map<Uri, AssetFileDescriptor> URI_TO_FILE_DESCRIPTOR = new HashMap<>();
     private static final Map<Uri, InputStream> URI_TO_INPUT_STREAMS = new HashMap<>();

--- a/library/src/test/java/com/bumptech/glide/ListPreloaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/ListPreloaderTest.java
@@ -1,13 +1,12 @@
 package com.bumptech.glide;
 
+import static com.bumptech.glide.tests.Util.cast;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
-
-import android.graphics.Bitmap;
 
 import com.bumptech.glide.request.target.SizeReadyCallback;
 import com.bumptech.glide.request.target.Target;
@@ -34,7 +33,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 @Config(manifest = Config.NONE, sdk = 18)
 public class ListPreloaderTest {
 
-  @Mock private RequestBuilder<Bitmap> request;
+  @Mock private RequestBuilder<Object> request;
   @Mock private RequestManager requestManager;
 
   @Before
@@ -71,8 +70,7 @@ public class ListPreloaderTest {
     }
 
     ListPreloaderAdapter preloaderAdapter = new ListPreloaderAdapter() {
-
-      public int expectedPosition;
+      private int expectedPosition;
 
       @Override
       public int[] getPreloadSize(Object item, int adapterPosition, int itemPosition) {
@@ -85,7 +83,8 @@ public class ListPreloaderTest {
       }
 
       @Override
-      public RequestBuilder<Bitmap> getPreloadRequestBuilder(Object item) {
+      @SuppressWarnings("unchecked")
+      public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
         assertEquals(objects.get(expectedPosition), item);
         expectedPosition++;
         return mock(RequestBuilder.class);
@@ -129,7 +128,7 @@ public class ListPreloaderTest {
     }
 
     ListPreloaderAdapter preloaderAdapter = new ListPreloaderAdapter() {
-      int expectedPosition = toPreload - 1;
+      private int expectedPosition = toPreload - 1;
 
       @Override
       public int[] getPreloadSize(Object item, int adapterPosition, int itemPosition) {
@@ -145,7 +144,8 @@ public class ListPreloaderTest {
       }
 
       @Override
-      public RequestBuilder<Bitmap> getPreloadRequestBuilder(Object item) {
+      @SuppressWarnings("unchecked")
+      public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
         assertEquals(objects.get(expectedPosition), item);
         expectedPosition--;
         return mock(RequestBuilder.class);
@@ -249,7 +249,7 @@ public class ListPreloaderTest {
     objects.add(new Object());
     objects.add(new Object());
     ListPreloaderAdapter preloaderAdapter = new ListPreloaderAdapter() {
-      public int expectedPosition = (1 + 10) * 2;
+      private int expectedPosition = (1 + 10) * 2;
 
       @Override
       public List<Object> getPreloadItems(int position) {
@@ -265,7 +265,7 @@ public class ListPreloaderTest {
       }
 
       @Override
-      public RequestBuilder getPreloadRequestBuilder(Object item) {
+      public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
         return request;
       }
     };
@@ -285,7 +285,7 @@ public class ListPreloaderTest {
     objects.add(new Object());
     objects.add(new Object());
     ListPreloaderAdapter preloaderAdapter = new ListPreloaderAdapter() {
-      int expectedPosition = objects.size() * 2 - 1;
+      private int expectedPosition = objects.size() * 2 - 1;
 
       @Override
       public List<Object> getPreloadItems(int position) {
@@ -301,7 +301,7 @@ public class ListPreloaderTest {
       }
 
       @Override
-      public RequestBuilder getPreloadRequestBuilder(Object item) {
+      public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
         return request;
       }
     };
@@ -316,12 +316,13 @@ public class ListPreloaderTest {
     assertEquals(expected, allValues);
   }
 
-  private List<Integer> getTargetsSizes(RequestBuilder<?> requestBuilder, VerificationMode mode) {
+  private <R> List<Integer> getTargetsSizes(
+      RequestBuilder<R> requestBuilder, VerificationMode mode) {
     ArgumentCaptor<Integer> integerArgumentCaptor = ArgumentCaptor.forClass(Integer.class);
-    ArgumentCaptor<Target> targetArgumentCaptor = ArgumentCaptor.forClass(Target.class);
+    ArgumentCaptor<Target<R>> targetArgumentCaptor = cast(ArgumentCaptor.forClass(Target.class));
     SizeReadyCallback cb = mock(SizeReadyCallback.class);
     verify(requestBuilder, mode).into(targetArgumentCaptor.capture());
-    for (Target target : targetArgumentCaptor.getAllValues()) {
+    for (Target<R> target : targetArgumentCaptor.getAllValues()) {
       target.getSize(cb);
     }
     verify(cb, mode).onSizeReady(integerArgumentCaptor.capture(), integerArgumentCaptor.capture());
@@ -341,7 +342,7 @@ public class ListPreloaderTest {
       }
 
       @Override
-      public RequestBuilder getPreloadRequestBuilder(Object item) {
+      public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
         loadedObjects.add(item);
         return super.getPreloadRequestBuilder(item);
       }
@@ -367,7 +368,8 @@ public class ListPreloaderTest {
     }
 
     @Override
-    public RequestBuilder getPreloadRequestBuilder(Object item) {
+    @SuppressWarnings("unchecked")
+    public RequestBuilder<Object> getPreloadRequestBuilder(Object item) {
       return mock(RequestBuilder.class);
     }
 

--- a/library/src/test/java/com/bumptech/glide/RequestBuilderTest.java
+++ b/library/src/test/java/com/bumptech/glide/RequestBuilderTest.java
@@ -38,11 +38,12 @@ public class RequestBuilderTest {
 
   @Test(expected = NullPointerException.class)
   public void testThrowsIfContextIsNull() {
-    new RequestBuilder(null /*context*/, requestManager, Object.class);
+    new RequestBuilder<>(null /*context*/, requestManager, Object.class);
   }
 
   @Test(expected = NullPointerException.class)
-  public void testThrowsWhenGlideAnimationFactoryIsNull() {
+  public void testThrowsWhenTransitionsOptionsIsNull() {
+    //noinspection ConstantConditions testing if @NonNull is enforced
     getNullModelRequest().transition(null);
   }
 
@@ -53,7 +54,7 @@ public class RequestBuilderTest {
 
   @Test
   public void testAddsNewRequestToRequestTracker() {
-    Target target = mock(Target.class);
+    Target<Object> target = mock(Target.class);
     getNullModelRequest().into(target);
 
     verify(requestManager).track(eq(target), isA(Request.class));
@@ -62,7 +63,7 @@ public class RequestBuilderTest {
   @Test
   public void testRemovesPreviousRequestFromRequestTracker() {
     Request previous = mock(Request.class);
-    Target target = mock(Target.class);
+    Target<Object> target = mock(Target.class);
     when(target.getRequest()).thenReturn(previous);
 
     getNullModelRequest().into(target);
@@ -72,7 +73,8 @@ public class RequestBuilderTest {
 
   @Test(expected = NullPointerException.class)
   public void testThrowsIfGivenNullTarget() {
-    getNullModelRequest().into((Target) null);
+    //noinspection ConstantConditions testing if @NonNull is enforced
+    getNullModelRequest().into((Target<Object>) null);
   }
 
   @Test(expected = NullPointerException.class)
@@ -94,7 +96,7 @@ public class RequestBuilderTest {
 
   @Test(expected = RuntimeException.class)
   public void testThrowsIfIntoTargetCalledOnBackgroundThread() throws InterruptedException {
-    final Target target = mock(Target.class);
+    final Target<Object> target = mock(Target.class);
     testInBackground(new BackgroundUtil.BackgroundTester() {
       @Override
       public void runTest() throws Exception {
@@ -103,13 +105,13 @@ public class RequestBuilderTest {
     });
   }
 
-  private RequestBuilder getNullModelRequest() {
+  private RequestBuilder<Object> getNullModelRequest() {
     when(glideContext.buildImageViewTarget(isA(ImageView.class), isA(Class.class)))
         .thenReturn(mock(Target.class));
     when(glideContext.getDefaultRequestOptions()).thenReturn(new RequestOptions());
     when(requestManager.getDefaultRequestOptions())
         .thenReturn((BaseRequestOptions) new RequestOptions());
-    return new RequestBuilder(glideContext, requestManager, Object.class)
+    return new RequestBuilder<>(glideContext, requestManager, Object.class)
         .load((Object) null);
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/MultiTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/MultiTransformationTest.java
@@ -1,11 +1,12 @@
 package com.bumptech.glide.load;
 
+import static com.bumptech.glide.tests.Util.anyResource;
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -25,6 +26,7 @@ import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 
 @RunWith(JUnit4.class)
+@SuppressWarnings("unchecked")
 public class MultiTransformationTest {
 
   @Mock Transformation<Object> first;
@@ -54,9 +56,9 @@ public class MultiTransformationTest {
 
   @Test
   public void testInitialResourceIsNotRecycled() {
-    when(first.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(firstTransformed);
+    when(first.transform(anyResource(), anyInt(), anyInt())).thenReturn(firstTransformed);
 
-    MultiTransformation<Object> transformation = new MultiTransformation(first);
+    MultiTransformation<Object> transformation = new MultiTransformation<>(first);
 
     transformation.transform(initial, 123, 456);
 
@@ -65,8 +67,8 @@ public class MultiTransformationTest {
 
   @Test
   public void testInitialResourceIsNotRecycledEvenIfReturnedByMultipleTransformations() {
-    when(first.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(initial);
-    when(second.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(initial);
+    when(first.transform(anyResource(), anyInt(), anyInt())).thenReturn(initial);
+    when(second.transform(anyResource(), anyInt(), anyInt())).thenReturn(initial);
 
     MultiTransformation<Object> transformation = new MultiTransformation<>(first, second);
     transformation.transform(initial, 1111, 2222);
@@ -77,9 +79,9 @@ public class MultiTransformationTest {
   @Test
   public void
   testInitialResourceIsNotRecycledIfReturnedByOneTransformationButNotByALaterTransformation() {
-    when(first.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(initial);
-    when(second.transform(any(Resource.class), anyInt(), anyInt()))
-        .thenReturn(mock(Resource.class));
+    when(first.transform(anyResource(), anyInt(), anyInt())).thenReturn(initial);
+    when(second.transform(anyResource(), anyInt(), anyInt()))
+        .thenReturn(mockResource());
 
     MultiTransformation<Object> transformation = new MultiTransformation<>(first, second);
     transformation.transform(initial, 1, 2);
@@ -89,23 +91,23 @@ public class MultiTransformationTest {
 
   @Test
   public void testFinalResourceIsNotRecycled() {
-    when(first.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(firstTransformed);
+    when(first.transform(anyResource(), anyInt(), anyInt())).thenReturn(firstTransformed);
 
     MultiTransformation<Object> transformation = new MultiTransformation<>(first);
 
-    transformation.transform(mock(Resource.class), 111, 222);
+    transformation.transform(mockResource(), 111, 222);
 
     verify(firstTransformed, never()).recycle();
   }
 
   @Test
   public void testIntermediateResourcesAreRecycled() {
-    when(first.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(firstTransformed);
-    when(second.transform(any(Resource.class), anyInt(), anyInt())).thenReturn(secondTransformed);
+    when(first.transform(anyResource(), anyInt(), anyInt())).thenReturn(firstTransformed);
+    when(second.transform(anyResource(), anyInt(), anyInt())).thenReturn(secondTransformed);
 
     MultiTransformation<Object> transformation = new MultiTransformation<>(first, second);
 
-    transformation.transform(mock(Resource.class), 233, 454);
+    transformation.transform(mockResource(), 233, 454);
 
     verify(firstTransformed).recycle();
   }
@@ -118,7 +120,7 @@ public class MultiTransformationTest {
 
     doAnswer(new Util.WriteDigest("second")).when(second)
         .updateDiskCacheKey(any(MessageDigest.class));
-    KeyAssertions.assertDifferent(new MultiTransformation<>(first),
-        new MultiTransformation<>(second));
+    KeyAssertions.assertDifferent(
+        new MultiTransformation<>(first), new MultiTransformation<>(second));
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbnailStreamOpenerTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbnailStreamOpenerTest.java
@@ -92,7 +92,7 @@ public class ThumbnailStreamOpenerTest {
   public void testVideoQueryReturnsVideoCursor() {
     Uri queryUri = MediaStore.Video.Thumbnails.EXTERNAL_CONTENT_URI;
     ThumbFetcher.VideoThumbnailQuery query =
-        new ThumbFetcher.VideoThumbnailQuery(getContentResovler());
+        new ThumbFetcher.VideoThumbnailQuery(getContentResolver());
     RoboCursor testCursor = new RoboCursor();
     Shadows.shadowOf(RuntimeEnvironment.application.getContentResolver())
         .setCursor(queryUri, testCursor);
@@ -103,14 +103,14 @@ public class ThumbnailStreamOpenerTest {
   public void testImageQueryReturnsImageCursor() {
     Uri queryUri = MediaStore.Images.Thumbnails.EXTERNAL_CONTENT_URI;
     ThumbFetcher.ImageThumbnailQuery query =
-        new ThumbFetcher.ImageThumbnailQuery(getContentResovler());
+        new ThumbFetcher.ImageThumbnailQuery(getContentResolver());
     RoboCursor testCursor = new RoboCursor();
     Shadows.shadowOf(RuntimeEnvironment.application.getContentResolver())
         .setCursor(queryUri, testCursor);
     assertEquals(testCursor, query.query(harness.uri));
   }
 
-  private static ContentResolver getContentResovler() {
+  private static ContentResolver getContentResolver() {
     return RuntimeEnvironment.application.getContentResolver();
   }
 
@@ -131,7 +131,7 @@ public class ThumbnailStreamOpenerTest {
     }
 
     public ThumbnailStreamOpener get() {
-      return new ThumbnailStreamOpener(service, query, byteArrayPool, getContentResovler());
+      return new ThumbnailStreamOpener(service, query, byteArrayPool, getContentResolver());
     }
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.load.engine;
 
 import static com.bumptech.glide.tests.Util.anyResource;
 import static com.bumptech.glide.tests.Util.isADataSource;
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
@@ -109,7 +110,7 @@ public class EngineJobTest {
     job.start(harness.decodeJob);
     job.onLoadFailed(new GlideException("test"));
     ShadowLooper.runUiThreadTasks();
-    verify(harness.listener).onEngineJobComplete(eq(harness.key), (EngineResource) isNull());
+    verify(harness.listener).onEngineJobComplete(eq(harness.key), isNull(EngineResource.class));
   }
 
   @Test
@@ -180,7 +181,7 @@ public class EngineJobTest {
   @SuppressWarnings("unchecked")
   @Test
   public void removingSomeCallbacksDoesNotCancelRunner() {
-    EngineJob job = harness.getJob();
+    EngineJob<Object> job = harness.getJob();
     job.addCallback(mock(ResourceCallback.class));
     job.removeCallback(harness.cb);
 
@@ -222,7 +223,7 @@ public class EngineJobTest {
     job.start(harness.decodeJob);
     job.onLoadFailed(new GlideException("test"));
 
-    verify(harness.listener).onEngineJobComplete(eq(harness.key), (EngineResource) isNull());
+    verify(harness.listener).onEngineJobComplete(eq(harness.key), isNull(EngineResource.class));
     verify(harness.listener, never()).onEngineJobCancelled(any(EngineJob.class), any(Key.class));
   }
 
@@ -256,9 +257,9 @@ public class EngineJobTest {
     final ResourceCallback existingCallback = mock(ResourceCallback.class);
     final ResourceCallback newCallback = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.addCallback(newCallback);
         return null;
       }
@@ -274,13 +275,13 @@ public class EngineJobTest {
   @Test
   public void testNotifiesNewCallbackOfExceptionIfCallbackIsAddedDuringOnException() {
     harness = new EngineJobHarness();
-    final EngineJob job = harness.getJob();
+    final EngineJob<Object> job = harness.getJob();
     final ResourceCallback existingCallback = mock(ResourceCallback.class);
     final ResourceCallback newCallback = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.addCallback(newCallback);
         return null;
       }
@@ -299,9 +300,9 @@ public class EngineJobTest {
     final EngineJob<Object> job = harness.getJob();
     final ResourceCallback cb = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.removeCallback(cb);
         return null;
       }
@@ -320,9 +321,9 @@ public class EngineJobTest {
     final EngineJob<Object> job = harness.getJob();
     final ResourceCallback cb = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.removeCallback(cb);
         return null;
       }
@@ -342,9 +343,9 @@ public class EngineJobTest {
     final EngineJob<Object> job = harness.getJob();
     final ResourceCallback notYetCalled = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.removeCallback(notYetCalled);
         return null;
       }
@@ -363,9 +364,9 @@ public class EngineJobTest {
     final EngineJob<Object> job = harness.getJob();
     final ResourceCallback notYetCalled = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.removeCallback(notYetCalled);
         return null;
       }
@@ -387,9 +388,9 @@ public class EngineJobTest {
     final ResourceCallback called = mock(ResourceCallback.class);
     final ResourceCallback notYetCalled = mock(ResourceCallback.class);
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         job.removeCallback(notYetCalled);
         return null;
       }
@@ -456,7 +457,7 @@ public class EngineJobTest {
   @SuppressWarnings("unchecked")
   private static class MultiCbHarness {
     Key key = mock(Key.class);
-    Resource<Object> resource = mock(Resource.class);
+    Resource<Object> resource = mockResource();
     EngineResource<Object> engineResource = mock(EngineResource.class);
     EngineJobListener listener = mock(EngineJobListener.class);
     boolean isCacheable = true;
@@ -491,7 +492,7 @@ public class EngineJobTest {
     Key key = mock(Key.class);
     Handler mainHandler = new Handler();
     ResourceCallback cb = mock(ResourceCallback.class);
-    Resource<Object> resource = mock(Resource.class);
+    Resource<Object> resource = mockResource();
     EngineResource<Object> engineResource = mock(EngineResource.class);
     EngineJobListener listener = mock(EngineJobListener.class);
     GlideExecutor diskCacheService = MockGlideExecutor.newMainThreadExecutor();
@@ -505,8 +506,9 @@ public class EngineJobTest {
 
     public EngineJob<Object> getJob() {
       when(factory.build(eq(resource), eq(isCacheable))).thenReturn(engineResource);
-      EngineJob result = new EngineJob(diskCacheService, sourceService, sourceUnlimitedService,
-          listener, pool, factory).init(key, isCacheable, useUnlimitedSourceGeneratorPool);
+      EngineJob<Object> result = new EngineJob<>(
+          diskCacheService, sourceService, sourceUnlimitedService, listener, pool, factory)
+          .init(key, isCacheable, useUnlimitedSourceGeneratorPool);
       result.addCallback(cb);
       return result;
     }

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineKeyTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineKeyTest.java
@@ -44,9 +44,10 @@ public class EngineKeyTest {
     String id = "testId";
     int width = 1;
     int height = 2;
-    Class resourceClass = Object.class;
-    Class transcodeClass = Integer.class;
+    Class<?> resourceClass = Object.class;
+    Class<?> transcodeClass = Integer.class;
     Key signature = mock(Key.class);
+    @SuppressWarnings("unchecked")
     Transformation<Object> transformation = mock(Transformation.class);
     Options options = new Options();
 
@@ -99,9 +100,9 @@ public class EngineKeyTest {
       throws UnsupportedEncodingException, NoSuchAlgorithmException {
     EngineKey first = harness.build();
     Key signature = mock(Key.class);
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         MessageDigest digest = (MessageDigest) invocationOnMock.getArguments()[0];
         digest.update("signature".getBytes("UTF-8"));
         return null;
@@ -135,7 +136,7 @@ public class EngineKeyTest {
   public void testDiffersIfTransformationsDiffer() throws NoSuchAlgorithmException {
     EngineKey first = harness.build();
 
-    Transformation<Object> other = mock(Transformation.class);
+    @SuppressWarnings("unchecked") Transformation<Object> other = mock(Transformation.class);
     doAnswer(new Util.WriteDigest("other")).when(other)
         .updateDiskCacheKey(any(MessageDigest.class));
     harness.transformation = other;

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineResourceTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -25,10 +26,9 @@ public class EngineResourceTest {
   private Key cacheKey = mock(Key.class);
   private Resource<Object> resource;
 
-  @SuppressWarnings("unchecked")
   @Before
   public void setUp() {
-    resource = mock(Resource.class);
+    resource = mockResource();
     engineResource = new EngineResource<>(resource, true /*isMemoryCacheable*/);
     listener = mock(EngineResource.ResourceListener.class);
     engineResource.setResourceListener(cacheKey, listener);
@@ -146,9 +146,9 @@ public class EngineResourceTest {
 
   @Test
   public void testCanSetAndGetIsCacheable() {
-    engineResource = new EngineResource<>(mock(Resource.class), true);
+    engineResource = new EngineResource<>(mockResource(), true);
     assertTrue(engineResource.isCacheable());
-    engineResource = new EngineResource<>(mock(Resource.class), false);
+    engineResource = new EngineResource<>(mockResource(), false);
     assertFalse(engineResource.isCacheable());
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/engine/ResourceRecyclerTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/ResourceRecyclerTest.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.mockito.Mockito.doAnswer;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
@@ -29,7 +29,7 @@ public class ResourceRecyclerTest {
 
   @Test
   public void testRecyclesResourceSynchronouslyIfNotAlreadyRecyclingResource() {
-    Resource resource = mock(Resource.class);
+    Resource<?> resource = mockResource();
     Shadows.shadowOf(Looper.getMainLooper()).pause();
     recycler.recycle(resource);
     verify(resource).recycle();
@@ -37,11 +37,11 @@ public class ResourceRecyclerTest {
 
   @Test
   public void testDoesNotRecycleChildResourceSynchronously() {
-    Resource parent = mock(Resource.class);
-    final Resource child = mock(Resource.class);
-    doAnswer(new Answer() {
+    Resource<?> parent = mockResource();
+    final Resource<?> child = mockResource();
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         recycler.recycle(child);
         return null;
       }

--- a/library/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
@@ -7,6 +7,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
+import android.annotation.TargetApi;
+import android.os.Build;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -16,11 +19,12 @@ import org.robolectric.annotation.Config;
 import java.util.Arrays;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.DEFAULT, sdk = 18)
+@Config(manifest = Config.NONE, sdk = 18)
+@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class LruArrayPoolTest {
   private static final int MAX_SIZE = 10;
-  private static final Class ARRAY_CLASS = byte[].class;
-  private static final ArrayAdapterInterface ADAPTER = new ByteArrayAdapter();
+  private static final Class<byte[]> ARRAY_CLASS = byte[].class;
+  private static final ArrayAdapterInterface<byte[]> ADAPTER = new ByteArrayAdapter();
   private LruArrayPool pool;
 
   @Before
@@ -41,8 +45,8 @@ public class LruArrayPoolTest {
     pool.put(createArray(ARRAY_CLASS, size, value), ARRAY_CLASS);
     Object array = pool.get(size, ARRAY_CLASS);
     assertNotNull(array);
-    assertTrue(ADAPTER.getArrayLength(array) >= size);
     assertTrue(array.getClass() == ARRAY_CLASS);
+    assertTrue(ADAPTER.getArrayLength((byte[]) array) >= size);
     assertTrue(((byte[]) array)[0] == (byte) 0);
   }
 
@@ -97,7 +101,8 @@ public class LruArrayPoolTest {
     }
   }
 
-  private Object createArray(Class type, int size, int value) {
+  @SuppressWarnings("unchecked")
+  private static <T> T createArray(Class<T> type, int size, int value) {
     Object array = null;
     if (type.equals(int[].class)) {
       array = new int[size];
@@ -106,6 +111,6 @@ public class LruArrayPoolTest {
       array = new byte[size];
       Arrays.fill((byte[]) array, (byte) value);
     }
-    return array;
+    return (T) array;
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.load.engine.cache;
 
 import static com.bumptech.glide.load.engine.cache.MemoryCache.ResourceRemovedListener;
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.eq;
@@ -9,7 +10,9 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.annotation.TargetApi;
 import android.content.ComponentCallbacks2;
+import android.os.Build;
 
 import com.bumptech.glide.load.Key;
 import com.bumptech.glide.load.engine.Resource;
@@ -21,11 +24,12 @@ import org.junit.runners.JUnit4;
 import java.security.MessageDigest;
 
 @RunWith(JUnit4.class)
+@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class LruResourceCacheTest {
   private static class TrimClearMemoryCacheHarness {
     LruResourceCache resourceCache = new LruResourceCache(100);
-    Resource first = mock(Resource.class);
-    Resource second = mock(Resource.class);
+    Resource<?> first = mockResource();
+    Resource<?> second = mockResource();
 
     ResourceRemovedListener listener = mock(ResourceRemovedListener.class);
 
@@ -71,7 +75,7 @@ public class LruResourceCacheTest {
   @Test
   public void testResourceRemovedListenerIsNotifiedWhenResourceIsRemoved() {
     LruResourceCache resourceCache = new LruResourceCache(100);
-    Resource resource = mock(Resource.class);
+    Resource<?> resource = mockResource();
     when(resource.getSize()).thenReturn(200);
 
     ResourceRemovedListener listener = mock(ResourceRemovedListener.class);
@@ -85,17 +89,17 @@ public class LruResourceCacheTest {
   @Test
   public void testSizeIsBasedOnResource() {
     LruResourceCache resourceCache = new LruResourceCache(100);
-    Resource first = getResource(50);
+    Resource<?> first = getResource(50);
     MockKey firstKey = new MockKey();
     resourceCache.put(firstKey, first);
-    Resource second = getResource(50);
+    Resource<?> second = getResource(50);
     MockKey secondKey = new MockKey();
     resourceCache.put(secondKey, second);
 
     assertTrue(resourceCache.contains(firstKey));
     assertTrue(resourceCache.contains(secondKey));
 
-    Resource third = getResource(50);
+    Resource<?> third = getResource(50);
     MockKey thirdKey = new MockKey();
     resourceCache.put(thirdKey, third);
 
@@ -104,8 +108,8 @@ public class LruResourceCacheTest {
     assertTrue(resourceCache.contains(thirdKey));
   }
 
-  private Resource getResource(int size) {
-    Resource resource = mock(Resource.class);
+  private Resource<?> getResource(int size) {
+    Resource<?> resource = mockResource();
     when(resource.getSize()).thenReturn(size);
     return resource;
   }

--- a/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.prefill;
 
+import static com.bumptech.glide.tests.Util.anyResource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Matchers.any;
@@ -56,7 +57,7 @@ public class BitmapPreFillRunnerTest {
     doAnswer(new AddBitmapPoolAnswer(addedBitmaps)).when(pool).put(any(Bitmap.class));
     when(pool.getDirty(anyInt(), anyInt(), any(Bitmap.Config.class)))
         .thenAnswer(new CreateBitmap());
-    when(cache.put(any(Key.class), any(Resource.class)))
+    when(cache.put(any(Key.class), anyResource()))
         .thenAnswer(new AddBitmapCacheAnswer(addedBitmaps));
   }
 
@@ -207,7 +208,7 @@ public class BitmapPreFillRunnerTest {
 
     getHandler(allocationOrder).run();
 
-    verify(cache).put(any(Key.class), any(Resource.class));
+    verify(cache).put(any(Key.class), anyResource());
     verify(pool, never()).put(any(Bitmap.class));
     // TODO(b/20335397): This code was relying on Bitmap equality which Robolectric removed
     // assertThat(addedBitmaps).containsExactly(bitmap);
@@ -226,7 +227,7 @@ public class BitmapPreFillRunnerTest {
 
     getHandler(allocationOrder).run();
 
-    verify(cache, never()).put(any(Key.class), any(Resource.class));
+    verify(cache, never()).put(any(Key.class), anyResource());
     // TODO(b/20335397): This code was relying on Bitmap equality which Robolectric removed
     // verify(pool).put(eq(bitmap));
     // assertThat(addedBitmaps).containsExactly(bitmap);
@@ -245,7 +246,7 @@ public class BitmapPreFillRunnerTest {
 
     getHandler(allocationOrder).run();
 
-    verify(cache, never()).put(any(Key.class), any(Resource.class));
+    verify(cache, never()).put(any(Key.class), anyResource());
     // TODO(b/20335397): This code was relying on Bitmap equality which Robolectric removed
     //verify(pool).put(eq(bitmap));
     //assertThat(addedBitmaps).containsExactly(bitmap);

--- a/library/src/test/java/com/bumptech/glide/load/model/ByteArrayLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/model/ByteArrayLoaderTest.java
@@ -52,7 +52,7 @@ public class ByteArrayLoaderTest {
   }
 
   @Test
-  public void testFetcherRetrunsDataClassFromConverter() {
+  public void testFetcherReturnsDataClassFromConverter() {
     when(converter.getDataClass()).thenReturn(Object.class);
     assertEquals(Object.class,
         loader.buildLoadData(new byte[10], 10, 10, options).fetcher.getDataClass());

--- a/library/src/test/java/com/bumptech/glide/load/model/DataUrlLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/model/DataUrlLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
@@ -22,6 +23,7 @@ import org.robolectric.annotation.Config;
 
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.util.Arrays;
 
 /**
@@ -32,6 +34,7 @@ import java.util.Arrays;
 public class DataUrlLoaderTest {
 
   // A valid base64-encoded PNG (a small "Google" logo).
+  @SuppressWarnings("SpellCheckingInspection")
   private static final String VALID_PNG = "data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAALCA"
       + "YAAAAeEY8BAAADFElEQVR42mNgAAK5ig+CiiUfSmUL3mVL5r7PE8t5M1U06027eMYLMQZKQUMDE8eyxGrOJYmdDKtC"
       + "mTHkFfO/iCsUfTykUPFeASH6n1Es+3WjSM5rKQYqANbFcTmsC2OXYpWUKXw/R67ofQEhQ+5FecnfDnYxPJNmzAp35n"
@@ -50,13 +53,13 @@ public class DataUrlLoaderTest {
   private static final String INVALID_URL_WRONG_SCHEME1 = "test";
   private static final String INVALID_URL_WRONG_SCHEME2 = "http://google.com";
   private static final String INVALID_URL_WRONG_SCHEME3 = "data:text";
-  private static final String INVALID_URL_MISSING_COMMA = "data:image/png;base64=NOTBASE64";
+  private static final String INVALID_URL_MISSING_COMMA = "data:image/png;base64=NOT_BASE64";
   private static final String INVALID_URL_WRONG_ENCODING = "data:image/png;base32,";
 
   @Mock
   private MultiModelLoaderFactory multiFactory;
-  private DataUrlLoader<Object> dataUrlLoader;
-  private DataFetcher<Object> fetcher;
+  private DataUrlLoader<InputStream> dataUrlLoader;
+  private DataFetcher<InputStream> fetcher;
   private Options options;
 
   @Before
@@ -64,7 +67,7 @@ public class DataUrlLoaderTest {
     MockitoAnnotations.initMocks(this);
     DataUrlLoader.StreamFactory factory = new DataUrlLoader.StreamFactory();
     options = new Options();
-    dataUrlLoader = (DataUrlLoader) factory.build(multiFactory);
+    dataUrlLoader = (DataUrlLoader<InputStream>) factory.build(multiFactory);
     fetcher = dataUrlLoader.buildLoadData(VALID_PNG, -1, -1, options).fetcher;
 
   }
@@ -88,7 +91,7 @@ public class DataUrlLoaderTest {
     CallBack callback = new CallBack();
     fetcher.loadData(Priority.HIGH, callback);
     byte[] result = new byte[((ByteArrayInputStream) callback.data).available()];
-    ((ByteArrayInputStream) callback.data).read(result);
+    assertEquals(result.length, ((ByteArrayInputStream) callback.data).read(result));
     assertTrue(Arrays.equals(result, expected));
     assertNull(callback.exception);
   }

--- a/library/src/test/java/com/bumptech/glide/load/model/stream/BaseGlideUrlLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/model/stream/BaseGlideUrlLoaderTest.java
@@ -101,9 +101,9 @@ public class BaseGlideUrlLoaderTest {
     int width = 400;
     int height = 500;
 
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         GlideUrl glideUrl = (GlideUrl) invocationOnMock.getArguments()[3];
         assertEquals(urlLoader.resultUrl, glideUrl.toStringUrl());
         return null;

--- a/library/src/test/java/com/bumptech/glide/load/resource/SimpleResourceTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/SimpleResourceTest.java
@@ -10,12 +10,12 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class SimpleResourceTest {
   private Anything object;
-  private SimpleResource resource;
+  private SimpleResource<?> resource;
 
   @Before
   public void setUp() {
     object = new Anything();
-    resource = new SimpleResource(object);
+    resource = new SimpleResource<>(object);
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/load/resource/UnitTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/UnitTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -22,8 +23,8 @@ public class UnitTransformationTest {
 
   @Test
   public void testReturnsGivenResource() {
-    Resource resource = mock(Resource.class);
-    UnitTransformation transformation = UnitTransformation.get();
+    Resource<Object> resource = mockResource();
+    UnitTransformation<Object> transformation = UnitTransformation.get();
     assertEquals(resource, transformation.transform(resource, 10, 10));
   }
 
@@ -31,7 +32,7 @@ public class UnitTransformationTest {
   public void testEquals() throws NoSuchAlgorithmException {
     KeyAssertions.assertSame(UnitTransformation.get(), UnitTransformation.get());
 
-    Transformation<Object> other = mock(Transformation.class);
+    @SuppressWarnings("unchecked") Transformation<Object> other = mock(Transformation.class);
     doAnswer(new Util.WriteDigest("other")).when(other)
         .updateDiskCacheKey(any(MessageDigest.class));
     KeyAssertions.assertDifferent(UnitTransformation.get(), other);

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformationTest.java
@@ -60,7 +60,7 @@ public class BitmapDrawableTransformationTest {
   public void testReturnsOriginalResourceIfTransformationDoesNotTransform() {
     int outWidth = 123;
     int outHeight = 456;
-    when(wrapped.transform(any(Resource.class), eq(outWidth), eq(outHeight)))
+    when(wrapped.transform(Util.<Bitmap>anyResource(), eq(outWidth), eq(outHeight)))
         .thenAnswer(new Answer<Object>() {
           @Override
           public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -80,9 +80,9 @@ public class BitmapDrawableTransformationTest {
     int outHeight = 555;
 
     Bitmap transformedBitmap = Bitmap.createBitmap(outWidth, outHeight, Bitmap.Config.RGB_565);
-    Resource<Bitmap> transformedBitmapResource = mock(Resource.class);
+    Resource<Bitmap> transformedBitmapResource = Util.mockResource();
     when(transformedBitmapResource.get()).thenReturn(transformedBitmap);
-    when(wrapped.transform(any(Resource.class), eq(outWidth), eq(outHeight)))
+    when(wrapped.transform(Util.<Bitmap>anyResource(), eq(outWidth), eq(outHeight)))
         .thenReturn(transformedBitmapResource);
 
     Resource<BitmapDrawable> transformed =
@@ -95,14 +95,14 @@ public class BitmapDrawableTransformationTest {
   public void testProvidesBitmapFromGivenResourceToWrappedTransformation() {
     int outWidth = 332;
     int outHeight = 111;
-    Resource<Bitmap> transformed = mock(Resource.class);
+    Resource<Bitmap> transformed = Util.mockResource();
     when(transformed.get())
         .thenReturn(Bitmap.createBitmap(outWidth, outHeight, Bitmap.Config.ARGB_8888));
-    when(wrapped.transform(any(Resource.class), anyInt(), anyInt()))
+    when(wrapped.transform(Util.<Bitmap>anyResource(), anyInt(), anyInt()))
         .thenReturn(transformed);
 
     transformation.transform(drawableResourceToTransform, outWidth, outHeight);
-    ArgumentCaptor<Resource> captor = ArgumentCaptor.forClass(Resource.class);
+    ArgumentCaptor<Resource<Bitmap>> captor = Util.cast(ArgumentCaptor.forClass(Resource.class));
 
     verify(wrapped).transform(captor.capture(), eq(outWidth), eq(outHeight));
 
@@ -116,7 +116,7 @@ public class BitmapDrawableTransformationTest {
     KeyAssertions.assertSame(transformation,
         new BitmapDrawableTransformation(RuntimeEnvironment.application, bitmapPool, wrapped));
 
-    Transformation<Bitmap> other = mock(Transformation.class);
+    @SuppressWarnings("unchecked") Transformation<Bitmap> other = mock(Transformation.class);
     doAnswer(new Util.WriteDigest("other")).when(other)
         .updateDiskCacheKey(any(MessageDigest.class));
     KeyAssertions.assertDifferent(transformation,

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
@@ -1,12 +1,14 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.annotation.TargetApi;
 import android.graphics.Bitmap;
+import android.os.Build;
 
 import com.bumptech.glide.load.EncodeStrategy;
 import com.bumptech.glide.load.Options;
@@ -58,6 +60,7 @@ public class BitmapEncoderTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   public void testEncoderObeysNonNullCompressFormat() throws IOException {
     Bitmap.CompressFormat format = Bitmap.CompressFormat.WEBP;
     harness.setFormat(format);
@@ -68,6 +71,7 @@ public class BitmapEncoderTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
   public void testEncoderEncodesJpegWithNullFormatAndBitmapWithoutAlpha() throws IOException {
     harness.setFormat(null);
     harness.bitmap.setHasAlpha(false);
@@ -78,6 +82,7 @@ public class BitmapEncoderTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
   public void testEncoderEncodesPngWithNullFormatAndBitmapWithAlpha() throws IOException {
     harness.setFormat(null);
     harness.bitmap.setHasAlpha(true);
@@ -103,9 +108,8 @@ public class BitmapEncoderTest {
     assertThat(string).contains(expected);
   }
 
-  @SuppressWarnings("unchecked")
   private static class EncoderHarness {
-    Resource<Bitmap> resource = mock(Resource.class);
+    Resource<Bitmap> resource = mockResource();
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
     Options options = new Options();
     File file = new File(RuntimeEnvironment.application.getCacheDir(), "test");

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
@@ -3,7 +3,6 @@ package com.bumptech.glide.load.resource.bitmap;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import android.graphics.Bitmap;
@@ -12,6 +11,7 @@ import android.support.annotation.NonNull;
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.request.target.Target;
+import com.bumptech.glide.tests.Util;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -106,7 +106,7 @@ public class BitmapTransformationTest {
         return null;
       }
     };
-    transformation.transform(mock(Resource.class), -1, 100);
+    transformation.transform(mockResource(1, 1), -1, 100);
   }
 
   @Test(expected = IllegalArgumentException.class)
@@ -123,7 +123,7 @@ public class BitmapTransformationTest {
       }
 
     };
-    transformation.transform(mock(Resource.class), 100, -1);
+    transformation.transform(mockResource(1, 1), 100, -1);
   }
 
   @Test
@@ -166,10 +166,9 @@ public class BitmapTransformationTest {
     assertEquals(expectedHeight, transform.givenHeight);
   }
 
-  @SuppressWarnings("unchecked")
   private Resource<Bitmap> mockResource(int width, int height) {
     Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-    Resource<Bitmap> resource = mock(Resource.class);
+    Resource<Bitmap> resource = Util.mockResource();
     when(resource.get()).thenReturn(bitmap);
     return resource;
   }

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CircleCropTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CircleCropTest.java
@@ -11,6 +11,7 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import android.os.Build;
 
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.tests.Util;
@@ -88,7 +89,7 @@ public class CircleCropTest {
     }
   }
 
-  @TargetApi(12)
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR1)
   private Bitmap createBitmapWithRedCircle(int width, int height) {
     int minEdge = Math.min(width, height);
     float radius = minEdge / 2f;

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
@@ -543,6 +543,7 @@ public class GifDrawableTest {
 
   @Test
   public void testReturnsCurrentTransformationInGetFrameTransformation() {
+    @SuppressWarnings("unchecked")
     Transformation<Bitmap> newTransformation = mock(Transformation.class);
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
     drawable.setFrameTransformation(newTransformation, bitmap);

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -34,9 +35,8 @@ public class GifDrawableTransformationTest {
   @Mock Transformation<Bitmap> wrapped;
   @Mock BitmapPool bitmapPool;
 
-  GifDrawableTransformation transformation;
+  private GifDrawableTransformation transformation;
 
-  @SuppressWarnings("unchecked")
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
@@ -44,8 +44,9 @@ public class GifDrawableTransformationTest {
   }
 
   @Test
+  @SuppressWarnings("unchecked")
   public void testSetsTransformationAsFrameTransformation() {
-    Resource<GifDrawable> resource = mock(Resource.class);
+    Resource<GifDrawable> resource = mockResource();
     GifDrawable gifDrawable = mock(GifDrawable.class);
     Transformation<Bitmap> unitTransformation = UnitTransformation.get();
     when(gifDrawable.getFrameTransformation()).thenReturn(unitTransformation);
@@ -59,9 +60,10 @@ public class GifDrawableTransformationTest {
     final int width = 123;
     final int height = 456;
     Bitmap expectedBitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
-    Resource<Bitmap> expectedResource = mock(Resource.class);
+    Resource<Bitmap> expectedResource = mockResource();
     when(expectedResource.get()).thenReturn(expectedBitmap);
-    when(wrapped.transform(isA(Resource.class), anyInt(), anyInt())).thenReturn(expectedResource);
+    when(wrapped.transform(Util.<Bitmap>anyResource(), anyInt(), anyInt()))
+        .thenReturn(expectedResource);
 
     transformation.transform(resource, width, height);
 
@@ -74,7 +76,7 @@ public class GifDrawableTransformationTest {
         .updateDiskCacheKey(isA(MessageDigest.class));
     KeyAssertions.assertSame(transformation, new GifDrawableTransformation(wrapped, bitmapPool));
 
-    Transformation<Bitmap> other = mock(Transformation.class);
+    @SuppressWarnings("unchecked") Transformation<Bitmap> other = mock(Transformation.class);
     doAnswer(new Util.WriteDigest("other")).when(other)
         .updateDiskCacheKey(isA(MessageDigest.class));
     KeyAssertions.assertDifferent(transformation, new GifDrawableTransformation(other, bitmapPool));

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
@@ -125,7 +125,7 @@ public class GifFrameLoaderTest {
   public void testStartGetsNextFrameIfNotStartedAndWithNoLoadPending() {
     loader.subscribe(callback);
 
-    verify(requestBuilder).into(isA(Target.class));
+    verify(requestBuilder).into(aTarget());
   }
 
   @Test
@@ -135,7 +135,7 @@ public class GifFrameLoaderTest {
     InOrder order = inOrder(gifDecoder, requestBuilder);
     order.verify(gifDecoder).advance();
     order.verify(requestBuilder).apply(isA(BaseRequestOptions.class));
-    order.verify(requestBuilder).into(isA(Target.class));
+    order.verify(requestBuilder).into(aTarget());
   }
 
   @Test
@@ -158,14 +158,14 @@ public class GifFrameLoaderTest {
     loader.subscribe(callback);
     loader.subscribe(mock(FrameCallback.class));
 
-    verify(requestBuilder, times(1)).into(isA(Target.class));
+    verify(requestBuilder, times(1)).into(aTarget());
   }
 
   @Test
   public void testGetNextFrameDoesNotStartLoadIfLoaderIsNotRunning() {
     loader.onFrameReady(mock(DelayTarget.class));
 
-    verify(requestBuilder, never()).into(isA(Target.class));
+    verify(requestBuilder, never()).into(aTarget());
   }
 
   @Test
@@ -174,7 +174,7 @@ public class GifFrameLoaderTest {
     loader.unsubscribe(callback);
     loader.subscribe(callback);
 
-    verify(requestBuilder, times(1)).into(isA(Target.class));
+    verify(requestBuilder, times(1)).into(aTarget());
   }
 
   @Test
@@ -185,7 +185,7 @@ public class GifFrameLoaderTest {
     loader.onFrameReady(mock(DelayTarget.class));
     loader.subscribe(callback);
 
-    verify(requestBuilder, times(2)).into(isA(Target.class));
+    verify(requestBuilder, times(2)).into(aTarget());
   }
 
   @Test
@@ -193,7 +193,7 @@ public class GifFrameLoaderTest {
     loader.subscribe(callback);
     loader.onFrameReady(mock(DelayTarget.class));
 
-    verify(requestBuilder, times(2)).into(isA(Target.class));
+    verify(requestBuilder, times(2)).into(aTarget());
   }
 
   @Test
@@ -283,5 +283,10 @@ public class GifFrameLoaderTest {
     new EqualsTester().addEqualityGroup(new GifFrameLoader.FrameSignature(first),
         new GifFrameLoader.FrameSignature(first))
         .addEqualityGroup(new GifFrameLoader.FrameSignature()).testEquals();
+  }
+
+  @SuppressWarnings("unchecked")
+  private static Target<Bitmap> aTarget() {
+    return isA(Target.class);
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapBytesTranscoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapBytesTranscoderTest.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static com.google.common.truth.Truth.assertThat;
-import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -55,13 +55,12 @@ public class BitmapBytesTranscoderTest {
     verify(harness.bitmapResource).recycle();
   }
 
-  @SuppressWarnings("unchecked")
   private static class BitmapBytesTranscoderHarness {
     Bitmap.CompressFormat compressFormat = Bitmap.CompressFormat.JPEG;
     int quality = 100;
     final String description = "TestDescription";
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ALPHA_8);
-    Resource<Bitmap> bitmapResource = mock(Resource.class);
+    Resource<Bitmap> bitmapResource = mockResource();
 
     public BitmapBytesTranscoderHarness() {
       when(bitmapResource.get()).thenReturn(bitmap);

--- a/library/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapDrawableTranscoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapDrawableTranscoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,7 +32,7 @@ public class BitmapDrawableTranscoderTest {
   @Test
   public void testReturnsBitmapDrawableResourceContainingGivenBitmap() {
     Bitmap expected = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    Resource<Bitmap> resource = mock(Resource.class);
+    Resource<Bitmap> resource = mockResource();
     when(resource.get()).thenReturn(expected);
 
     Resource<BitmapDrawable> transcoded = transcoder.transcode(resource);

--- a/library/src/test/java/com/bumptech/glide/load/resource/transcode/GifDrawableBytesTranscoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/transcode/GifDrawableBytesTranscoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertArrayEquals;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -20,11 +21,10 @@ public class GifDrawableBytesTranscoderTest {
   private GifDrawable gifDrawable;
   private Resource<GifDrawable> resource;
 
-  @SuppressWarnings("unchecked")
   @Before
   public void setUp() {
     gifDrawable = mock(GifDrawable.class);
-    resource = mock(Resource.class);
+    resource = mockResource();
     when(resource.get()).thenReturn(gifDrawable);
     transcoder = new GifDrawableBytesTranscoder();
   }

--- a/library/src/test/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistryTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistryTest.java
@@ -27,7 +27,8 @@ public class TranscoderRegistryTest {
 
   @Test
   public void testCanRegisterAndRetrieveResourceTranscoder() {
-    ResourceTranscoder transcoder = mock(ResourceTranscoder.class);
+    @SuppressWarnings("unchecked")
+    ResourceTranscoder<File, String> transcoder = mock(ResourceTranscoder.class);
     factories.register(File.class, String.class, transcoder);
 
     assertEquals(transcoder, factories.get(File.class, String.class));

--- a/library/src/test/java/com/bumptech/glide/load/resource/transcode/UnitTranscoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/transcode/UnitTranscoderTest.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
-import static org.mockito.Mockito.mock;
 
 import com.bumptech.glide.load.engine.Resource;
 
@@ -14,7 +14,7 @@ public class UnitTranscoderTest {
 
   @Test
   public void testReturnsTheGivenResource() {
-    Resource resource = mock(Resource.class);
+    Resource<Object> resource = mockResource();
     ResourceTranscoder<Object, Object> unitTranscoder = UnitTranscoder.get();
 
     assertEquals(resource, unitTranscoder.transcode(resource));

--- a/library/src/test/java/com/bumptech/glide/manager/Issue117Activity.java
+++ b/library/src/test/java/com/bumptech/glide/manager/Issue117Activity.java
@@ -1,6 +1,10 @@
 package com.bumptech.glide.manager;
 
+import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
+
+import android.annotation.TargetApi;
 import android.content.Context;
+import android.os.Build;
 import android.os.Bundle;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -17,14 +21,14 @@ import com.bumptech.glide.Glide;
 /**
  * A test activity to reproduce Issue #117: https://github.com/bumptech/glide/issues/117.
  */
+@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 class Issue117Activity extends FragmentActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
     ViewPager viewPager = new ViewPager(this);
     viewPager.setId(View.generateViewId());
-    setContentView(viewPager, new ViewGroup.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-        ViewGroup.LayoutParams.MATCH_PARENT));
+    setContentView(viewPager, new ViewGroup.LayoutParams(MATCH_PARENT, MATCH_PARENT));
     viewPager.setAdapter(new Issue117Adapter(getSupportFragmentManager()));
   }
 

--- a/library/src/test/java/com/bumptech/glide/manager/RequestManagerFragmentTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/RequestManagerFragmentTest.java
@@ -7,7 +7,9 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
+import android.os.Build;
 import android.support.v4.app.FragmentActivity;
 
 import com.bumptech.glide.RequestManager;
@@ -23,6 +25,7 @@ import org.robolectric.util.ActivityController;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 18)
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class RequestManagerFragmentTest {
   private static final String TAG = "tag";
   private Harness[] harnesses;
@@ -167,7 +170,7 @@ public class RequestManagerFragmentTest {
 
     ActivityFragmentLifecycle getFragmentLifecycle();
 
-    ActivityController getController();
+    ActivityController<?> getController();
 
     void onLowMemory();
 
@@ -218,7 +221,7 @@ public class RequestManagerFragmentTest {
     }
 
     @Override
-    public ActivityController getController() {
+    public ActivityController<?> getController() {
       return controller;
     }
 
@@ -276,7 +279,7 @@ public class RequestManagerFragmentTest {
     }
 
     @Override
-    public ActivityController getController() {
+    public ActivityController<?> getController() {
       return supportController;
     }
 

--- a/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
@@ -9,6 +9,7 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
+import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
@@ -36,6 +37,7 @@ import org.robolectric.util.ActivityController;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 18, shadows = GlideShadowLooper.class)
+@TargetApi(Build.VERSION_CODES.HONEYCOMB)
 public class RequestManagerRetrieverTest {
   private static final String PARENT_TAG = "parent";
   private RetrieverHarness[] harnesses;
@@ -165,6 +167,7 @@ public class RequestManagerRetrieverTest {
     helpTestCanGetRequestManagerFromDetachedFragment();
   }
 
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
   private void helpTestCanGetRequestManagerFromDetachedFragment() {
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();
     android.app.Fragment fragment = new android.app.Fragment();
@@ -213,14 +216,14 @@ public class RequestManagerRetrieverTest {
 
   @Test(expected = IllegalArgumentException.class)
   public void testThrowsIfActivityDestroyed() {
-    DefaultRetrieverHarness harness = new DefaultRetrieverHarness();
+    RetrieverHarness harness = new DefaultRetrieverHarness();
     harness.getController().pause().stop().destroy();
     harness.doGet();
   }
 
   @Test(expected = IllegalArgumentException.class)
   public void testThrowsIfFragmentActivityDestroyed() {
-    SupportRetrieverHarness harness = new SupportRetrieverHarness();
+    RetrieverHarness harness = new SupportRetrieverHarness();
     harness.getController().pause().stop().destroy();
     harness.doGet();
   }
@@ -232,7 +235,7 @@ public class RequestManagerRetrieverTest {
 
   @Test
   public void testChecksIfContextIsFragmentActivity() {
-    SupportRetrieverHarness harness = new SupportRetrieverHarness();
+    RetrieverHarness harness = new SupportRetrieverHarness();
     RequestManager requestManager = harness.doGet();
 
     assertEquals(requestManager, retriever.get((Context) harness.getController().get()));
@@ -240,7 +243,7 @@ public class RequestManagerRetrieverTest {
 
   @Test
   public void testChecksIfContextIsActivity() {
-    DefaultRetrieverHarness harness = new DefaultRetrieverHarness();
+    RetrieverHarness harness = new DefaultRetrieverHarness();
     RequestManager requestManager = harness.doGet();
 
     assertEquals(requestManager, retriever.get((Context) harness.getController().get()));
@@ -248,9 +251,9 @@ public class RequestManagerRetrieverTest {
 
   @Test
   public void testHandlesContextWrappersForActivities() {
-    DefaultRetrieverHarness harness = new DefaultRetrieverHarness();
+    RetrieverHarness harness = new DefaultRetrieverHarness();
     RequestManager requestManager = harness.doGet();
-    ContextWrapper contextWrapper = new ContextWrapper((Context) harness.getController().get());
+    ContextWrapper contextWrapper = new ContextWrapper(harness.getController().get());
 
     assertEquals(requestManager, retriever.get(contextWrapper));
   }
@@ -316,6 +319,7 @@ public class RequestManagerRetrieverTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testDoesNotThrowIfAskedToGetManagerForActivityPreJellYBeanMr1() {
     Util.setSdkVersionInt(Build.VERSION_CODES.JELLY_BEAN);
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();
@@ -326,6 +330,7 @@ public class RequestManagerRetrieverTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
   public void testDoesNotThrowIfAskedToGetManagerForFragmentPreHoneyCombMr2() {
     Util.setSdkVersionInt(Build.VERSION_CODES.HONEYCOMB_MR1);
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();
@@ -339,6 +344,7 @@ public class RequestManagerRetrieverTest {
   }
 
   @Test
+  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testDoesNotThrowIfAskedToGetManagerForFragmentPreJellyBeanMr1() {
     Util.setSdkVersionInt(Build.VERSION_CODES.JELLY_BEAN);
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();
@@ -352,14 +358,13 @@ public class RequestManagerRetrieverTest {
   }
 
   private interface RetrieverHarness {
+    ActivityController<?> getController();
 
-    public ActivityController getController();
+    RequestManager doGet();
 
-    public RequestManager doGet();
+    boolean hasFragmentWithTag(String tag);
 
-    public boolean hasFragmentWithTag(String tag);
-
-    public void addFragmentWithTag(String tag, RequestManager manager);
+    void addFragmentWithTag(String tag, RequestManager manager);
   }
 
   public class DefaultRetrieverHarness implements RetrieverHarness {
@@ -378,7 +383,7 @@ public class RequestManagerRetrieverTest {
     }
 
     @Override
-    public ActivityController getController() {
+    public ActivityController<?> getController() {
       return controller;
     }
 
@@ -421,7 +426,7 @@ public class RequestManagerRetrieverTest {
     }
 
     @Override
-    public ActivityController getController() {
+    public ActivityController<?> getController() {
       return controller;
     }
 

--- a/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
@@ -218,9 +218,9 @@ public class RequestFutureTargetTest {
   @Test(expected = InterruptedException.class)
   public void testThrowsInterruptedExceptionIfThreadInterruptedWhenDoneWaiting()
       throws InterruptedException, ExecutionException {
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         Thread.currentThread().interrupt();
         return null;
       }
@@ -232,9 +232,9 @@ public class RequestFutureTargetTest {
   @Test(expected = ExecutionException.class)
   public void testThrowsExecutionExceptionIfLoadFailsWhileWaiting()
       throws ExecutionException, InterruptedException {
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         future.onLoadFailed(null);
         return null;
       }
@@ -245,9 +245,9 @@ public class RequestFutureTargetTest {
   @Test(expected = CancellationException.class)
   public void testThrowsCancellationExceptionIfCancelledWhileWaiting()
       throws ExecutionException, InterruptedException {
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         future.cancel(false);
         return null;
       }
@@ -297,9 +297,9 @@ public class RequestFutureTargetTest {
   public void testReturnsResourceIfReceivedWhileWaiting()
       throws ExecutionException, InterruptedException {
     final Object expected = new Object();
-    doAnswer(new Answer() {
+    doAnswer(new Answer<Void>() {
       @Override
-      public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
+      public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
         future.onResourceReady(expected, null);
         return null;
       }

--- a/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.request;
 
 import static com.bumptech.glide.tests.Util.isADataSource;
+import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -50,6 +51,7 @@ import java.util.Map;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 18)
+@SuppressWarnings("rawtypes")
 public class SingleRequestTest {
   private RequestHarness harness;
 
@@ -57,21 +59,23 @@ public class SingleRequestTest {
    * {@link Number} and {@link List} are arbitrarily chosen types to test some type safety as well.
    * Both are in the middle of the hierarchy having multiple descendants and ancestors.
    */
-  @SuppressWarnings("unchecked")
   private static class RequestHarness {
     Engine engine = mock(Engine.class);
     Number model = 123456;
+    @SuppressWarnings("unchecked")
     Target<List> target = mock(Target.class);
-    Resource<List> resource = mock(Resource.class);
+    Resource<List> resource = mockResource();
     RequestCoordinator requestCoordinator = mock(RequestCoordinator.class);
     Drawable placeholderDrawable = null;
     Drawable errorDrawable = null;
     Drawable fallbackDrawable = null;
+    @SuppressWarnings("unchecked")
     RequestListener<List> requestListener = mock(RequestListener.class);
+    @SuppressWarnings("unchecked")
     TransitionFactory<List> factory = mock(TransitionFactory.class);
     int overrideWidth = -1;
     int overrideHeight = -1;
-    List result = new ArrayList();
+    List<?> result = new ArrayList<>();
     GlideContext glideContext = mock(GlideContext.class);
     Key signature = mock(Key.class);
     Priority priority = Priority.HIGH;
@@ -743,6 +747,7 @@ public class SingleRequestTest {
             any(Options.class), anyBoolean(), eq(Boolean.FALSE), any(ResourceCallback.class));
   }
 
+  // TODO do we want to move these to Util?
   @SuppressWarnings("unchecked")
   private static <T> Transition<T> mockTransition() {
     return mock(Transition.class);

--- a/library/src/test/java/com/bumptech/glide/request/target/ImageViewTargetFactoryTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/ImageViewTargetFactoryTest.java
@@ -41,7 +41,7 @@ public class ImageViewTargetFactoryTest {
     BitmapDrawable drawable = new BitmapDrawable(RuntimeEnvironment.application.getResources(),
         Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_4444));
 
-    Target target = factory.buildTarget(view, BitmapDrawable.class);
+    Target<BitmapDrawable> target = factory.buildTarget(view, BitmapDrawable.class);
     target.onResourceReady(drawable, null);
     assertThat(target).isInstanceOf(DrawableImageViewTarget.class);
   }

--- a/library/src/test/java/com/bumptech/glide/request/target/ImageViewTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/ImageViewTargetTest.java
@@ -74,7 +74,7 @@ public class ImageViewTargetTest {
 
   @Test
   public void testSetsDrawableOnViewInOnResourceReadyWhenAnimationReturnsFalse() {
-    Transition<Drawable> animation = mock(Transition.class);
+    @SuppressWarnings("unchecked") Transition<Drawable> animation = mock(Transition.class);
     when(animation.transition(any(Drawable.class), eq(target))).thenReturn(false);
     Drawable resource = new ColorDrawable(Color.GRAY);
     target.onResourceReady(resource, animation);
@@ -85,7 +85,7 @@ public class ImageViewTargetTest {
   @Test
   public void testDoesNotSetDrawableOnViewInOnResourceReadyWhenAnimationReturnsTrue() {
     Drawable resource = new ColorDrawable(Color.RED);
-    Transition<Drawable> animation = mock(Transition.class);
+    @SuppressWarnings("unchecked") Transition<Drawable> animation = mock(Transition.class);
     when(animation.transition(eq(resource), eq(target))).thenReturn(true);
     target.onResourceReady(resource, animation);
 
@@ -97,7 +97,7 @@ public class ImageViewTargetTest {
     Drawable placeholder = new ColorDrawable(Color.BLACK);
     view.setImageDrawable(placeholder);
 
-    Transition<Drawable> animation = mock(Transition.class);
+    @SuppressWarnings("unchecked") Transition<Drawable> animation = mock(Transition.class);
 
     target.onResourceReady(new ColorDrawable(Color.GREEN), animation);
 

--- a/library/src/test/java/com/bumptech/glide/request/target/ViewTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/ViewTargetTest.java
@@ -44,7 +44,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
     ViewTargetTest.PreDrawShadowViewTreeObserver.class })
 public class ViewTargetTest {
   private View view;
-  private ViewTarget target;
+  private ViewTarget<View, Object> target;
   private SizedShadowView shadowView;
   private PreDrawShadowViewTreeObserver shadowObserver;
 
@@ -489,7 +489,7 @@ public class ViewTargetTest {
     }
 
     @Override
-    public void onResourceReady(Object resource, Transition transition) {
+    public void onResourceReady(Object resource, Transition<? super Object> transition) {
 
     }
 

--- a/library/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeFactoryTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeFactoryTest.java
@@ -25,7 +25,7 @@ public class DrawableCrossFadeFactoryTest {
   public void setUp() {
     ViewAnimationFactory<Drawable> viewAnimationFactory = mock(ViewAnimationFactory.class);
     factory = new DrawableCrossFadeFactory(viewAnimationFactory, 100 /*duration*/,
-        false /*isCrosFadeEnabled*/);
+        false /*isCrossFadeEnabled*/);
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/request/transition/ViewTransitionAnimationFactoryTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/transition/ViewTransitionAnimationFactoryTest.java
@@ -25,12 +25,12 @@ import org.robolectric.annotation.Config;
 @Config(manifest = Config.NONE)
 public class ViewTransitionAnimationFactoryTest {
   private ViewTransition.ViewTransitionAnimationFactory viewTransitionAnimationFactory;
-  private ViewAnimationFactory factory;
+  private ViewAnimationFactory<Object> factory;
 
   @Before
   public void setUp() {
     viewTransitionAnimationFactory = mock(ViewTransition.ViewTransitionAnimationFactory.class);
-    factory = new ViewAnimationFactory(viewTransitionAnimationFactory);
+    factory = new ViewAnimationFactory<>(viewTransitionAnimationFactory);
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/tests/Util.java
+++ b/library/src/test/java/com/bumptech/glide/tests/Util.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
+import static org.mockito.Mockito.mock;
 
 import android.graphics.Bitmap;
 import android.os.Build;
@@ -12,6 +13,7 @@ import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.data.DataFetcher;
 import com.bumptech.glide.load.engine.Resource;
 
+import org.mockito.ArgumentCaptor;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
 import org.robolectric.util.ReflectionHelpers;
@@ -27,16 +29,40 @@ import java.security.MessageDigest;
 // FIXME move to testutil module
 public class Util {
 
-  public static String getExpectedClassId(Class clazz) {
+  public static String getExpectedClassId(Class<?> clazz) {
     return clazz.getSimpleName() + "." + clazz.getPackage().getName();
+  }
+
+  /**
+   * Gives the proper generic type to the {@link ArgumentCaptor}.
+   * Only useful when the captor's {@code T} is also a generic type.
+   * Without this it's really ugly to have a properly typed captor object.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> ArgumentCaptor<T> cast(ArgumentCaptor<?> captor) {
+    return (ArgumentCaptor<T>) captor;
   }
 
   public static DataSource isADataSource() {
     return isA(DataSource.class);
   }
 
-  public static Resource<?> anyResource() {
+  /**
+   * Creates a Mockito argument matcher to be used in verify.
+   * It returns a generic typed {@link Resource} to prevent unchecked warnings.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Resource<T> anyResource() {
     return any(Resource.class);
+  }
+
+  /**
+   * Creates a Mockito mock object.
+   * It returns a generic typed {@link Resource} to prevent unchecked warnings.
+   */
+  @SuppressWarnings("unchecked")
+  public static <T> Resource<T> mockResource() {
+    return mock(Resource.class);
   }
 
   public static boolean isWindows() {

--- a/samples/flickr/build.gradle
+++ b/samples/flickr/build.gradle
@@ -17,11 +17,11 @@ android {
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.flickr'
-        minSdkVersion 11
+        minSdkVersion 11 // TODO it uses SearchView (and not the compat one)
         targetSdkVersion TARGET_SDK_VERSION as int
 
         versionCode 1
-        versionName '1.0.0'
+        versionName '1.0'
     }
 
     compileOptions {

--- a/samples/flickr/src/main/AndroidManifest.xml
+++ b/samples/flickr/src/main/AndroidManifest.xml
@@ -6,9 +6,6 @@
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
-    <uses-sdk android:minSdkVersion="10"
-      android:targetSdkVersion="22" />
-
     <application
         android:label="@string/app_name"
         android:icon="@android:drawable/sym_def_app_icon"

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoGrid.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoGrid.java
@@ -208,7 +208,7 @@ public class FlickrPhotoGrid extends Fragment implements PhotoViewer {
     }
 
     @Override
-    public RequestBuilder getPreloadRequestBuilder(Photo item) {
+    public RequestBuilder<Drawable> getPreloadRequestBuilder(Photo item) {
       return preloadRequest.load(item);
     }
   }

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoList.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrPhotoList.java
@@ -176,7 +176,7 @@ public class FlickrPhotoList extends Fragment implements PhotoViewer {
     }
 
     @Override
-    public RequestBuilder getPreloadRequestBuilder(Photo item) {
+    public RequestBuilder<Drawable> getPreloadRequestBuilder(Photo item) {
       return fullRequest.thumbnail(thumbRequest.load(item)).load(item);
     }
   }

--- a/samples/gallery/build.gradle
+++ b/samples/gallery/build.gradle
@@ -11,14 +11,14 @@ dependencies {
 
 android {
     compileSdkVersion COMPILE_SDK_VERSION as int
-    buildToolsVersion BUILD_TOOLS_VERSION
+    buildToolsVersion BUILD_TOOLS_VERSION as String
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.gallery'
         minSdkVersion MIN_SDK_VERSION as int
         targetSdkVersion TARGET_SDK_VERSION as int
         versionCode 1
-        versionName "1.0"
+        versionName '1.0'
     }
 
     compileOptions {

--- a/samples/gallery/src/main/AndroidManifest.xml
+++ b/samples/gallery/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
 
   <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
-  <uses-sdk
-        android:minSdkVersion="10"
-        android:targetSdkVersion="22" />
-
   <application
           android:label="@string/app_name"
           android:icon="@android:drawable/sym_def_app_icon"

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/RecyclerAdapter.java
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/RecyclerAdapter.java
@@ -29,7 +29,7 @@ import java.util.List;
 /**
  * Displays {@link com.bumptech.glide.samples.gallery.MediaStoreData} in a recycler view.
  */
-class RecyclerAdapter extends RecyclerView.Adapter
+class RecyclerAdapter extends RecyclerView.Adapter<RecyclerAdapter.ListViewHolder>
     implements ListPreloader.PreloadSizeProvider<MediaStoreData>,
     ListPreloader.PreloadModelProvider<MediaStoreData> {
 
@@ -47,13 +47,13 @@ class RecyclerAdapter extends RecyclerView.Adapter
 
     setHasStableIds(true);
 
-    screenWidth = getWidth(context);
+    screenWidth = getScreenWidth(context);
   }
 
   @Override
-  public RecyclerView.ViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
-    final View view = LayoutInflater.from(viewGroup.getContext())
-        .inflate(R.layout.recycler_item, viewGroup, false);
+  public ListViewHolder onCreateViewHolder(ViewGroup viewGroup, int viewType) {
+    LayoutInflater inflater = LayoutInflater.from(viewGroup.getContext());
+    final View view = inflater.inflate(R.layout.recycler_item, viewGroup, false);
     view.getLayoutParams().width = screenWidth;
 
     if (actualDimensions == null) {
@@ -73,10 +73,8 @@ class RecyclerAdapter extends RecyclerView.Adapter
   }
 
   @Override
-  public void onBindViewHolder(RecyclerView.ViewHolder viewHolder, int position) {
+  public void onBindViewHolder(ListViewHolder viewHolder, int position) {
     MediaStoreData current = data.get(position);
-
-    final ListViewHolder vh = (ListViewHolder) viewHolder;
 
     Key signature =
         new MediaStoreSignature(current.mimeType, current.dateModified, current.orientation);
@@ -85,7 +83,7 @@ class RecyclerAdapter extends RecyclerView.Adapter
         .clone()
         .apply(signatureOf(signature))
         .load(current.uri)
-        .into(vh.image);
+        .into(viewHolder.image);
   }
 
   @Override
@@ -109,7 +107,7 @@ class RecyclerAdapter extends RecyclerView.Adapter
   }
 
   @Override
-  public RequestBuilder getPreloadRequestBuilder(MediaStoreData item) {
+  public RequestBuilder<Drawable> getPreloadRequestBuilder(MediaStoreData item) {
     MediaStoreSignature signature =
         new MediaStoreSignature(item.mimeType, item.dateModified, item.orientation);
     return requestBuilder
@@ -126,7 +124,7 @@ class RecyclerAdapter extends RecyclerView.Adapter
   // Display#getSize(Point)
   @TargetApi(Build.VERSION_CODES.HONEYCOMB_MR2)
   @SuppressWarnings("deprecation")
-  private static int getWidth(Context context) {
+  private static int getScreenWidth(Context context) {
     WindowManager wm = (WindowManager) context.getSystemService(Context.WINDOW_SERVICE);
     Display display = wm.getDefaultDisplay();
 

--- a/samples/giphy/build.gradle
+++ b/samples/giphy/build.gradle
@@ -15,10 +15,10 @@ android {
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.giphy'
-        minSdkVersion 14
+        minSdkVersion 14 // TODO uses Holo.Light.DarkActionBar theme
         targetSdkVersion TARGET_SDK_VERSION as int
         versionCode 1
-        versionName '1.0.0'
+        versionName '1.0'
     }
 
     compileOptions {

--- a/samples/giphy/src/main/AndroidManifest.xml
+++ b/samples/giphy/src/main/AndroidManifest.xml
@@ -4,9 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <uses-sdk android:minSdkVersion="14"
-      android:targetSdkVersion="22" />
-
     <application
         android:allowBackup="true"
         android:icon="@android:drawable/sym_def_app_icon"

--- a/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/Api.java
+++ b/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/Api.java
@@ -26,7 +26,7 @@ public final class Api {
   private static final String TRENDING_PATH = "v1/gifs/trending";
   private final Handler bgHandler;
   private final Handler mainHandler;
-  private final HashSet<Monitor> monitors = new HashSet<Monitor>();
+  private final HashSet<Monitor> monitors = new HashSet<>();
 
   private static String signUrl(String url) {
     return url + "&api_key=" + BETA_KEY;
@@ -154,7 +154,7 @@ public final class Api {
    */
   public static class GifResult {
     public String id;
-    // Page url not gif url
+    // Page url not GIF url
     public String url;
     public GifUrlSet images;
 

--- a/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
+++ b/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
@@ -145,7 +145,7 @@ public class MainActivity extends Activity implements Api.Monitor {
     }
 
     @Override
-    public RequestBuilder getPreloadRequestBuilder(Api.GifResult item) {
+    public RequestBuilder<Drawable> getPreloadRequestBuilder(Api.GifResult item) {
       return requestBuilder.load(item);
     }
   }

--- a/samples/svg/src/main/AndroidManifest.xml
+++ b/samples/svg/src/main/AndroidManifest.xml
@@ -4,10 +4,6 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
 
-    <uses-sdk
-            android:minSdkVersion="10"
-            android:targetSdkVersion="22" />
-
     <application
         android:allowBackup="true"
         android:icon="@android:drawable/sym_def_app_icon"

--- a/testutil/src/main/java/com/bumptech/glide/testutil/TestResourceUtil.java
+++ b/testutil/src/main/java/com/bumptech/glide/testutil/TestResourceUtil.java
@@ -17,7 +17,7 @@ public final class TestResourceUtil {
    * @param subPath   The sub-path under androidTest/resources where the desired resource is
    *                  located. Should not be prefixed with a '/'
    */
-  public static InputStream openResource(Class testClass, String subPath) {
+  public static InputStream openResource(Class<?> testClass, String subPath) {
     return testClass.getResourceAsStream("/" + subPath);
   }
 }

--- a/testutil/src/main/java/com/bumptech/glide/testutil/TestUtil.java
+++ b/testutil/src/main/java/com/bumptech/glide/testutil/TestUtil.java
@@ -14,7 +14,7 @@ public final class TestUtil {
     // Utility class.
   }
 
-  public static byte[] resourceToBytes(Class testClass, String resourceName) throws IOException {
+  public static byte[] resourceToBytes(Class<?> testClass, String resourceName) throws IOException {
     return isToBytes(TestResourceUtil.openResource(testClass, resourceName));
   }
 
@@ -33,7 +33,7 @@ public final class TestUtil {
   }
 
   public static String isToString(InputStream is) throws IOException {
-    return new String(isToBytes(is));
+    return new String(isToBytes(is), "utf-8");
   }
 
   public static void assertStreamOf(String expected, InputStream result) throws IOException {

--- a/third_party/gif_decoder/gradle.properties
+++ b/third_party/gif_decoder/gradle.properties
@@ -1,4 +1,4 @@
-POM_NAME=Glide Gif Decoder Library
+POM_NAME=Glide GIF Decoder Library
 POM_ARTIFACT_ID=gifdecoder
 POM_PACKAGING=aar
 

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
@@ -1,32 +1,32 @@
 package com.bumptech.glide.gifdecoder;
 
 import android.graphics.Bitmap;
+import android.support.annotation.IntDef;
 import android.support.annotation.NonNull;
 
 import java.io.InputStream;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
 import java.nio.ByteBuffer;
 
 /**
  * Shared interface for GIF decoders.
  */
 public interface GifDecoder {
+  /** File read status: No errors. */
+  int STATUS_OK = 0;
+  /** File read status: Error decoding file (may be partially decoded). */
+  int STATUS_FORMAT_ERROR = 1;
+  /** File read status: Unable to open source. */
+  int STATUS_OPEN_ERROR = 2;
+  /** Unable to fully decode the current frame. */
+  int STATUS_PARTIAL_DECODE = 3;
 
-  /**
-   * File read status: No errors.
-   */
-  public static final int STATUS_OK = 0;
-  /**
-   * File read status: Error decoding file (may be partially decoded).
-   */
-  public static final int STATUS_FORMAT_ERROR = 1;
-  /**
-   * File read status: Unable to open source.
-   */
-  public static final int STATUS_OPEN_ERROR = 2;
-  /**
-   * Unable to fully decode the current frame.
-   */
-  public static final int STATUS_PARTIAL_DECODE = 3;
+  /** Android Lint annotation for status codes that can be used with a GIF decoder. */
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef(value = {STATUS_OK, STATUS_FORMAT_ERROR, STATUS_OPEN_ERROR, STATUS_PARTIAL_DECODE})
+  @interface GifDecodeStatus {
+  }
 
   /**
    * An interface that can be used to provide reused {@link android.graphics.Bitmap}s to avoid GCs
@@ -63,13 +63,11 @@ public interface GifDecoder {
 
     /**
      * Returns an int array used for decoding/generating the frame bitmaps.
-     * @param size
      */
     int[] obtainIntArray(int size);
 
     /**
      * Release the given array back to the pool.
-     * @param array
      */
     void release(int[] array);
   }
@@ -87,6 +85,7 @@ public interface GifDecoder {
    * was decoded successfully and/or completely. Format and open failures persist across frames.
    * </p>
    */
+  @GifDecodeStatus
   int getStatus();
 
   /**
@@ -153,6 +152,7 @@ public interface GifDecoder {
    * @param is containing GIF file.
    * @return read status code (0 = no errors).
    */
+  @GifDecodeStatus
   int read(InputStream is, int contentLength);
 
   void clear();
@@ -169,6 +169,7 @@ public interface GifDecoder {
    * @param data containing GIF file.
    * @return read status code (0 = no errors).
    */
+  @GifDecodeStatus
   int read(byte[] data);
 
 }

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifFrame.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifFrame.java
@@ -1,9 +1,58 @@
 package com.bumptech.glide.gifdecoder;
 
+import android.support.annotation.ColorInt;
+import android.support.annotation.IntDef;
+
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
 /**
  * Inner model class housing metadata for each frame.
+ *
+ * @see <a href="https://www.w3.org/Graphics/GIF/spec-gif89a.txt">GIF 89a Specification</a>
  */
 class GifFrame {
+  /**
+   * GIF Disposal Method meaning take no action.
+   * <p><b>GIF89a</b>: <i>No disposal specified.
+   * The decoder is not required to take any action.</i></p>
+   */
+  public static final int DISPOSAL_UNSPECIFIED = 0;
+  /**
+   * GIF Disposal Method meaning leave canvas from previous frame.
+   * <p><b>GIF89a</b>: <i>Do not dispose.
+   * The graphic is to be left in place.</i></p>
+   */
+  public static final int DISPOSAL_NONE = 1;
+  /**
+   * GIF Disposal Method meaning clear canvas to background color.
+   * <p><b>GIF89a</b>: <i>Restore to background color.
+   * The area used by the graphic must be restored to the background color.</i></p>
+   */
+  public static final int DISPOSAL_BACKGROUND = 2;
+  /**
+   * GIF Disposal Method meaning clear canvas to frame before last.
+   * <p><b>GIF89a</b>: <i>Restore to previous.
+   * The decoder is required to restore the area overwritten by the graphic
+   * with what was there prior to rendering the graphic.</i></p>
+   */
+  public static final int DISPOSAL_PREVIOUS = 3;
+
+  /**
+   * <p><b>GIF89a</b>:
+   * <i>Indicates the way in which the graphic is to be treated after being displayed.</i></p>
+   * Disposal methods 0-3 are defined, 4-7 are reserved for future use.
+   *
+   * @see #DISPOSAL_UNSPECIFIED
+   * @see #DISPOSAL_NONE
+   * @see #DISPOSAL_BACKGROUND
+   * @see #DISPOSAL_PREVIOUS
+   */
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef(value = {DISPOSAL_UNSPECIFIED, DISPOSAL_NONE, DISPOSAL_BACKGROUND, DISPOSAL_PREVIOUS})
+  @interface GifDisposalMethod {
+  }
+
   int ix, iy, iw, ih;
   /**
    * Control Flag.
@@ -16,13 +65,14 @@ class GifFrame {
   /**
    * Disposal Method.
    */
+  @GifDisposalMethod
   int dispose;
   /**
    * Transparency Index.
    */
   int transIndex;
   /**
-   * Delay, in ms, to next frame.
+   * Delay, in milliseconds, to next frame.
    */
   int delay;
   /**
@@ -32,5 +82,6 @@ class GifFrame {
   /**
    * Local Color Table.
    */
+  @ColorInt
   int[] lct;
 }

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.gifdecoder;
 
+import android.support.annotation.ColorInt;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -8,31 +10,39 @@ import java.util.List;
  * metadata like width and height that can be used to decode each individual frame of the GIF. Can
  * be shared by one or more {@link com.bumptech.glide.gifdecoder.GifDecoder}s to play the same
  * animated GIF in multiple views.
+ *
+ * @see <a href="https://www.w3.org/Graphics/GIF/spec-gif89a.txt">GIF 89a Specification</a>
  */
 public class GifHeader {
 
+  @ColorInt
   int[] gct = null;
+  @GifDecoder.GifDecodeStatus
   int status = GifDecoder.STATUS_OK;
   int frameCount = 0;
 
   GifFrame currentFrame;
-  List<GifFrame> frames = new ArrayList<GifFrame>();
-  // Logical screen size.
-  // Full image width.
+  List<GifFrame> frames = new ArrayList<>();
+  /** Logical screen size: Full image width. */
   int width;
-  // Full image height.
+  /** Logical screen size: Full image height. */
   int height;
 
   // 1 : global color table flag.
   boolean gctFlag;
-  // 2-4 : color resolution.
-  // 5 : gct sort flag.
-  // 6-8 : gct size.
+  /**
+   * Size of Global Color Table.
+   * The value is already computed to be a regular number, this field doesn't store the exponent.
+   */
   int gctSize;
-  // Background color index.
+  /** Background color index into the Global/Local color table. */
   int bgIndex;
-  // Pixel aspect ratio.
+  /**
+   * Pixel aspect ratio.
+   * Factor used to compute an approximation of the aspect ratio of the pixel in the original image.
+   */
   int pixelAspect;
+  @ColorInt
   int bgColor;
   int loopCount;
 
@@ -51,6 +61,7 @@ public class GifHeader {
   /**
    * Global status code of GIF data parsing.
    */
+  @GifDecoder.GifDecodeStatus
   public int getStatus() {
     return status;
   }

--- a/third_party/gif_encoder/README.third_party
+++ b/third_party/gif_encoder/README.third_party
@@ -4,7 +4,7 @@ License: Notice
 License File: LICENSE
 
 Description:
-Android port of a gif encoder.
+Android port of a GIF encoder.
 
 See also:
 http://members.ozemail.com.au/~dekker/NEUQUANT.HTML

--- a/third_party/gif_encoder/src/main/java/com/bumptech/glide/gifencoder/AnimatedGifEncoder.java
+++ b/third_party/gif_encoder/src/main/java/com/bumptech/glide/gifencoder/AnimatedGifEncoder.java
@@ -191,7 +191,7 @@ public class AnimatedGifEncoder {
             getImagePixels(); // convert to correct format if necessary
             analyzePixels(); // build color table & map pixels
             if (firstFrame) {
-                writeLSD(); // logical screen descriptior
+                writeLSD(); // logical screen descriptor
                 writePalette(); // global color table
                 if (repeat >= 0) {
                     // use NS app extension to indicate reps
@@ -222,7 +222,7 @@ public class AnimatedGifEncoder {
         boolean ok = true;
         started = false;
         try {
-            out.write(0x3b); // gif trailer
+            out.write(0x3b); // GIF trailer
             out.flush();
             if (closeStream) {
                 out.close();


### PR DESCRIPTION
## Description
Mostly javac/LINT/gradle/IDEA warnings, typos, and consistency fixes.

Detailed Global changes:
 * Fix some JavaDoc formatting issues (e.g. broken links)
 * Fix some JavaDoc build issues (inner class ctor links were broken)
 * Fix mis-typed words that caused grammatical issues
 * Fix Gradle deprecation warning during build
 * Make samples' build.gradle files more similar
 * Remove redundant <uses-sdk> from manifest

Mostly test related classes:
 * Add some generic arguments where missing
 * Add @TargetApi annotations to test code to suppress LINTs
 * Reduce the scope of suppressions or remove them completely
 * Use some specialized mocking/matching methods to reduce uncheckedness

GIF related classes:
 * Reduce number of magic constants, name them
 * Add some documentation from the standard for the constants
 * Remove some meaningless comments
 * Convert most inline comments to JavaDocs
 * Add annotations for ints designating color/status/etc (int is too overloaded)

There's an outstanding change in sjudd/disklrucache#4 to be fully warning free during build.

## Motivation and Context
I have a little OCD when it comes to warnings... they, must, go!
Everything should be trivial changes only, and most of them are in tests.