### PR TITLE
[WIP] Added PositionedCrop Feature as requested in #382

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
@@ -1,9 +1,7 @@
 package com.bumptech.glide.load.resource.bitmap;
 
 import android.content.Context;
-
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
-
 import java.security.MessageDigest;
 
 /**
@@ -18,16 +16,16 @@ public class CenterCrop extends PositionedCrop {
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
   public CenterCrop(Context context) {
-    super(context, 0.5f, 0.5f);
+    super(context, PositionedCrop.CENTER, PositionedCrop.CENTER);
   }
 
   public CenterCrop(BitmapPool bitmapPool) {
-    super(bitmapPool, 0.5f, 0.5f);
+    super(bitmapPool, PositionedCrop.CENTER, PositionedCrop.CENTER);
   }
 
   @Override
   public boolean equals(Object o) {
-    return o instanceof CenterCrop;
+    return o != null && getClass() == o.getClass();
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
@@ -1,9 +1,9 @@
 package com.bumptech.glide.load.resource.bitmap;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.support.annotation.NonNull;
+
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+
 import java.security.MessageDigest;
 
 /**
@@ -13,24 +13,16 @@ import java.security.MessageDigest;
  *
  * Does not maintain the image's aspect ratio
  */
-public class CenterCrop extends BitmapTransformation {
+public class CenterCrop extends PositionedCrop {
   private static final String ID = "com.bumptech.glide.load.resource.bitmap.CenterCrop";
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
   public CenterCrop(Context context) {
-    super(context);
+    super(context, 0.5f, 0.5f);
   }
 
   public CenterCrop(BitmapPool bitmapPool) {
-    super(bitmapPool);
-  }
-
-  // Bitmap doesn't implement equals, so == and .equals are equivalent here.
-  @SuppressWarnings("PMD.CompareObjectsWithEquals")
-  @Override
-  protected Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth,
-      int outHeight) {
-    return TransformationUtils.centerCrop(pool, toTransform, outWidth, outHeight);
+    super(bitmapPool, 0.5f, 0.5f);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/PositionedCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/PositionedCrop.java
@@ -1,0 +1,80 @@
+package com.bumptech.glide.load.resource.bitmap;
+
+import static android.os.Build.ID;
+
+import android.content.Context;
+import android.graphics.Bitmap;
+import android.support.annotation.FloatRange;
+
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+
+import java.security.MessageDigest;
+
+/**
+ * Scale the image so that either the width of the image matches the given width and the height of
+ * the image is greater than the given height or vice versa, and then crop the larger dimension to
+ * match the given dimension.
+ *
+ * Using percentages the crop area can be adjusted
+ *
+ * Example usage:
+ *
+ * Crop top-left: new PositionedCrop(context, 0, 0);
+ *
+ * Crop top-right: new PositionedCrop(context, 0, 1);
+ *
+ * Crop bottom-right: new PositionedCrop(context, 1, 1);
+ *
+ * Crop top-center: new PositionedCrop(context, 0,5f, 0);
+ *
+ * Does not maintain the image's aspect ratio
+ */
+public class PositionedCrop extends BitmapTransformation {
+  private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
+
+  private float xPercentage = 0.5f;
+  private float yPercentage = 0.5f;
+
+  public PositionedCrop(Context context, @FloatRange(from = 0.0, to = 1.0) float xPercentage, @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
+    super(context);
+    this.xPercentage = xPercentage;
+    this.yPercentage = yPercentage;
+  }
+
+  public PositionedCrop(BitmapPool bitmapPool, @FloatRange(from = 0.0, to = 1.0) float xPercentage, @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
+    super(bitmapPool);
+    this.xPercentage = xPercentage;
+    this.yPercentage = yPercentage;
+  }
+
+  // Bitmap doesn't implement equals, so == and .equals are equivalent here.
+  @SuppressWarnings("PMD.CompareObjectsWithEquals")
+  @Override
+  protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
+
+    return TransformationUtils.cropPosition(pool, toTransform, outWidth, outHeight, xPercentage, yPercentage);
+  }
+
+  public String getId() {
+    return "PositionedCrop.com.bumptech.glide.load.resource.bitmap.x:" + xPercentage + ".y:" + yPercentage;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof PositionedCrop) {
+      return ((PositionedCrop) o).xPercentage == xPercentage && ((PositionedCrop) o).yPercentage == yPercentage;
+    } else {
+      return false;
+    }
+  }
+
+  @Override
+  public int hashCode() {
+    return getId().hashCode();
+  }
+
+  @Override
+  public void updateDiskCacheKey(MessageDigest messageDigest) {
+    messageDigest.update(ID_BYTES);
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/PositionedCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/PositionedCrop.java
@@ -1,13 +1,9 @@
 package com.bumptech.glide.load.resource.bitmap;
 
-import static android.os.Build.ID;
-
 import android.content.Context;
 import android.graphics.Bitmap;
 import android.support.annotation.FloatRange;
-
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
-
 import java.security.MessageDigest;
 
 /**
@@ -30,39 +26,46 @@ import java.security.MessageDigest;
  * Does not maintain the image's aspect ratio
  */
 public class PositionedCrop extends BitmapTransformation {
-  private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
-  private float xPercentage = 0.5f;
-  private float yPercentage = 0.5f;
+  public static final float START = 0;
+  public static final float CENTER = 0.5f;
+  public static final float END = 1;
 
-  public PositionedCrop(Context context, @FloatRange(from = 0.0, to = 1.0) float xPercentage, @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
+  private final float xPercentage;
+  private final float yPercentage;
+
+  public PositionedCrop(Context context, @FloatRange(from = 0.0, to = 1.0) float xPercentage,
+      @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
     super(context);
     this.xPercentage = xPercentage;
     this.yPercentage = yPercentage;
   }
 
-  public PositionedCrop(BitmapPool bitmapPool, @FloatRange(from = 0.0, to = 1.0) float xPercentage, @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
+  public PositionedCrop(BitmapPool bitmapPool, @FloatRange(from = 0.0, to = 1.0) float xPercentage,
+      @FloatRange(from = 0.0, to = 1.0) float yPercentage) {
     super(bitmapPool);
     this.xPercentage = xPercentage;
     this.yPercentage = yPercentage;
   }
 
   // Bitmap doesn't implement equals, so == and .equals are equivalent here.
-  @SuppressWarnings("PMD.CompareObjectsWithEquals")
   @Override
   protected Bitmap transform(BitmapPool pool, Bitmap toTransform, int outWidth, int outHeight) {
 
-    return TransformationUtils.cropPosition(pool, toTransform, outWidth, outHeight, xPercentage, yPercentage);
+    return TransformationUtils.cropPosition(pool, toTransform, outWidth, outHeight, xPercentage,
+        yPercentage);
   }
 
   public String getId() {
-    return "PositionedCrop.com.bumptech.glide.load.resource.bitmap.x:" + xPercentage + ".y:" + yPercentage;
+    return "PositionedCrop.com.bumptech.glide.load.resource.bitmap(x=" + xPercentage + ",y="
+        + yPercentage + ")";
   }
 
   @Override
   public boolean equals(Object o) {
     if (o instanceof PositionedCrop) {
-      return ((PositionedCrop) o).xPercentage == xPercentage && ((PositionedCrop) o).yPercentage == yPercentage;
+      return ((PositionedCrop) o).xPercentage == xPercentage && ((PositionedCrop) o).yPercentage
+          == yPercentage;
     } else {
       return false;
     }
@@ -75,6 +78,6 @@ public class PositionedCrop extends BitmapTransformation {
 
   @Override
   public void updateDiskCacheKey(MessageDigest messageDigest) {
-    messageDigest.update(ID_BYTES);
+    messageDigest.update(getId().getBytes(CHARSET));
   }
 }

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterCropTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterCropTest.java
@@ -10,7 +10,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-
 import android.graphics.Bitmap;
 import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/PositionedCropTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/PositionedCropTest.java
@@ -1,0 +1,149 @@
+package com.bumptech.glide.load.resource.bitmap;
+
+import static org.junit.Assert.assertEquals;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyInt;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Matchers.isNull;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.reset;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import android.graphics.Bitmap;
+import com.bumptech.glide.load.Transformation;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.tests.KeyAssertions;
+import com.bumptech.glide.tests.Util;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 18)
+public class PositionedCropTest {
+  @Mock Resource<Bitmap> resource;
+  @Mock BitmapPool pool;
+  @Mock Transformation<Bitmap> transformation;
+
+  private int bitmapWidth;
+  private int bitmapHeight;
+  private Bitmap bitmap;
+
+  @Before
+  public void setUp() {
+    MockitoAnnotations.initMocks(this);
+    bitmapWidth = 100;
+    bitmapHeight = 100;
+    bitmap = Bitmap.createBitmap(bitmapWidth, bitmapHeight, Bitmap.Config.ARGB_8888);
+    when(resource.get()).thenReturn(bitmap);
+
+    when(pool.get(anyInt(), anyInt(), any(Bitmap.Config.class)))
+        .thenAnswer(new Util.CreateBitmap());
+
+  }
+
+  @Test
+  public void testDoesNotPutNullBitmapAcquiredFromPool() {
+    reset(pool);
+    when(pool.get(anyInt(), anyInt(), any(Bitmap.Config.class))).thenReturn(null);
+
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    positionedCrop.transform(resource, 100, 100);
+
+    verify(pool, never()).put(any(Bitmap.class));
+  }
+
+  @Test
+  public void testReturnsGivenResourceIfMatchesSizeExactly() {
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    Resource<Bitmap> result =
+        positionedCrop.transform(resource, bitmapWidth, bitmapHeight);
+
+    assertEquals(resource, result);
+  }
+
+  @Test
+  public void testDoesNotRecycleGivenResourceIfMatchesSizeExactly() {
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    positionedCrop.transform(resource, bitmapWidth, bitmapHeight);
+
+    verify(resource, never()).recycle();
+  }
+
+  @Test
+  public void testDoesNotRecycleGivenResource() {
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    positionedCrop.transform(resource, 50, 50);
+
+    verify(resource, never()).recycle();
+  }
+
+  @Test
+  public void testAsksBitmapPoolForArgb8888IfInConfigIsNull() {
+    Shadows.shadowOf(bitmap).setConfig(null);
+
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    positionedCrop.transform(resource, 10, 10);
+
+    verify(pool).get(anyInt(), anyInt(), eq(Bitmap.Config.ARGB_8888));
+    verify(pool, never()).get(anyInt(), anyInt(), (Bitmap.Config) isNull());
+  }
+
+  @Test
+  public void testReturnsBitmapWithExactlyGivenDimensionsIfBitmapIsLargerThanTarget() {
+    int expectedWidth = 75;
+    int expectedHeight = 74;
+
+    for (int[] dimens : new int[][] { new int[] { 800, 200 }, new int[] { 450, 100 },
+        new int[] { 78, 78 } }) {
+      Bitmap toTransform = Bitmap.createBitmap(dimens[0], dimens[1], Bitmap.Config.ARGB_4444);
+      when(resource.get()).thenReturn(toTransform);
+
+      PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+      Resource<Bitmap> result =
+          positionedCrop.transform(resource, expectedWidth, expectedHeight);
+      Bitmap transformed = result.get();
+      assertEquals(expectedWidth, transformed.getWidth());
+      assertEquals(expectedHeight, transformed.getHeight());
+    }
+  }
+
+  @Test
+  public void testReturnsBitmapWithExactlyGivenDimensionsIfBitmapIsSmallerThanTarget() {
+    int expectedWidth = 100;
+    int expectedHeight = 100;
+
+    for (int[] dimens : new int[][] { new int[] { 50, 90 }, new int[] { 150, 2 },
+        new int[] { 78, 78 } }) {
+      Bitmap toTransform = Bitmap.createBitmap(dimens[0], dimens[1], Bitmap.Config.ARGB_4444);
+      when(resource.get()).thenReturn(toTransform);
+
+      PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+      Resource<Bitmap> result =
+          positionedCrop.transform(resource, expectedWidth, expectedHeight);
+      Bitmap transformed = result.get();
+      assertEquals(expectedWidth, transformed.getWidth());
+      assertEquals(expectedHeight, transformed.getHeight());
+    }
+  }
+
+  @Test
+  public void testEquals() throws NoSuchAlgorithmException {
+    PositionedCrop positionedCrop = new PositionedCrop(pool, 0, 0);
+    KeyAssertions.assertSame(positionedCrop, new PositionedCrop(pool, 0, 0));
+
+    doAnswer(new Util.WriteDigest("other")).when(transformation)
+        .updateDiskCacheKey(any(MessageDigest.class));
+    KeyAssertions.assertDifferent(positionedCrop, transformation);
+  }
+}


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->

<!-- Don't forget that you can always force push to your private branches to make changes. -->

<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->

<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->
## Description

<!-- Please describe the changes you made on a high level. -->

<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

This adds the feature requested in requested in #382 
CenterCrop now inherits from PositionedCrop.
## Motivation and Context

<!-- Why is this change required? What problem does it solve? -->

<!-- If it's fixing a bug reference it or provide repro steps. -->

The ability to position the crop area in addition to the CenterCrop Transformation. Using a percentage allows for many different usages.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->

The tests were succesful.
