### PR TITLE
Add Glide.setModulesEnabled API for 3.x to allow apps to disable Manifest parsing

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -139,8 +139,7 @@ public class Glide {
     }
 
     /**
-     * Enable or disable the parsing of AndroidManifest.xml
-     * looking for {@link GlideModule} implementations.
+     * Enable or disable the parsing of AndroidManifest.xml looking for {@link GlideModule} implementations.
      * @throws IllegalArgumentException if the Glide singleton has already been created.
      */
     public static void setModulesEnabled(boolean enabled) {


### PR DESCRIPTION
## Description
Adding a static flag to Glide to disable parsing the manifest to find configured modules.
Added unit tests.
Same as #1753 but backported to 3.0 branch
Fixes #684

## Motivation and Context
he Dropbox app has been crashing on launch approximately 9000 times a day due to RuntimeExceptions thrown by PackageManager. We'd like to remove the dependency on PackageManager from our startup path, and we don't use any GlideModules. While #1742 in 4.0 will address this long term, we'd like a short term way to run Glide without runtime manifest parsing.

In order to enable unit testing, I decided to make this a set method that takes a boolean.