### PR TITLE
Add Context as a parameter to Transformations.

### DIFF
--- a/integration/gifencoder/src/main/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoder.java
+++ b/integration/gifencoder/src/main/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoder.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.integration.gifencoder;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.util.Log;
 import com.bumptech.glide.gifdecoder.GifDecoder;
@@ -58,15 +59,17 @@ public class ReEncodingGifResourceEncoder implements ResourceEncoder<GifDrawable
   private static final Factory FACTORY = new Factory();
   private static final String TAG = "GifEncoder";
   private final GifDecoder.BitmapProvider provider;
+  private Context context;
   private final BitmapPool bitmapPool;
   private final Factory factory;
 
-  public ReEncodingGifResourceEncoder(BitmapPool bitmapPool) {
-    this(bitmapPool, FACTORY);
+  public ReEncodingGifResourceEncoder(Context context, BitmapPool bitmapPool) {
+    this(context, bitmapPool, FACTORY);
   }
 
   // Visible for testing.
-  ReEncodingGifResourceEncoder(BitmapPool bitmapPool, Factory factory) {
+  ReEncodingGifResourceEncoder(Context context, BitmapPool bitmapPool, Factory factory) {
+    this.context = context;
     this.bitmapPool = bitmapPool;
     provider = new GifBitmapProvider(bitmapPool);
     this.factory = factory;
@@ -179,8 +182,9 @@ public class ReEncodingGifResourceEncoder implements ResourceEncoder<GifDrawable
       Transformation<Bitmap> transformation, GifDrawable drawable) {
     // TODO: what if current frame is null?
     Resource<Bitmap> bitmapResource = factory.buildFrameResource(currentFrame, bitmapPool);
-    Resource<Bitmap> transformedResource = transformation
-        .transform(bitmapResource, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
+    Resource<Bitmap> transformedResource =
+        transformation.transform(
+            context, bitmapResource, drawable.getIntrinsicWidth(), drawable.getIntrinsicHeight());
     if (!bitmapResource.equals(transformedResource)) {
       bitmapResource.recycle();
     }

--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -159,6 +159,16 @@ public class Glide implements ComponentCallbacks2 {
     return glide;
   }
 
+  @VisibleForTesting
+  public static void init(Glide glide) {
+    Glide.glide = glide;
+  }
+
+  @VisibleForTesting
+  public static void tearDown() {
+    glide = null;
+  }
+
   @SuppressWarnings("deprecation")
   private static void initGlide(Context context) {
     Context applicationContext = context.getApplicationContext();
@@ -202,7 +212,7 @@ public class Glide implements ComponentCallbacks2 {
     if (annotationGeneratedModule != null) {
       annotationGeneratedModule.applyOptions(applicationContext, builder);
     }
-    glide = builder.createGlide(applicationContext);
+    glide = builder.build(applicationContext);
     for (GlideModule module : manifestModules) {
       module.registerComponents(applicationContext, glide.registry);
     }
@@ -237,11 +247,6 @@ public class Glide implements ComponentCallbacks2 {
           + " processor will generate a correct implementation.", e);
     }
     return result;
-  }
-
-  @VisibleForTesting
-  public static void tearDown() {
-    glide = null;
   }
 
   @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)

--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -39,10 +39,6 @@ public final class GlideBuilder {
   @Nullable
   private RequestManagerFactory requestManagerFactory;
 
-  GlideBuilder() {
-    // Package private visibility.
-  }
-
   /**
    * Sets the {@link com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool} implementation to use
    * to store and retrieve reused {@link android.graphics.Bitmap}s.
@@ -267,7 +263,7 @@ public final class GlideBuilder {
     return this;
   }
 
-  Glide createGlide(Context context) {
+  public Glide build(Context context) {
     if (sourceExecutor == null) {
       sourceExecutor = GlideExecutor.newSourceExecutor();
     }

--- a/library/src/main/java/com/bumptech/glide/RequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/RequestBuilder.java
@@ -390,15 +390,15 @@ public class RequestBuilder<TranscodeType> implements Cloneable {
       }
       switch (view.getScaleType()) {
         case CENTER_CROP:
-          requestOptions.optionalCenterCrop(context);
+          requestOptions.optionalCenterCrop();
           break;
         case CENTER_INSIDE:
-          requestOptions.optionalCenterInside(context);
+          requestOptions.optionalCenterInside();
           break;
         case FIT_CENTER:
         case FIT_START:
         case FIT_END:
-          requestOptions.optionalFitCenter(context);
+          requestOptions.optionalFitCenter();
           break;
         //$CASES-OMITTED$
         default:

--- a/library/src/main/java/com/bumptech/glide/load/MultiTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/MultiTransformation.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load;
 
+import android.content.Context;
 import com.bumptech.glide.load.engine.Resource;
 import java.security.MessageDigest;
 import java.util.Arrays;
@@ -31,11 +32,12 @@ public class MultiTransformation<T> implements Transformation<T> {
   }
 
   @Override
-  public Resource<T> transform(Resource<T> resource, int outWidth, int outHeight) {
+  public Resource<T> transform(
+      Context context, Resource<T> resource, int outWidth, int outHeight) {
     Resource<T> previous = resource;
 
     for (Transformation<T> transformation : transformations) {
-      Resource<T> transformed = transformation.transform(previous, outWidth, outHeight);
+      Resource<T> transformed = transformation.transform(context, previous, outWidth, outHeight);
       if (previous != null && !previous.equals(resource) && !previous.equals(transformed)) {
         previous.recycle();
       }

--- a/library/src/main/java/com/bumptech/glide/load/Transformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/Transformation.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load;
 
+import android.content.Context;
 import com.bumptech.glide.load.engine.Resource;
 
 /**
@@ -40,6 +41,7 @@ public interface Transformation<T> extends Key {
    * Transformation. Otherwise the resource you request may be loaded from disk cache and your
    * Transformation may not be called.
    *
+   * @param context The Application context
    * @param resource  The resource to transform.
    * @param outWidth  The width of the view or target the resource will be displayed in, or {@link
    *                  com.bumptech.glide.request.target.Target#SIZE_ORIGINAL} to indicate the
@@ -49,5 +51,5 @@ public interface Transformation<T> extends Key {
    *                  original resource height.
    * @return The transformed resource.
    */
-  Resource<T> transform(Resource<T> resource, int outWidth, int outHeight);
+  Resource<T> transform(Context context, Resource<T> resource, int outWidth, int outHeight);
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
@@ -480,7 +480,7 @@ class DecodeJob<R> implements DataFetcherGenerator.FetcherReadyCallback,
       Resource<Z> transformed = decoded;
       if (dataSource != DataSource.RESOURCE_DISK_CACHE) {
         appliedTransformation = decodeHelper.getTransformation(resourceSubClass);
-        transformed = appliedTransformation.transform(decoded, width, height);
+        transformed = appliedTransformation.transform(glideContext, decoded, width, height);
       }
       // TODO: Make this the responsibility of the Transformation.
       if (!decoded.equals(transformed)) {

--- a/library/src/main/java/com/bumptech/glide/load/resource/UnitTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/UnitTransformation.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource;
 
+import android.content.Context;
 import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;
 import java.security.MessageDigest;
@@ -27,7 +28,7 @@ public final class UnitTransformation<T> implements Transformation<T> {
   }
 
   @Override
-  public Resource<T> transform(Resource<T> resource, int outWidth, int outHeight) {
+  public Resource<T> transform(Context context, Resource<T> resource, int outWidth, int outHeight) {
     return resource;
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformation.java
@@ -15,31 +15,43 @@ import java.security.MessageDigest;
  */
 public class BitmapDrawableTransformation implements Transformation<BitmapDrawable> {
 
-  private final Context context;
-  private final BitmapPool bitmapPool;
   private final Transformation<Bitmap> wrapped;
 
-  public BitmapDrawableTransformation(Context context, Transformation<Bitmap> wrapped) {
-    this(context, Glide.get(context).getBitmapPool(), wrapped);
-  }
-
-  // Visible for testing.
-  BitmapDrawableTransformation(Context context, BitmapPool bitmapPool,
-      Transformation<Bitmap> wrapped) {
-    this.context = context.getApplicationContext();
-    this.bitmapPool = Preconditions.checkNotNull(bitmapPool);
+  public BitmapDrawableTransformation(Transformation<Bitmap> wrapped) {
     this.wrapped = Preconditions.checkNotNull(wrapped);
   }
 
+  /**
+   * @deprecated use {@link #BitmapDrawableTransformation(Transformation)}}
+   */
+  @Deprecated
+  public BitmapDrawableTransformation(
+      @SuppressWarnings("unused") Context context, Transformation<Bitmap> wrapped) {
+    this(wrapped);
+  }
+
+  /**
+   * @deprecated use {@link #BitmapDrawableTransformation(Transformation)}}
+   */
+  @Deprecated
+  public BitmapDrawableTransformation(
+      @SuppressWarnings("unused") Context context,
+      @SuppressWarnings("unused") BitmapPool bitmapPool,
+      Transformation<Bitmap> wrapped) {
+    this(wrapped);
+  }
+
   @Override
-  public Resource<BitmapDrawable> transform(Resource<BitmapDrawable> drawableResourceToTransform,
-      int outWidth, int outHeight) {
+  public Resource<BitmapDrawable> transform(
+      Context context, Resource<BitmapDrawable> drawableResourceToTransform, int outWidth,
+      int outHeight) {
     BitmapDrawable drawableToTransform = drawableResourceToTransform.get();
     Bitmap bitmapToTransform = drawableToTransform.getBitmap();
 
+    BitmapPool bitmapPool = Glide.get(context).getBitmapPool();
     BitmapResource bitmapResourceToTransform = BitmapResource.obtain(bitmapToTransform, bitmapPool);
     Resource<Bitmap> transformedBitmapResource =
-        wrapped.transform(bitmapResourceToTransform, outWidth, outHeight);
+        wrapped.transform(context, bitmapResourceToTransform, outWidth, outHeight);
 
     if (transformedBitmapResource.equals(bitmapResourceToTransform)) {
       return drawableResourceToTransform;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformation.java
@@ -52,23 +52,29 @@ import com.bumptech.glide.util.Util;
  */
 public abstract class BitmapTransformation implements Transformation<Bitmap> {
 
-  private final BitmapPool bitmapPool;
-
-  public BitmapTransformation(Context context) {
-    this(Glide.get(context).getBitmapPool());
+  public BitmapTransformation() {
+    // Intentionally empty.
   }
 
-  public BitmapTransformation(BitmapPool bitmapPool) {
-    this.bitmapPool = bitmapPool;
+  @Deprecated
+  public BitmapTransformation(@SuppressWarnings("unused") Context context) {
+    this();
+  }
+
+  @Deprecated
+  public BitmapTransformation(@SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this();
   }
 
   @Override
-  public final Resource<Bitmap> transform(Resource<Bitmap> resource, int outWidth, int outHeight) {
+  public final Resource<Bitmap> transform(
+      Context context, Resource<Bitmap> resource, int outWidth, int outHeight) {
     if (!Util.isValidDimensions(outWidth, outHeight)) {
       throw new IllegalArgumentException(
           "Cannot apply transformation on width: " + outWidth + " or height: " + outHeight
               + " less than or equal to zero and not Target.SIZE_ORIGINAL");
     }
+    BitmapPool bitmapPool = Glide.get(context).getBitmapPool();
     Bitmap toTransform = resource.get();
     int targetWidth = outWidth == Target.SIZE_ORIGINAL ? toTransform.getWidth() : outWidth;
     int targetHeight = outHeight == Target.SIZE_ORIGINAL ? toTransform.getHeight() : outHeight;
@@ -111,6 +117,6 @@ public abstract class BitmapTransformation implements Transformation<Bitmap> {
    * @param outHeight   The ideal height of the transformed bitmap (the transformed height does not
    *                    need to match exactly).
    */
-  protected abstract Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform,
-      int outWidth, int outHeight);
+  protected abstract Bitmap transform(
+      @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight);
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterCrop.java
@@ -17,19 +17,25 @@ public class CenterCrop extends BitmapTransformation {
   private static final String ID = "com.bumptech.glide.load.resource.bitmap.CenterCrop";
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
-  public CenterCrop(Context context) {
-    super(context);
+  public CenterCrop() {
+    // Intentionally empty.
   }
 
-  public CenterCrop(BitmapPool bitmapPool) {
-    super(bitmapPool);
+  @Deprecated
+  public CenterCrop(@SuppressWarnings("unused") Context context) {
+    this();
+  }
+
+  @Deprecated
+  public CenterCrop(@SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this();
   }
 
   // Bitmap doesn't implement equals, so == and .equals are equivalent here.
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   @Override
-  protected Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth,
-      int outHeight) {
+  protected Bitmap transform(
+      @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
     return TransformationUtils.centerCrop(pool, toTransform, outWidth, outHeight);
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterInside.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CenterInside.java
@@ -17,17 +17,29 @@ public class CenterInside extends BitmapTransformation {
   private static final String ID = "com.bumptech.glide.load.resource.bitmap.CenterInside";
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
-  public CenterInside(Context context) {
-    super(context);
+  public CenterInside() {
+    // Intentionally empty.
   }
 
-  public CenterInside(BitmapPool bitmapPool) {
-    super(bitmapPool);
+  /**
+   * Use {@link #CenterInside()}.
+   */
+  @Deprecated
+  public CenterInside(@SuppressWarnings("unused") Context context) {
+    this();
+  }
+
+  /**
+   * Use {@link #CenterInside()}.
+   */
+  @Deprecated
+  public CenterInside(@SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this();
   }
 
   @Override
-  protected Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth,
-      int outHeight) {
+  protected Bitmap transform(
+      @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
     return TransformationUtils.centerInside(pool, toTransform, outWidth, outHeight);
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CircleCrop.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/CircleCrop.java
@@ -19,19 +19,31 @@ public class CircleCrop extends BitmapTransformation {
   private static final String ID = "com.bumptech.glide.load.resource.bitmap.CircleCrop." + VERSION;
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
-  public CircleCrop(Context context) {
-    super(context);
+  public CircleCrop() {
+    // Intentionally empty.
   }
 
-  public CircleCrop(BitmapPool bitmapPool) {
-    super(bitmapPool);
+  /**
+   * @deprecated Use {@link #CircleCrop()}.
+   */
+  @Deprecated
+  public CircleCrop(@SuppressWarnings("unused") Context context) {
+    this();
+  }
+
+  /**
+   * @deprecated Use {@link #CircleCrop()}
+   */
+  @Deprecated
+  public CircleCrop(@SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this();
   }
 
   // Bitmap doesn't implement equals, so == and .equals are equivalent here.
   @SuppressWarnings("PMD.CompareObjectsWithEquals")
   @Override
-  protected Bitmap transform(@NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth,
-      int outHeight) {
+  protected Bitmap transform(
+      @NonNull BitmapPool pool, @NonNull Bitmap toTransform, int outWidth, int outHeight) {
     return TransformationUtils.circleCrop(pool, toTransform, outWidth, outHeight);
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/FitCenter.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/FitCenter.java
@@ -15,12 +15,24 @@ public class FitCenter extends BitmapTransformation {
   private static final String ID = "com.bumptech.glide.load.resource.bitmap.FitCenter";
   private static final byte[] ID_BYTES = ID.getBytes(CHARSET);
 
-  public FitCenter(Context context) {
-    super(context);
+  public FitCenter() {
+    // Intentionally empty.
   }
 
-  public FitCenter(BitmapPool bitmapPool) {
-    super(bitmapPool);
+  /**
+   * @deprecated Use {@link #FitCenter()}.
+   */
+  @Deprecated
+  public FitCenter(@SuppressWarnings("unused") Context context) {
+    this();
+  }
+
+  /**
+   * @deprecated Use {@link #FitCenter()}.
+   */
+  @Deprecated
+  public FitCenter(@SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this();
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
@@ -21,8 +21,7 @@ public final class RoundedCorners extends BitmapTransformation {
    * @param roundingRadius the corner radius (in device-specific pixels).
    * @throws IllegalArgumentException if rounding radius is 0 or less.
    */
-  public RoundedCorners(BitmapPool bitmapPool, int roundingRadius) {
-    super(bitmapPool);
+  public RoundedCorners(int roundingRadius) {
     Preconditions.checkArgument(roundingRadius > 0, "roundingRadius must be greater than 0.");
     this.roundingRadius = roundingRadius;
   }
@@ -30,11 +29,23 @@ public final class RoundedCorners extends BitmapTransformation {
   /**
    * @param roundingRadius the corner radius (in device-specific pixels).
    * @throws IllegalArgumentException if rounding radius is 0 or less.
+   *
+   * @deprecated Use {@link #RoundedCorners(int)}
    */
-  public RoundedCorners(Context context, int roundingRadius) {
-    super(context);
-    Preconditions.checkArgument(roundingRadius > 0, "roundingRadius must be greater than 0.");
-    this.roundingRadius = roundingRadius;
+  @Deprecated
+  public RoundedCorners(@SuppressWarnings("unused") BitmapPool bitmapPool, int roundingRadius) {
+    this(roundingRadius);
+  }
+
+  /**
+   * @param roundingRadius the corner radius (in device-specific pixels).
+   * @throws IllegalArgumentException if rounding radius is 0 or less.
+   *
+   * @deprecated Use {@link #RoundedCorners(int)}
+   */
+  @Deprecated
+  public RoundedCorners(@SuppressWarnings("unused") Context context, int roundingRadius) {
+    this(roundingRadius);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformation.java
@@ -17,20 +17,32 @@ import java.security.MessageDigest;
  */
 public class GifDrawableTransformation implements Transformation<GifDrawable> {
   private final Transformation<Bitmap> wrapped;
-  private final BitmapPool bitmapPool;
 
-  public GifDrawableTransformation(Context context, Transformation<Bitmap> wrapped) {
-    this(wrapped, Glide.get(context).getBitmapPool());
+  public GifDrawableTransformation(Transformation<Bitmap> wrapped) {
+    this.wrapped = Preconditions.checkNotNull(wrapped);
   }
 
-  public GifDrawableTransformation(Transformation<Bitmap> wrapped, BitmapPool bitmapPool) {
-    this.wrapped = Preconditions.checkNotNull(wrapped);
-    this.bitmapPool = Preconditions.checkNotNull(bitmapPool);
+  /**
+   * @deprecated Use {@link #GifDrawableTransformation(Transformation)}.
+   */
+  @Deprecated
+  public GifDrawableTransformation(
+      @SuppressWarnings("unused") Context context, Transformation<Bitmap> wrapped) {
+    this(wrapped);
+  }
+
+  /**
+   * @deprecated Use {@link #GifDrawableTransformation(Transformation)}
+   */
+  @Deprecated
+  public GifDrawableTransformation(
+      Transformation<Bitmap> wrapped, @SuppressWarnings("unused") BitmapPool bitmapPool) {
+    this(wrapped);
   }
 
   @Override
-  public Resource<GifDrawable> transform(Resource<GifDrawable> resource, int outWidth,
-      int outHeight) {
+  public Resource<GifDrawable> transform(
+      Context context, Resource<GifDrawable> resource, int outWidth, int outHeight) {
     GifDrawable drawable = resource.get();
 
     // The drawable needs to be initialized with the correct width and height in order for a view
@@ -38,9 +50,10 @@ public class GifDrawableTransformation implements Transformation<GifDrawable> {
     // modify the dimensions of our GIF, here we create a stand in for a frame and pass it to the
     // transformation to see what the final transformed dimensions will be so that our drawable can
     // report the correct intrinsic width and height.
+    BitmapPool bitmapPool = Glide.get(context).getBitmapPool();
     Bitmap firstFrame = drawable.getFirstFrame();
     Resource<Bitmap> bitmapResource = new BitmapResource(firstFrame, bitmapPool);
-    Resource<Bitmap> transformed = wrapped.transform(bitmapResource, outWidth, outHeight);
+    Resource<Bitmap> transformed = wrapped.transform(context, bitmapResource, outWidth, outHeight);
     if (!bitmapResource.equals(transformed)) {
       bitmapResource.recycle();
     }

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
@@ -3,7 +3,6 @@ package com.bumptech.glide.load.resource.gif;
 import static com.bumptech.glide.request.RequestOptions.diskCacheStrategyOf;
 import static com.bumptech.glide.request.RequestOptions.signatureOf;
 
-import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Handler;
 import android.os.Looper;
@@ -32,7 +31,6 @@ import java.util.UUID;
 class GifFrameLoader {
   private final GifDecoder gifDecoder;
   private final Handler handler;
-  private final Context context;
   private final List<FrameCallback> callbacks = new ArrayList<>();
   @Synthetic final RequestManager requestManager;
   private final BitmapPool bitmapPool;
@@ -59,7 +57,6 @@ class GifFrameLoader {
       Transformation<Bitmap> transformation,
       Bitmap firstFrame) {
     this(
-        glide.getContext(),
         glide.getBitmapPool(),
         Glide.with(glide.getContext()),
         gifDecoder,
@@ -71,7 +68,6 @@ class GifFrameLoader {
 
   @SuppressWarnings("PMD.ConstructorCallsOverridableMethod")
   GifFrameLoader(
-      Context context,
       BitmapPool bitmapPool,
       RequestManager requestManager,
       GifDecoder gifDecoder,
@@ -83,7 +79,6 @@ class GifFrameLoader {
     if (handler == null) {
       handler = new Handler(Looper.getMainLooper(), new FrameLoaderCallback());
     }
-    this.context = context;
     this.bitmapPool = bitmapPool;
     this.handler = handler;
     this.requestBuilder = requestBuilder;
@@ -96,7 +91,7 @@ class GifFrameLoader {
   void setFrameTransformation(Transformation<Bitmap> transformation, Bitmap firstFrame) {
     this.transformation = Preconditions.checkNotNull(transformation);
     this.firstFrame = Preconditions.checkNotNull(firstFrame);
-    requestBuilder = requestBuilder.apply(new RequestOptions().transform(context, transformation));
+    requestBuilder = requestBuilder.apply(new RequestOptions().transform(transformation));
   }
 
   Transformation<Bitmap> getFrameTransformation() {

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -513,31 +513,71 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link android.content.Context}.
    * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
    * @see #centerCrop(android.content.Context)
+   *
+   * @deprecated Use {@link #optionalCenterCrop()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "optionalCenterCropTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD optionalCenterCrop(@SuppressWarnings("unused") Context context) {
+    return optionalCenterCrop();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.CenterCrop} to all default types, and
+   * ignores unknown types.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
+   * @see #centerCrop()
    */
   @GlideOption(
       staticMethodName = "optionalCenterCropTransform",
       memoizeStaticMethod = true
   )
-  public CHILD optionalCenterCrop(Context context) {
-    return optionalTransform(context, DownsampleStrategy.CENTER_OUTSIDE, new CenterCrop(context));
+  public CHILD optionalCenterCrop() {
+    return optionalTransform(DownsampleStrategy.CENTER_OUTSIDE, new CenterCrop());
   }
 
   /**
    * Applies {@link com.bumptech.glide.load.resource.bitmap.CenterCrop} to all default types and
    * throws an exception if asked to transform an unknown type.
    *
-   * <p>This will override previous calls to {@link #dontTransform()}.
+   * <p>this will override previous calls to {@link #dontTransform()}.
    *
-   * @param context Any {@link android.content.Context}.
+   * @param context any {@link android.content.Context}.
    * @see #transform(Class, com.bumptech.glide.load.Transformation)
    * @see #optionalCenterCrop(android.content.Context)
+   *
+   * @deprecated Use {@link #centerCrop()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "centerCropTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD centerCrop(@SuppressWarnings("unused") Context context) {
+    return centerCrop();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.CenterCrop} to all default types and
+   * throws an exception if asked to transform an unknown type.
+   *
+   * <p>this will override previous calls to {@link #dontTransform()} ()}.
+   *
+   * @see #transform(Class, com.bumptech.glide.load.Transformation)
+   * @see #optionalCenterCrop()
    */
   @GlideOption(
       staticMethodName = "centerCropTransform",
       memoizeStaticMethod = true
   )
-  public CHILD centerCrop(Context context) {
-    return transform(context, DownsampleStrategy.CENTER_OUTSIDE, new CenterCrop(context));
+  public CHILD centerCrop() {
+    return transform(DownsampleStrategy.CENTER_OUTSIDE, new CenterCrop());
   }
 
   /**
@@ -549,13 +589,33 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link android.content.Context}.
    * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
    * @see #fitCenter(android.content.Context)
+   *
+   * @deprecated Use {@link #optionalFitCenter()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "optionalFitCenterTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD optionalFitCenter(@SuppressWarnings("unused") Context context) {
+    return optionalFitCenter();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.FitCenter} to all default types, and
+   * ignores unknown types.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
+   * @see #fitCenter()
    */
   @GlideOption(
       staticMethodName = "optionalFitCenterTransform",
       memoizeStaticMethod = true
   )
-  public CHILD optionalFitCenter(Context context) {
-    return optionalTransform(context, DownsampleStrategy.FIT_CENTER, new FitCenter(context));
+  public CHILD optionalFitCenter() {
+    return optionalTransform(DownsampleStrategy.FIT_CENTER, new FitCenter());
   }
 
   /**
@@ -567,13 +627,33 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link android.content.Context}.
    * @see #transform(Class, com.bumptech.glide.load.Transformation)
    * @see #optionalFitCenter(android.content.Context)
+   *
+   * @deprecated Use {@link #fitCenter()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "fitCenterTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD fitCenter(@SuppressWarnings("unused") Context context) {
+    return fitCenter();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.FitCenter} to all default types and
+   * throws an exception if asked to transform an unknown type.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #transform(Class, com.bumptech.glide.load.Transformation)
+   * @see #optionalFitCenter()
    */
   @GlideOption(
       staticMethodName = "fitCenterTransform",
       memoizeStaticMethod = true
   )
-  public CHILD fitCenter(Context context) {
-    return transform(context, DownsampleStrategy.FIT_CENTER, new FitCenter(context));
+  public CHILD fitCenter() {
+    return transform(DownsampleStrategy.FIT_CENTER, new FitCenter());
   }
 
   /**
@@ -585,13 +665,33 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link android.content.Context}.
    * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
    * @see #centerInside(Context) (android.content.Context)
+   *
+   * @deprecated Use {@link #optionalCenterInside()}
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "optionalCenterInsideTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD optionalCenterInside(@SuppressWarnings("unused") Context context) {
+    return optionalCenterInside();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.CenterInside} to all default types, and
+   * ignores unknown types.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
+   * @see #centerInside()
    */
   @GlideOption(
       staticMethodName = "optionalCenterInsideTransform",
       memoizeStaticMethod = true
   )
-  public CHILD optionalCenterInside(Context context) {
-    return optionalTransform(context, DownsampleStrategy.CENTER_INSIDE, new CenterInside(context));
+  public CHILD optionalCenterInside() {
+    return optionalTransform(DownsampleStrategy.CENTER_INSIDE, new CenterInside());
   }
 
   /**
@@ -603,13 +703,29 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link android.content.Context}.
    * @see #transform(Class, com.bumptech.glide.load.Transformation)
    * @see #optionalCenterInside(Context) (android.content.Context)
+   *
+   * @deprecated Use {@link #centerInside()}}
    */
+  @Deprecated
   @GlideOption(
       staticMethodName = "centerInsideTransform",
       memoizeStaticMethod = true
   )
-  public CHILD centerInside(Context context) {
-    return transform(context, DownsampleStrategy.CENTER_INSIDE, new CenterInside(context));
+  public CHILD centerInside(@SuppressWarnings("unused") Context context) {
+    return centerInside();
+  }
+
+  /**
+   * Applies {@link com.bumptech.glide.load.resource.bitmap.CenterInside} to all default types and
+   * throws an exception if asked to transform an unknown type.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #transform(Class, com.bumptech.glide.load.Transformation)
+   * @see #optionalCenterInside()
+   */
+  public CHILD centerInside() {
+    return transform(DownsampleStrategy.CENTER_INSIDE, new CenterInside());
   }
 
   /**
@@ -620,13 +736,32 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link Context}.
    * @see #optionalTransform(Context, Transformation)
    * @see #circleCrop(Context)
+   *
+   * @deprecated use {@link #optionalCircleCrop()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "optionalCircleCropTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD optionalCircleCrop(@SuppressWarnings("unused") Context context) {
+    return optionalCircleCrop();
+  }
+
+  /**
+   * Applies {@link CircleCrop} to all default types, and ignores unknown types.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #optionalTransform(Transformation)
+   * @see #circleCrop()
    */
   @GlideOption(
       staticMethodName = "optionalCircleCropTransform",
       memoizeStaticMethod = true
   )
-  public CHILD optionalCircleCrop(Context context) {
-    return optionalTransform(context, DownsampleStrategy.CENTER_OUTSIDE, new CircleCrop(context));
+  public CHILD optionalCircleCrop() {
+    return optionalTransform(DownsampleStrategy.CENTER_OUTSIDE, new CircleCrop());
   }
 
   /**
@@ -638,33 +773,57 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    * @param context Any {@link Context}.
    * @see #transform(Class, Transformation)
    * @see #optionalCenterCrop(Context)
+   *
+   * @deprecated Use {@link #circleCrop()}.
+   */
+  @Deprecated
+  @GlideOption(
+      staticMethodName = "circleCropTransform",
+      memoizeStaticMethod = true
+  )
+  public CHILD circleCrop(@SuppressWarnings("unused") Context context) {
+    return circleCrop();
+  }
+
+  /**
+   * Applies {@link CircleCrop} to all default types and throws an exception if asked to transform
+   * an unknown type.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @see #transform(Class, Transformation)
+   * @see #optionalCenterCrop()
    */
   @GlideOption(
       staticMethodName = "circleCropTransform",
       memoizeStaticMethod = true
   )
-  public CHILD circleCrop(Context context) {
-    return transform(context, DownsampleStrategy.CENTER_OUTSIDE, new CircleCrop(context));
+  public CHILD circleCrop() {
+    return transform(DownsampleStrategy.CENTER_INSIDE, new CircleCrop());
   }
 
-  final CHILD optionalTransform(Context context, DownsampleStrategy downsampleStrategy,
+  // calling optionalTransform() on the result of clone() requires greater access.
+  @SuppressWarnings("WeakerAccess")
+  final CHILD optionalTransform(DownsampleStrategy downsampleStrategy,
       Transformation<Bitmap> transformation) {
     if (isAutoCloneEnabled) {
-      return clone().optionalTransform(context, downsampleStrategy, transformation);
+      return clone().optionalTransform(downsampleStrategy, transformation);
     }
 
     downsample(downsampleStrategy);
-    return optionalTransform(context, transformation);
+    return optionalTransform(transformation);
   }
 
-  final CHILD transform(Context context, DownsampleStrategy downsampleStrategy,
+  // calling transform() on the result of clone() requires greater access.
+  @SuppressWarnings("WeakerAccess")
+  final CHILD transform(DownsampleStrategy downsampleStrategy,
       Transformation<Bitmap> transformation) {
     if (isAutoCloneEnabled) {
-      return clone().transform(context, downsampleStrategy, transformation);
+      return clone().transform(downsampleStrategy, transformation);
     }
 
     downsample(downsampleStrategy);
-    return transform(context, transformation);
+    return transform(transformation);
   }
 
   /**
@@ -681,14 +840,37 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    *                       {@link android.graphics.Bitmap}s.
    * @see #optionalTransform(android.content.Context, com.bumptech.glide.load.Transformation)
    * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
+   *
+   * @deprecated See {@link #transform(Transformation)}.
+   */
+  @Deprecated
+  @GlideOption(staticMethodName = "bitmapTransform")
+  public CHILD transform(
+      @SuppressWarnings("unused") Context context, @NonNull Transformation<Bitmap> transformation) {
+    return transform(transformation);
+  }
+
+  /**
+   * Applies the given {@link com.bumptech.glide.load.Transformation} for
+   * {@link android.graphics.Bitmap Bitmaps} to the default types ({@link android.graphics.Bitmap},
+   * {@link android.graphics.drawable.BitmapDrawable}, and
+   * {@link com.bumptech.glide.load.resource.gif.GifDrawable})
+   * and throws an exception if asked to transform an unknown type.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @param transformation Any {@link com.bumptech.glide.load.Transformation} for
+   *                       {@link android.graphics.Bitmap}s.
+   * @see #optionalTransform(com.bumptech.glide.load.Transformation)
+   * @see #optionalTransform(Class, com.bumptech.glide.load.Transformation)
    */
   @GlideOption(staticMethodName = "bitmapTransform")
-  public CHILD transform(Context context, @NonNull Transformation<Bitmap> transformation) {
+  public CHILD transform(@NonNull Transformation<Bitmap> transformation) {
     if (isAutoCloneEnabled) {
-      return clone().transform(context, transformation);
+      return clone().transform(transformation);
     }
 
-    optionalTransform(context, transformation);
+    optionalTransform(transformation);
     isTransformationRequired = true;
     fields |= TRANSFORMATION_REQUIRED;
     return selfOrThrowIfLocked();
@@ -707,18 +889,39 @@ public abstract class BaseRequestOptions<CHILD extends BaseRequestOptions<CHILD>
    *                       {@link android.graphics.Bitmap}s.
    * @see #transform(android.content.Context, com.bumptech.glide.load.Transformation)
    * @see #transform(Class, com.bumptech.glide.load.Transformation)
+   *
+   * @deprecated Use {@link #optionalTransform(Transformation)}
    */
+  @Deprecated
   @GlideOption(staticMethodName = "optionalBitmapTransform")
   public CHILD optionalTransform(Context context, Transformation<Bitmap> transformation) {
+    return optionalTransform(transformation);
+  }
+
+  /**
+   * Applies the given {@link com.bumptech.glide.load.Transformation} for
+   * {@link android.graphics.Bitmap Bitmaps} to the default types ({@link android.graphics.Bitmap},
+   * {@link android.graphics.drawable.BitmapDrawable}, and
+   * {@link com.bumptech.glide.load.resource.gif.GifDrawable}) and ignores unknown types.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @param transformation Any {@link com.bumptech.glide.load.Transformation} for
+   *                       {@link android.graphics.Bitmap}s.
+   * @see #transform(com.bumptech.glide.load.Transformation)
+   * @see #transform(Class, com.bumptech.glide.load.Transformation)
+   */
+  @GlideOption(staticMethodName = "optionalBitmapTransform")
+  public CHILD optionalTransform(Transformation<Bitmap> transformation) {
     if (isAutoCloneEnabled) {
-      return clone().optionalTransform(context, transformation);
+      return clone().optionalTransform(transformation);
     }
 
     optionalTransform(Bitmap.class, transformation);
     // TODO: remove BitmapDrawable decoder and this transformation.
     optionalTransform(BitmapDrawable.class,
-        new BitmapDrawableTransformation(context, transformation));
-    optionalTransform(GifDrawable.class, new GifDrawableTransformation(context, transformation));
+        new BitmapDrawableTransformation(transformation));
+    optionalTransform(GifDrawable.class, new GifDrawableTransformation(transformation));
     return selfOrThrowIfLocked();
   }
 

--- a/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
@@ -120,59 +120,108 @@ public final class RequestOptions extends BaseRequestOptions<RequestOptions> {
   }
 
   /**
-   * Returns a {@link RequestOptions} object with {@link #fitCenter(Context)} set.
+   * Returns a {@link RequestOptions} object with {@link #fitCenter()} set.
+   *
+   * @deprecated Use {@link #fitCenterTransform()}.
    */
+  @Deprecated
   public static RequestOptions fitCenterTransform(Context context) {
+    return fitCenterTransform();
+  }
+
+  /**
+   * Returns a {@link RequestOptions} object with {@link #fitCenter()} set.
+   */
+  public static RequestOptions fitCenterTransform() {
     if (fitCenterOptions == null) {
       fitCenterOptions = new RequestOptions()
-          .fitCenter(context.getApplicationContext())
+          .fitCenter()
           .autoLock();
     }
     return fitCenterOptions;
   }
 
   /**
-   * Returns a {@link RequestOptions} object with {@link #centerInside(Context)} set.
+   * Returns a {@link RequestOptions} object with {@link #centerInside()} set.
+   *
+   * @deprecated Use {@link #centerInsideTransform()}.
    */
+  @Deprecated
   public static RequestOptions centerInsideTransform(Context context) {
+    return centerInsideTransform();
+  }
+
+  /**
+   * Returns a {@link RequestOptions} object with {@link #centerInside()} set.
+   */
+  public static RequestOptions centerInsideTransform() {
     if (centerInsideOptions == null) {
       centerInsideOptions = new RequestOptions()
-              .centerInside(context.getApplicationContext())
+              .centerInside()
               .autoLock();
     }
     return centerInsideOptions;
   }
 
   /**
-   * Returns a {@link RequestOptions} object with {@link #centerCrop(Context)} set.
+   * Returns a {@link RequestOptions} object with {@link #centerCrop()} set.
+   *
+   * @deprecated Use {@link #centerCropTransform()}.
    */
   public static RequestOptions centerCropTransform(Context context) {
+    return centerCropTransform();
+  }
+
+  /**
+   * Returns a {@link RequestOptions} object with {@link #centerCrop()} set.
+   */
+  public static RequestOptions centerCropTransform() {
     if (centerCropOptions == null) {
       centerCropOptions = new RequestOptions()
-          .centerCrop(context.getApplicationContext())
+          .centerCrop()
           .autoLock();
     }
     return centerCropOptions;
   }
 
   /**
-   * Returns a {@link RequestOptions} object with {@link RequestOptions#circleCrop(Context)} set.
+   * Returns a {@link RequestOptions} object with {@link RequestOptions#circleCrop()} set.
+   *
+   * @deprecated Use {@link #circleCropTransform()}.
    */
+  @Deprecated
   public static RequestOptions circleCropTransform(Context context) {
+    return circleCropTransform();
+  }
+
+  /**
+   * Returns a {@link RequestOptions} object with {@link RequestOptions#circleCrop()} set.
+   */
+  public static RequestOptions circleCropTransform() {
     if (circleCropOptions == null) {
       circleCropOptions = new RequestOptions()
-          .circleCrop(context.getApplicationContext())
+          .circleCrop()
           .autoLock();
     }
     return circleCropOptions;
   }
 
   /**
-   * Returns a {@link RequestOptions} object with {@link #transform(Context, Transformation)} set.
+   * Returns a {@link RequestOptions} object with {@link #transform(Transformation)} set.
+   *
+   * @deprecated Use {@link #bitmapTransform(Transformation)}.
    */
-  public static RequestOptions bitmapTransform(Context context,
-      @NonNull Transformation<Bitmap> transformation) {
-    return new RequestOptions().transform(context, transformation);
+  @Deprecated
+  public static RequestOptions bitmapTransform(
+      Context context, @NonNull Transformation<Bitmap> transformation) {
+    return bitmapTransform(transformation);
+  }
+
+  /**
+   * Returns a {@link RequestOptions} object with {@link #transform(Transformation)} set.
+   */
+  public static RequestOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new RequestOptions().transform(transformation);
   }
 
   /**

--- a/library/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/src/test/java/com/bumptech/glide/GlideTest.java
@@ -141,7 +141,7 @@ public class GlideTest {
     MemoryCategory memoryCategory = MemoryCategory.NORMAL;
     Glide glide =
         new GlideBuilder().setMemoryCache(memoryCache).setBitmapPool(bitmapPool)
-            .createGlide(getContext());
+            .build(getContext());
     glide.setMemoryCategory(memoryCategory);
 
     verify(memoryCache).setSizeMultiplier(eq(memoryCategory.getMultiplier()));
@@ -155,7 +155,7 @@ public class GlideTest {
 
     Glide glide =
         new GlideBuilder().setBitmapPool(bitmapPool).setMemoryCache(memoryCache)
-            .createGlide(getContext());
+            .build(getContext());
 
     glide.clearMemory();
 
@@ -170,7 +170,7 @@ public class GlideTest {
 
     Glide glide =
         new GlideBuilder().setBitmapPool(bitmapPool).setMemoryCache(memoryCache)
-            .createGlide(getContext());
+            .build(getContext());
 
     final int level = 123;
 

--- a/library/src/test/java/com/bumptech/glide/load/resource/UnitTransformationTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/UnitTransformationTest.java
@@ -6,24 +6,34 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 
+import android.app.Application;
 import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.tests.KeyAssertions;
 import com.bumptech.glide.tests.Util;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.robolectric.RuntimeEnvironment;
 
 @RunWith(JUnit4.class)
 public class UnitTransformationTest {
+
+  private Application app;
+
+  @Before
+  public void setUp() {
+    app = RuntimeEnvironment.application;
+  }
 
   @Test
   public void testReturnsGivenResource() {
     Resource<Object> resource = mockResource();
     UnitTransformation<Object> transformation = UnitTransformation.get();
-    assertEquals(resource, transformation.transform(resource, 10, 10));
+    assertEquals(resource, transformation.transform(app, resource, 10, 10));
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterCropTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterCropTest.java
@@ -11,7 +11,10 @@ import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import android.app.Application;
 import android.graphics.Bitmap;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.GlideBuilder;
 import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
@@ -19,12 +22,14 @@ import com.bumptech.glide.tests.KeyAssertions;
 import com.bumptech.glide.tests.Util;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
 import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 
@@ -39,6 +44,7 @@ public class CenterCropTest {
   private int bitmapWidth;
   private int bitmapHeight;
   private Bitmap bitmap;
+  private Application context;
 
   @Before
   public void setUp() {
@@ -50,8 +56,15 @@ public class CenterCropTest {
 
     when(pool.get(anyInt(), anyInt(), any(Bitmap.Config.class)))
         .thenAnswer(new Util.CreateBitmap());
+    context = RuntimeEnvironment.application;
+    Glide.init(new GlideBuilder().setBitmapPool(pool).build(context));
 
-    centerCrop = new CenterCrop(pool);
+    centerCrop = new CenterCrop();
+  }
+
+  @After
+  public void tearDown() {
+    Glide.tearDown();
   }
 
   @Test
@@ -59,7 +72,7 @@ public class CenterCropTest {
     reset(pool);
     when(pool.get(anyInt(), anyInt(), any(Bitmap.Config.class))).thenReturn(null);
 
-    centerCrop.transform(resource, 100, 100);
+    centerCrop.transform(context, resource, 100, 100);
 
     verify(pool, never()).put(any(Bitmap.class));
   }
@@ -67,21 +80,21 @@ public class CenterCropTest {
   @Test
   public void testReturnsGivenResourceIfMatchesSizeExactly() {
     Resource<Bitmap> result =
-        centerCrop.transform(resource, bitmapWidth, bitmapHeight);
+        centerCrop.transform(context, resource, bitmapWidth, bitmapHeight);
 
     assertEquals(resource, result);
   }
 
   @Test
   public void testDoesNotRecycleGivenResourceIfMatchesSizeExactly() {
-    centerCrop.transform(resource, bitmapWidth, bitmapHeight);
+    centerCrop.transform(context, resource, bitmapWidth, bitmapHeight);
 
     verify(resource, never()).recycle();
   }
 
   @Test
   public void testDoesNotRecycleGivenResource() {
-    centerCrop.transform(resource, 50, 50);
+    centerCrop.transform(context, resource, 50, 50);
 
     verify(resource, never()).recycle();
   }
@@ -90,7 +103,7 @@ public class CenterCropTest {
   public void testAsksBitmapPoolForArgb8888IfInConfigIsNull() {
     Shadows.shadowOf(bitmap).setConfig(null);
 
-    centerCrop.transform(resource, 10, 10);
+    centerCrop.transform(context, resource, 10, 10);
 
     verify(pool).get(anyInt(), anyInt(), eq(Bitmap.Config.ARGB_8888));
     verify(pool, never()).get(anyInt(), anyInt(), (Bitmap.Config) isNull());
@@ -107,7 +120,7 @@ public class CenterCropTest {
       when(resource.get()).thenReturn(toTransform);
 
       Resource<Bitmap> result =
-          centerCrop.transform(resource, expectedWidth, expectedHeight);
+          centerCrop.transform(context, resource, expectedWidth, expectedHeight);
       Bitmap transformed = result.get();
       assertEquals(expectedWidth, transformed.getWidth());
       assertEquals(expectedHeight, transformed.getHeight());
@@ -125,7 +138,7 @@ public class CenterCropTest {
       when(resource.get()).thenReturn(toTransform);
 
       Resource<Bitmap> result =
-          centerCrop.transform(resource, expectedWidth, expectedHeight);
+          centerCrop.transform(context, resource, expectedWidth, expectedHeight);
       Bitmap transformed = result.get();
       assertEquals(expectedWidth, transformed.getWidth());
       assertEquals(expectedHeight, transformed.getHeight());
@@ -134,7 +147,7 @@ public class CenterCropTest {
 
   @Test
   public void testEquals() throws NoSuchAlgorithmException {
-    KeyAssertions.assertSame(centerCrop, new CenterCrop(pool));
+    KeyAssertions.assertSame(centerCrop, new CenterCrop());
 
     doAnswer(new Util.WriteDigest("other")).when(transformation)
         .updateDiskCacheKey(any(MessageDigest.class));

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CircleCropTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/CircleCropTest.java
@@ -5,13 +5,17 @@ import static org.mockito.Matchers.any;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Mockito.when;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.Rect;
+import com.bumptech.glide.Glide;
+import com.bumptech.glide.GlideBuilder;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.tests.Util;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,7 +37,14 @@ public class CircleCropTest {
     MockitoAnnotations.initMocks(this);
     when(bitmapPool.get(anyInt(), anyInt(), any(Bitmap.Config.class)))
         .thenAnswer(new Util.CreateBitmap());
-    circleCrop = new CircleCrop(RuntimeEnvironment.application);
+    Context context = RuntimeEnvironment.application;
+    Glide.init(new GlideBuilder().setBitmapPool(bitmapPool).build(context));
+    circleCrop = new CircleCrop();
+  }
+
+  @After
+  public void tearDown() {
+    Glide.tearDown();
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
@@ -82,7 +82,6 @@ public class GifFrameLoaderTest {
   private GifFrameLoader createGifFrameLoader(Handler handler) {
     Glide glide = getGlideSingleton();
     return new GifFrameLoader(
-        glide.getContext(),
         glide.getBitmapPool(),
         requestManager,
         gifDecoder,

--- a/library/src/test/java/com/bumptech/glide/request/BaseRequestOptionsTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/BaseRequestOptionsTest.java
@@ -10,7 +10,6 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
-import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
@@ -69,7 +68,7 @@ public class BaseRequestOptionsTest {
 
   @Test
   public void testApplyingDontTransform_overridesTransformations() {
-    options.transform(RuntimeEnvironment.application, transformation);
+    options.transform(transformation);
     options.dontTransform();
     assertThat(options.isTransformationSet()).isFalse();
     assertThat(options.isTransformationRequired()).isFalse();
@@ -79,7 +78,7 @@ public class BaseRequestOptionsTest {
   @Test
   public void testApplyingTransformation_overridesDontTransform() {
     options.dontTransform();
-    options.transform(RuntimeEnvironment.application, transformation);
+    options.transform(transformation);
 
     assertThat(options.isTransformationAllowed()).isTrue();
     assertThat(options.isTransformationRequired()).isTrue();
@@ -88,7 +87,7 @@ public class BaseRequestOptionsTest {
 
   @Test
   public void testApplyingOptions_withDontTransform_overridesTransformations() {
-    options.transform(RuntimeEnvironment.application, transformation);
+    options.transform(transformation);
     TestOptions other = new TestOptions();
     other.dontTransform();
 
@@ -104,7 +103,7 @@ public class BaseRequestOptionsTest {
   public void testApplyingOptions_withTransformation_overridesDontTransform() {
     options.dontTransform();
     TestOptions other = new TestOptions();
-    other.transform(RuntimeEnvironment.application, transformation);
+    other.transform(transformation);
 
     options.apply(other);
 
@@ -126,7 +125,7 @@ public class BaseRequestOptionsTest {
 
   @Test
   public void testApplyingDefaultOptions_withTransform_retrainsTransform() {
-    options.transform(RuntimeEnvironment.application, transformation);
+    options.transform(transformation);
     options.apply(new TestOptions());
 
     assertThat(options.isTransformationAllowed()).isTrue();

--- a/library/src/test/java/com/bumptech/glide/tests/Util.java
+++ b/library/src/test/java/com/bumptech/glide/tests/Util.java
@@ -6,6 +6,7 @@ import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.RETURNS_DEFAULTS;
 import static org.mockito.Mockito.mock;
 
+import android.content.Context;
 import android.graphics.Bitmap;
 import android.os.Build;
 import com.bumptech.glide.load.DataSource;
@@ -42,6 +43,10 @@ public class Util {
 
   public static DataSource isADataSource() {
     return isA(DataSource.class);
+  }
+
+  public static Context anyContext() {
+    return any(Context.class);
   }
 
   /**


### PR DESCRIPTION
Doing so allows us to remove the Context parameter
from all of the various transformation methods
in BaseRequestOptions/RequestOptions. In turn the
lack of a Context should make it easier to memoize
or retain static copies of options.