### PR TITLE
Add vector drawable support via appcompat

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -20,7 +20,7 @@ dependencies {
     compile project(':third_party:disklrucache')
     compile project(':annotation')
     compile "com.android.support:support-v4:${SUPPORT_V4_VERSION}"
-
+    provided "com.android.support:appcompat-v7:${SUPPORT_V7_VERSION}"
     testCompile project(':testutil')
     testCompile 'com.google.guava:guava-testlib:18.0'
     testCompile "com.google.truth:truth:${TRUTH_VERSION}"


### PR DESCRIPTION


## Description

use the support lib in order to inflate resources.  
This allows you to use the ids of VectorDrawables for placeholder, error or fallback calls.
