### PR TITLE
added note for DexGuard only

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,8 @@ Depending on your ProGuard (DexGuard) config and usage, you may need to include 
   **[] $VALUES;
   public *;
 }
+
+# for DexGuard only
 -keepresourcexmlelements manifest/application/meta-data@value=GlideModule
 ```
 


### PR DESCRIPTION
https://github.com/bumptech/glide/wiki/Configuration#keeping-a-glidemodule

## Motivation and Context

Not everybody uses DexGuard and adding `-keepresourcexmlelements` will cause failing builds if one doesn't use DexGuard.