### PR TITLE
 Move calculating the total iteration count of an animated GIF from GifDrawable to GifDecoder

### DIFF
--- a/library/src/androidTest/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
+++ b/library/src/androidTest/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
@@ -493,29 +493,26 @@ public class GifDrawableTest {
     }
 
     @Test
-    public void testUsesDecoderNetscapeLoopCountIfLoopCountIsLoopIntrinsic() {
+    public void testUsesDecoderTotalIterationCountIfLoopCountIsLoopIntrinsic() {
         final int frameCount = 3;
         final int loopCount = 2;
-        when(gifDecoder.getNetscapeIterationCount()).thenReturn(loopCount);
+        when(gifDecoder.getTotalIterationCount()).thenReturn(loopCount);
         when(gifDecoder.getFrameCount()).thenReturn(frameCount);
         drawable.setLoopCount(GlideDrawable.LOOP_INTRINSIC);
         drawable.setVisible(true, true);
         drawable.start();
 
-        // According to
-        // https://bugs.chromium.org/p/chromium/issues/detail?id=592735#c5,
-        // the image should be displayed for a total of ((netscape loop count) + 1) loops.
-        runLoops(loopCount + 1, frameCount);
+        runLoops(loopCount, frameCount);
 
-        verifyRanLoops(loopCount + 1, frameCount);
+        verifyRanLoops(loopCount, frameCount);
         assertFalse("drawable should be stopped after loop is completed", drawable.isRunning());
     }
 
     @Test
-    public void testLoopsForeverIfLoopCountIsLoopIntrinsicAndNetscapeLoopCountIsZero() {
+    public void testLoopsForeverIfLoopCountIsLoopIntrinsicAndTotalIterationCountIsForever() {
         final int frameCount = 3;
         final int loopCount = 40;
-        when(gifDecoder.getNetscapeIterationCount()).thenReturn(GifHeader.NETSCAPE_ITERATION_COUNT_FOREVER);
+        when(gifDecoder.getTotalIterationCount()).thenReturn(GifDecoder.TOTAL_ITERATION_COUNT_FOREVER);
         when(gifDecoder.getFrameCount()).thenReturn(frameCount);
         drawable.setLoopCount(GlideDrawable.LOOP_INTRINSIC);
         drawable.setVisible(true, true);
@@ -525,22 +522,6 @@ public class GifDrawableTest {
 
         verifyRanLoops(loopCount, frameCount);
         assertTrue("drawable should be still running", drawable.isRunning());
-    }
-
-    @Test
-    public void testLoopsOnceIfLoopCountIsLoopIntrinsicAndNetscapeLoopCountDoesntExist() {
-        final int frameCount = 3;
-        final int loopCount = 1;
-        when(gifDecoder.getNetscapeIterationCount()).thenReturn(GifHeader.NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST);
-        when(gifDecoder.getFrameCount()).thenReturn(frameCount);
-        drawable.setLoopCount(GlideDrawable.LOOP_INTRINSIC);
-        drawable.setVisible(true, true);
-        drawable.start();
-
-        runLoops(loopCount, frameCount);
-
-        verifyRanLoops(loopCount, frameCount);
-        assertFalse("drawable should be stopped after loop is completed", drawable.isRunning());
     }
 
     @Test

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.gifdecoder.GifDecoder.TOTAL_ITERATION_COUNT_FOREVER;
+
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.res.Resources;
@@ -309,23 +311,8 @@ public class GifDrawable extends GlideDrawable implements GifFrameLoader.FrameCa
         }
 
         if (loopCount == LOOP_INTRINSIC) {
-            int netscapeIterationCount = decoder.getNetscapeIterationCount();
-            switch (netscapeIterationCount) {
-                case GifHeader.NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST:
-                    maxLoopCount = 1;
-                    break;
-                case GifHeader.NETSCAPE_ITERATION_COUNT_FOREVER:
-                    maxLoopCount = LOOP_FOREVER;
-                    break;
-                default:
-                    // According to
-                    // https://bugs.chromium.org/p/chromium/issues/detail?id=592735#c5,
-                    // if "Netscape" iteration count is n,
-                    // the image should be displayed for a total of (n + 1) loops
-                    // because most web browsers behave like this.
-                    maxLoopCount = netscapeIterationCount + 1;
-                    break;
-            }
+            int intrinsicCount = decoder.getTotalIterationCount();
+            maxLoopCount = (intrinsicCount == TOTAL_ITERATION_COUNT_FOREVER) ? LOOP_FOREVER : intrinsicCount;
         } else {
             maxLoopCount = loopCount;
         }

--- a/third_party/gif_decoder/src/androidTest/java/com/bumptech/glide/gifdecoder/GifDecoderTest.java
+++ b/third_party/gif_decoder/src/androidTest/java/com/bumptech/glide/gifdecoder/GifDecoderTest.java
@@ -61,6 +61,36 @@ public class GifDecoderTest {
     }
 
     @Test
+    public void testTotalIterationCountIsOneIfNetscapeLoopCountDoesntExist() {
+        GifHeader gifheader = new GifHeader();
+        gifheader.loopCount = GifHeader.NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST;
+        byte[] data = new byte[0];
+        GifDecoder decoder = new GifDecoder(provider);
+        decoder.setData(gifheader, data);
+        assertEquals(1, decoder.getTotalIterationCount());
+    }
+
+    @Test
+    public void testTotalIterationCountIsForeverIfNetscapeLoopCountIsForever() {
+        GifHeader gifheader = new GifHeader();
+        gifheader.loopCount = GifHeader.NETSCAPE_LOOP_COUNT_FOREVER;
+        byte[] data = new byte[0];
+        GifDecoder decoder = new GifDecoder(provider);
+        decoder.setData(gifheader, data);
+        assertEquals(GifDecoder.TOTAL_ITERATION_COUNT_FOREVER, decoder.getTotalIterationCount());
+    }
+
+    @Test
+    public void testTotalIterationCountIsTwoIfNetscapeLoopCountIsOne() {
+        GifHeader gifheader = new GifHeader();
+        gifheader.loopCount = 1;
+        byte[] data = new byte[0];
+        GifDecoder decoder = new GifDecoder(provider);
+        decoder.setData(gifheader, data);
+        assertEquals(2, decoder.getTotalIterationCount());
+    }
+
+    @Test
     public void testAdvanceIncrementsFrameIndex() {
         GifHeader gifheader = new GifHeader();
         gifheader.frameCount = 4;

--- a/third_party/gif_decoder/src/androidTest/java/com/bumptech/glide/gifdecoder/GifHeaderParserTest.java
+++ b/third_party/gif_decoder/src/androidTest/java/com/bumptech/glide/gifdecoder/GifHeaderParserTest.java
@@ -69,7 +69,7 @@ public class GifHeaderParserTest {
         byte[] data = TestUtil.resourceToBytes(getClass(), "gif_netscape_iteration_0.gif");
         parser.setData(data);
         GifHeader header = parser.parseHeader();
-        assertEquals(GifHeader.NETSCAPE_ITERATION_COUNT_FOREVER, header.loopCount);
+        assertEquals(GifHeader.NETSCAPE_LOOP_COUNT_FOREVER, header.loopCount);
     }
 
     @Test
@@ -110,7 +110,7 @@ public class GifHeaderParserTest {
         byte[] data = TestUtil.resourceToBytes(getClass(), "gif_without_netscape_iteration.gif");
         parser.setData(data);
         GifHeader header = parser.parseHeader();
-        assertEquals(GifHeader.NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST, header.loopCount);
+        assertEquals(GifHeader.NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST, header.loopCount);
     }
 
     @Test

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifDecoder.java
@@ -72,6 +72,12 @@ public class GifDecoder {
      * Unable to fully decode the current frame.
      */
     public static final int STATUS_PARTIAL_DECODE = 3;
+
+    /**
+     * The total iteration count which means repeat forever.
+     */
+    public static final int TOTAL_ITERATION_COUNT_FOREVER = 0;
+
     /**
      * max decoder pixel stack size.
      */
@@ -238,29 +244,65 @@ public class GifDecoder {
     }
 
     /**
-     * Gets the "Netscape" iteration count, if any. A count of 0 means repeat indefinitely.
+     * Gets the "Netscape" loop count, if any. A count of 0 means repeat indefinitely.
      *
-     * @deprecated Use {@link #getNetscapeIterationCount()} instead.
-     *             This method cannot distinguish whether the iteration count is 1 or doesn't exist.
-     * @return iteration count if one was specified, else 1.
+     * @deprecated Use {@link #getNetscapeLoopCount()} instead.
+     *             This method cannot distinguish whether the loop count is 1 or doesn't exist.
+     * @return loop count if one was specified, else 1.
      */
     @Deprecated
     public int getLoopCount() {
-        if (header.loopCount == GifHeader.NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST) {
+        if (header.loopCount == GifHeader.NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST) {
             return 1;
         }
         return header.loopCount;
     }
 
     /**
-     * Gets the "Netscape" iteration count, if any. A count of 0 ({@link GifHeader#NETSCAPE_ITERATION_COUNT_FOREVER})
+     * Gets the "Netscape" loop count, if any. A count of 0 ({@link GifHeader#NETSCAPE_LOOP_COUNT_FOREVER})
      * means repeat indefinitely. It must not be a negative value.
+     * <br>
+     * Use {@link #getTotalIterationCount()} to know how many times the animation sequence should be displayed.
      *
-     * @return iteration count if one was specified,
-     *         else -1 ({@link GifHeader#NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST}).
+     * @return loop count if one was specified,
+     *         else -1 ({@link GifHeader#NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST}).
      */
-    public int getNetscapeIterationCount() {
+    public int getNetscapeLoopCount() {
         return header.loopCount;
+    }
+
+    /**
+     * Gets the total count which represents how many times the animation sequence should be displayed.
+     * A count of 0 ({@link #TOTAL_ITERATION_COUNT_FOREVER}) means repeat indefinitely.
+     * It must not be a negative value.
+     * <p>
+     *     The total count is calculated as follows by using {@link #getNetscapeLoopCount()}.
+     *     This behavior is the same as most web browsers.
+     *     <table border='1'>
+     *         <tr class='TableSubHeadingColor'><th>{@code getNetscapeLoopCount()}</th>
+     *             <th>The total count</th></tr>
+     *         <tr><td>{@link GifHeader#NETSCAPE_LOOP_COUNT_FOREVER}</td>
+     *             <td>{@link #TOTAL_ITERATION_COUNT_FOREVER}</td></tr>
+     *         <tr><td>{@link GifHeader#NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST}</td>
+     *             <td>1</td></tr>
+     *         <tr><td>{@code n (n > 0)}</td>
+     *             <td>{@code n +1}</td></tr>
+     *     </table>
+     * </p>
+     *
+     * @see <a href="https://bugs.chromium.org/p/chromium/issues/detail?id=592735#c5">Discussion about
+     *      the iteration count of animated GIFs (Chromium Issue 592735)</a>
+     *
+     * @return total iteration count calculated from "Netscape" loop count.
+     */
+    public int getTotalIterationCount() {
+        if (header.loopCount == GifHeader.NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST) {
+            return 1;
+        }
+        if (header.loopCount == GifHeader.NETSCAPE_LOOP_COUNT_FOREVER) {
+            return TOTAL_ITERATION_COUNT_FOREVER;
+        }
+        return header.loopCount + 1;
     }
 
     /**

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/GifHeader.java
@@ -10,10 +10,10 @@ import java.util.List;
  */
 public class GifHeader {
 
-    /** The "Netscape" iteration count which means loop forever. */
-    public static final int NETSCAPE_ITERATION_COUNT_FOREVER = 0;
-    /** Indicates that this header has no "Netscape" iteration count. */
-    public static final int NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST = -1;
+    /** The "Netscape" loop count which means loop forever. */
+    public static final int NETSCAPE_LOOP_COUNT_FOREVER = 0;
+    /** Indicates that this header has no "Netscape" loop count. */
+    public static final int NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST = -1;
 
     int[] gct = null;
     int status = GifDecoder.STATUS_OK;
@@ -38,7 +38,7 @@ public class GifHeader {
     // Pixel aspect ratio.
     int pixelAspect;
     int bgColor;
-    int loopCount = NETSCAPE_ITERATION_COUNT_DOES_NOT_EXIST;
+    int loopCount = NETSCAPE_LOOP_COUNT_DOES_NOT_EXIST;
 
     public int getHeight() {
         return height;


### PR DESCRIPTION
Refactoring that addresses the comments on #1813

- Rename `getNetscapeIterationCount()` to `getNetscapeLoopCount()` in `GifDecoder`
- Move calculating the total iteration count of an animated GIF from `GifDrawable#setLoopCount()` to `GifDecoder#getTotalIterationCount()`