### PR TITLE
return the old MemoryCategory used by Glide.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -96,6 +96,7 @@ public class Glide implements ComponentCallbacks2 {
   private final ArrayPool arrayPool;
   private final ConnectivityMonitorFactory connectivityMonitorFactory;
   private final List<RequestManager> managers = new ArrayList<>();
+  private MemoryCategory memoryCategory = MemoryCategory.NORMAL;
 
   /**
    * Returns a directory with a default name in the private cache directory of the application to
@@ -393,13 +394,18 @@ public class Glide implements ComponentCallbacks2 {
    * used to temporarily increase or decrease memory usage for a single Activity or part of the app.
    * Use {@link GlideBuilder#setMemoryCache(MemoryCache)} to put a permanent memory size if you want
    * to change the default. </p>
+   *
+   * @return the previous MemoryCategory used by Glide.
    */
-  public void setMemoryCategory(MemoryCategory memoryCategory) {
+  public MemoryCategory setMemoryCategory(MemoryCategory memoryCategory) {
     // Engine asserts this anyway when removing resources, fail faster and consistently
     Util.assertMainThread();
     // memory cache needs to be trimmed before bitmap pool to trim re-pooled Bitmaps too. See #687.
     memoryCache.setSizeMultiplier(memoryCategory.getMultiplier());
     bitmapPool.setSizeMultiplier(memoryCategory.getMultiplier());
+    MemoryCategory oldCategory = this.memoryCategory;
+    this.memoryCategory = memoryCategory;
+    return oldCategory;
   }
 
   /**


### PR DESCRIPTION
## Description
return the previous `MemoryCategory` used by Glide when setting a new one.

## Motivation and Context
If the app enters a section of the app that would benefit from a boost of Glide's memory, the developer has the option to boost the memory used by Glide.
However there is no way currently to know what was the current `MemoryCategory` used by Glide before entering that high memory usage portion of the app, which makes it impossible to restore the `MemoryCategory` once that portion of the app is done.

Example  I have an image picker RecyclerView activity. I would like to boost Glide's memory in onCreate but I can't restore it to the previous value in the onDestroy of the activity.

