### PR TITLE
Prevent leaking activities due to a call without context

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/BitmapImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/BitmapImageViewTarget.java
@@ -20,6 +20,9 @@ public class BitmapImageViewTarget extends ImageViewTarget<Bitmap> {
    */
   @Override
   protected void setResource(Bitmap resource) {
-    view.setImageBitmap(resource);
+    ImageView view = viewReference.get();
+    if (view != null) {
+      view.setImageBitmap(resource);
+    }
   }
 }

--- a/library/src/main/java/com/bumptech/glide/request/target/BitmapThumbnailImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/BitmapThumbnailImageViewTarget.java
@@ -15,6 +15,7 @@ public class BitmapThumbnailImageViewTarget extends ThumbnailImageViewTarget<Bit
 
   @Override
   protected Drawable getDrawable(Bitmap resource) {
-    return new BitmapDrawable(view.getResources(), resource);
+    ImageView view = viewReference.get();
+    return view != null ? new BitmapDrawable(view.getResources(), resource) : null;
   }
 }

--- a/library/src/main/java/com/bumptech/glide/request/target/DrawableImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/DrawableImageViewTarget.java
@@ -15,6 +15,9 @@ public class DrawableImageViewTarget extends ImageViewTarget<Drawable> {
 
   @Override
   protected void setResource(@Nullable Drawable resource) {
-    view.setImageDrawable(resource);
+    ImageView view = viewReference.get();
+    if (view != null) {
+      view.setImageDrawable(resource);
+    }
   }
 }

--- a/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
@@ -30,7 +30,8 @@ public abstract class ImageViewTarget<Z> extends ViewTarget<ImageView, Z>
   @Override
   @Nullable
   public Drawable getCurrentDrawable() {
-    return view.getDrawable();
+    ImageView view = viewReference.get();
+    return view != null ? view.getDrawable() : null;
   }
 
   /**
@@ -41,7 +42,10 @@ public abstract class ImageViewTarget<Z> extends ViewTarget<ImageView, Z>
    */
   @Override
   public void setDrawable(Drawable drawable) {
-    view.setImageDrawable(drawable);
+    ImageView view = viewReference.get();
+    if (view != null) {
+      view.setImageDrawable(drawable);
+    }
   }
 
   /**

--- a/library/src/main/java/com/bumptech/glide/request/target/ThumbnailImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ThumbnailImageViewTarget.java
@@ -28,6 +28,11 @@ public abstract class ThumbnailImageViewTarget<T> extends ImageViewTarget<T> {
 
   @Override
   protected void setResource(@Nullable T resource) {
+    ImageView view = viewReference.get();
+    if (view == null) {
+      return;
+    }
+
     ViewGroup.LayoutParams layoutParams = view.getLayoutParams();
     Drawable result = getDrawable(resource);
     if (layoutParams != null && layoutParams.width > 0 && layoutParams.height > 0) {

--- a/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
@@ -44,11 +44,11 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
   private static boolean isTagUsedAtLeastOnce = false;
   @Nullable private static Integer tagId = null;
 
-  protected final T view;
+  protected final WeakReference<T> viewReference;
   private final SizeDeterminer sizeDeterminer;
 
   public ViewTarget(T view) {
-    this.view = Preconditions.checkNotNull(view);
+    this.viewReference = new WeakReference<T>(Preconditions.checkNotNull(view));
     sizeDeterminer = new SizeDeterminer(view);
   }
 
@@ -56,7 +56,7 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
    * Returns the wrapped {@link android.view.View}.
    */
   public T getView() {
-    return view;
+    return viewReference.get();
   }
 
   /**
@@ -118,10 +118,20 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
 
   @Override
   public String toString() {
-    return "Target for: " + view;
+    View view = viewReference.get();
+    if (view == null) {
+      return "Target for an already destroyed view.";
+    } else {
+      return "Target for: " + view;
+    }
   }
 
   private void setTag(@Nullable Object tag) {
+    View view = viewReference.get();
+    if (view == null) {
+      return;
+    }
+
     if (tagId == null) {
       isTagUsedAtLeastOnce = true;
       view.setTag(tag);
@@ -132,6 +142,10 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
 
   @Nullable
   private Object getTag() {
+    View view = viewReference.get();
+    if (view == null) {
+      return null;
+    }
     if (tagId == null) {
       return view.getTag();
     } else {

--- a/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
+++ b/library/src/main/java/com/bumptech/glide/request/transition/BitmapContainerTransitionFactory.java
@@ -4,6 +4,8 @@ import android.content.res.Resources;
 import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
+import android.view.View;
+
 import com.bumptech.glide.load.DataSource;
 
 /**
@@ -46,9 +48,14 @@ public abstract class BitmapContainerTransitionFactory<R> implements TransitionF
 
     @Override
     public boolean transition(R current, ViewAdapter adapter) {
-      Resources resources = adapter.getView().getResources();
-      Drawable currentBitmap = new BitmapDrawable(resources, getBitmap(current));
-      return transition.transition(currentBitmap, adapter);
+      View view = adapter.getView();
+      if (view == null) {
+        return false;
+      } else {
+        Resources resources = adapter.getView().getResources();
+        Drawable currentBitmap = new BitmapDrawable(resources, getBitmap(current));
+        return transition.transition(currentBitmap, adapter);
+      }
     }
   }
 }

--- a/library/src/main/java/com/bumptech/glide/request/transition/Transition.java
+++ b/library/src/main/java/com/bumptech/glide/request/transition/Transition.java
@@ -25,6 +25,7 @@ public interface Transition<R> {
     /**
      * Returns the wrapped {@link android.view.View}.
      */
+    @Nullable
     View getView();
 
     /**


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
We detect some memory leaks due to the ViewTarget being leaking the target view. If glide is called without a context, this ViewTarget is never cancelled and bad things happens. This is a change to prevent that to happen.

## Motivation and Context
Due to a bad use of the library or because of architecture restrictions, you may be calling Glide with a ViewTarget but without any activity or fragment context, so your view could be leaked and with it, the fragment and the activity that contains it. With this change, making ViewTarget to handle the view as a WeakReference, prevent it from doing any kind of leak, no matter how the library is used.
