### PR TITLE
Add a Glide.with method for View subclasses.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -6,6 +6,9 @@ import android.app.Application;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.os.Build;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.os.Bundle;
 import android.os.Handler;
 import android.os.Looper;
 import android.os.Message;
@@ -13,11 +16,15 @@ import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
+import android.support.v4.util.ArrayMap;
 import android.util.Log;
+import android.view.View;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
+import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.Util;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 
 /**
@@ -31,6 +38,11 @@ public class RequestManagerRetriever implements Handler.Callback {
 
   private static final int ID_REMOVE_FRAGMENT_MANAGER = 1;
   private static final int ID_REMOVE_SUPPORT_FRAGMENT_MANAGER = 2;
+
+  // Hacks based on the implementation of FragmentManagerImpl in the non-support libraries that
+  // allow us to iterate over and retrieve all active Fragments in a FragmentManager.
+  private static final String FRAGMENT_INDEX_KEY = "key";
+  private static final String FRAGMENT_MANAGER_GET_FRAGMENT_KEY = "i";
 
   /**
    * The top application level RequestManager.
@@ -56,6 +68,11 @@ public class RequestManagerRetriever implements Handler.Callback {
    */
   private final Handler handler;
   private final RequestManagerFactory factory;
+
+  // Objects used to find Fragments and Activities containing views.
+  private final ArrayMap<View, Fragment> tempViewToSupportFragment = new ArrayMap<>();
+  private final ArrayMap<View, android.app.Fragment> tempViewToFragment = new ArrayMap<>();
+  private final Bundle tempBundle = new Bundle();
 
   // Visible for testing.
   public RequestManagerRetriever(@Nullable RequestManagerFactory factory) {
@@ -106,15 +123,13 @@ public class RequestManagerRetriever implements Handler.Callback {
     } else {
       assertNotDestroyed(activity);
       FragmentManager fm = activity.getSupportFragmentManager();
-      return supportFragmentGet(activity, fm, null);
+      return supportFragmentGet(activity, fm, null /*parentHint*/);
     }
   }
 
   public RequestManager get(Fragment fragment) {
-    if (fragment.getActivity() == null) {
-      throw new IllegalArgumentException(
-          "You cannot start a load on a fragment before it is attached");
-    }
+    Preconditions.checkNotNull(fragment.getActivity(),
+          "You cannot start a load on a fragment before it is attached or after it is destroyed");
     if (Util.isOnBackgroundThread()) {
       return get(fragment.getActivity().getApplicationContext());
     } else {
@@ -129,7 +144,135 @@ public class RequestManagerRetriever implements Handler.Callback {
     } else {
       assertNotDestroyed(activity);
       android.app.FragmentManager fm = activity.getFragmentManager();
-      return fragmentGet(activity, fm, null);
+      return fragmentGet(activity, fm, null /*parentHint*/);
+    }
+  }
+
+  public RequestManager get(View view) {
+    if (Util.isOnBackgroundThread()) {
+      return get(view.getContext().getApplicationContext());
+    }
+
+    Preconditions.checkNotNull(view);
+    Preconditions.checkNotNull(view.getContext(),
+        "Unable to obtain a request manager for a view without a Context");
+    Activity activity = findActivity(view.getContext());
+    // The view might be somewhere else, like a service.
+    if (activity == null) {
+      return get(view.getContext().getApplicationContext());
+    }
+
+    // Support Fragments.
+    if (activity instanceof FragmentActivity) {
+      Fragment fragment = findSupportFragment(view, (FragmentActivity) activity);
+      if (fragment == null) {
+        return get(activity);
+      }
+      return get(fragment);
+    }
+
+    // Standard Fragments.
+    android.app.Fragment fragment = findFragment(view, activity);
+    if (fragment == null) {
+      return get(activity);
+    }
+    return get(fragment);
+  }
+
+  private static void findAllSupportFragmentsWithViews(@Nullable List<Fragment> topLevelFragments,
+      Map<View, Fragment> result) {
+    if (topLevelFragments == null) {
+      return;
+    }
+    for (Fragment fragment : topLevelFragments) {
+      if (fragment.getView() == null) {
+        continue;
+      }
+      result.put(fragment.getView(), fragment);
+      findAllSupportFragmentsWithViews(fragment.getChildFragmentManager().getFragments(), result);
+    }
+  }
+
+  @Nullable
+  private Fragment findSupportFragment(View target, FragmentActivity activity) {
+    tempViewToSupportFragment.clear();
+    findAllSupportFragmentsWithViews(
+        activity.getSupportFragmentManager().getFragments(), tempViewToSupportFragment);
+    Fragment result = null;
+    View activityRoot = activity.findViewById(android.R.id.content);
+    View current = target;
+    while (!current.equals(activityRoot)) {
+      result = tempViewToSupportFragment.get(current);
+      if (result != null) {
+        break;
+      }
+      if (current.getParent() instanceof View) {
+        current = (View) current.getParent();
+      } else {
+        break;
+      }
+    }
+
+    tempViewToSupportFragment.clear();
+    return result;
+  }
+
+  @Nullable
+  private android.app.Fragment findFragment(View target, Activity activity) {
+    tempViewToFragment.clear();
+    findAllFragmentsWithViews(activity.getFragmentManager(), tempViewToFragment);
+
+    android.app.Fragment result = null;
+
+    View activityRoot = activity.findViewById(android.R.id.content);
+    View current = target;
+     while (!current.equals(activityRoot)) {
+      result = tempViewToFragment.get(current);
+      if (result != null) {
+        break;
+      }
+      if (current.getParent() instanceof View) {
+        current = (View) current.getParent();
+      } else {
+        break;
+      }
+    }
+    tempViewToFragment.clear();
+    return result;
+  }
+
+  // TODO: Consider using an accessor class in the support library package to more directly retrieve
+  // non-support Fragments.
+  private void findAllFragmentsWithViews(
+      android.app.FragmentManager fragmentManager, ArrayMap<View, android.app.Fragment> result) {
+    int index = 0;
+    while (true) {
+      tempBundle.putInt(FRAGMENT_INDEX_KEY, index++);
+      android.app.Fragment fragment = null;
+      try {
+        fragment = fragmentManager.getFragment(tempBundle, FRAGMENT_MANAGER_GET_FRAGMENT_KEY);
+      } catch (Exception e) {
+        // This generates log spam from FragmentManager anyway.
+      }
+      if (fragment == null) {
+        break;
+      }
+      if (fragment.getView() != null) {
+        result.put(fragment.getView(), fragment);
+        if (VERSION.SDK_INT >= VERSION_CODES.JELLY_BEAN_MR1) {
+          findAllFragmentsWithViews(fragment.getChildFragmentManager(), result);
+        }
+      }
+    }
+  }
+
+  private Activity findActivity(Context context) {
+    if (context instanceof Activity) {
+      return (Activity) context;
+    } else if (context instanceof ContextWrapper) {
+      return findActivity(((ContextWrapper) context).getBaseContext());
+    } else {
+      return null;
     }
   }
 

--- a/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
@@ -204,7 +204,7 @@ public class RequestManagerRetrieverTest {
     retriever.get(fragment);
   }
 
-  @Test(expected = IllegalArgumentException.class)
+  @Test(expected = NullPointerException.class)
   public void testThrowsIfSupportFragmentNotAttached() {
     Fragment fragment = new Fragment();
     retriever.get(fragment);


### PR DESCRIPTION
The implementation, especially for non-support 
Fragments, relies on implementation details of
FragmentManagerImpl. It’s not ideal, but it does
resolve a longstanding problem where View 
subclasses end up using the wrong RequestManager.