### PR TITLE
Add Glide.setModulesEnabled API to allow apps to disable Manifest parsing

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -75,6 +75,7 @@ import java.io.InputStream;
 import java.net.URL;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 
 /**
@@ -87,6 +88,7 @@ public class Glide implements ComponentCallbacks2 {
   private static final String DEFAULT_DISK_CACHE_DIR = "image_manager_disk_cache";
   private static final String TAG = "Glide";
   private static volatile Glide glide;
+  private static boolean modulesEnabled = true;
 
   private final Engine engine;
   private final BitmapPool bitmapPool;
@@ -137,6 +139,17 @@ public class Glide implements ComponentCallbacks2 {
   }
 
   /**
+   * Enable or disable the parsing of AndroidManifest.xml
+   * looking for {@link GlideModule} implementations.
+   * Must be called before accessing the Glide singleton; otherwise, has no effect.
+   */
+  public static void setModulesEnabled(boolean enabled) {
+    synchronized (Glide.class) {
+      modulesEnabled = enabled;
+    }
+  }
+
+  /**
    * Get the singleton.
    *
    * @return the singleton
@@ -146,9 +159,8 @@ public class Glide implements ComponentCallbacks2 {
       synchronized (Glide.class) {
         if (glide == null) {
           Context applicationContext = context.getApplicationContext();
-          List<GlideModule> modules = new ManifestParser(applicationContext).parse();
-
           GlideBuilder builder = new GlideBuilder(applicationContext);
+          List<GlideModule> modules = parseGlideModules(applicationContext);
           for (GlideModule module : modules) {
             module.applyOptions(applicationContext, builder);
           }
@@ -161,6 +173,18 @@ public class Glide implements ComponentCallbacks2 {
     }
 
     return glide;
+  }
+
+  /**
+   * If modules are enabled, parses the application manifest and returns the configured modules.
+   * Otherwise, returns an empty list.
+   */
+  private static List<GlideModule> parseGlideModules(Context applicationContext) {
+    if (modulesEnabled) {
+      return new ManifestParser(applicationContext).parse();
+    } else {
+      return Collections.emptyList();
+    }
   }
 
   @VisibleForTesting

--- a/library/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/src/test/java/com/bumptech/glide/GlideTest.java
@@ -137,6 +137,7 @@ public class GlideTest {
   @After
   public void tearDown() {
     Glide.tearDown();
+    Glide.setModulesEnabled(true);
   }
 
   @Test
@@ -554,7 +555,7 @@ public class GlideTest {
 
   @Test
   public void testSetModulesEnabledTrue() throws Exception {
-    // teaDown glide instance first so we have a clean slate and not the Glide.get() call in setUp
+    // tearDown glide instance first so we have a clean slate and not the Glide.get() call in setUp
     Glide.tearDown();
 
     // This is the default, so it should be a no-op
@@ -572,22 +573,19 @@ public class GlideTest {
 
   @Test
   public void testSetModulesEnabledFalse() throws Exception {
-    // teaDown glide instance first so we have a clean slate and not the Glide.get() call in setUp
+    // tearDown glide instance first so we have a clean slate and not the Glide.get() call in setUp
     Glide.tearDown();
 
     Glide.setModulesEnabled(false);
-    try {
-      Glide glide = Glide.get(getContext());
-      List<ModelLoader<GlideUrl, ?>> modelLoaders =
-          glide.getRegistry().getModelLoaders(mock(GlideUrl.class));
 
-      // With modules disabled, SetupModule below should not have been initialized,
-      // so the default modelLoader should remain
-      assertEquals(1, modelLoaders.size());
-      assertTrue(modelLoaders.get(0) instanceof HttpGlideUrlLoader);
-    } finally {
-      Glide.setModulesEnabled(true);
-    }
+    Glide glide = Glide.get(getContext());
+    List<ModelLoader<GlideUrl, ?>> modelLoaders =
+        glide.getRegistry().getModelLoaders(mock(GlideUrl.class));
+
+    // With modules disabled, SetupModule below should not have been initialized,
+    // so the default modelLoader should remain
+    assertEquals(1, modelLoaders.size());
+    assertTrue(modelLoaders.get(0) instanceof HttpGlideUrlLoader);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
## Description
Adding a static flag to Glide to disable parsing the manifest to find configured modules.
Added unit tests.
Fixes #684 

## Motivation and Context
The Dropbox app has been crashing on launch approximately 9000 times a day due to `RuntimeException`s  thrown by `PackageManager`.  We'd like to remove the dependency on `PackageManager` from our startup path, and we don't use any `GlideModule`s.  While #1742 in 4.0 will address this long term, we'd like a short term way to run Glide without runtime manifest parsing.

In order to enable unit testing, I decided to make this a set method that takes a `boolean`.

Not sure if I found the best way to unit test this.  Feel free to propose a cleaner approach.