### PR TITLE
Fixes #1464

### DIFF
--- a/third_party/gif_decoder/build.gradle
+++ b/third_party/gif_decoder/build.gradle
@@ -21,4 +21,4 @@ android {
     }
 }
 
-//apply from: "${rootProject.projectDir}/scripts/upload.gradle"
+apply from: "${rootProject.projectDir}/scripts/upload.gradle"


### PR DESCRIPTION
## Description
Not sure why that line was commented out. I removed the comment and everything built fine with:
```bash
gradlew clean buildArchives uploadArchives -PSNAPSHOT_REPOSITORY_URL=file://p:\projects\contrib\github-glide-m2 -PRELEASE_REPOSITORY_URL=file://p:\projects\contrib\github-glide-m2
```
I also checked the poms (gifdecoder and glide modules) and they look ok:
```xml
    <dependency>
      <groupId>com.github.bumptech.glide</groupId>
      <artifactId>gifdecoder</artifactId>
      <version>1.0.0-SNAPSHOT</version>
      <scope>compile</scope>
    </dependency>
```

## Motivation and Context
v4 snapshot users had their build broken this morning, see #1464