### PR TITLE
Fix broken Proguard rules

### DIFF
--- a/_posts/2017-03-14-configuration.md
+++ b/_posts/2017-03-14-configuration.md
@@ -61,7 +61,8 @@ annotationProcessor 'com.github.bumptech.glide:compiler:1.0.0-SNAPSHOT'
 
 Finally, you should keep AppGlideModule implementations in your ``proguard.cfg``:
 ```
--keep public class * extends com.bumptech.glide.AppGlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep class com.bumptech.glide.GeneratedAppGlideModuleImpl
 ```
 
 ### Application Options


### PR DESCRIPTION
AppGlideModule resides in the 'module' sub-package and the GeneratedAppGlideModuleImpl needs to be kept as well so that Class.forName("com.bumptech.glide.GeneratedAppGlideModuleImpl") inside Glide.getAnnotationGeneratedGlideModules() won't fail.

People's obfuscated release builds will break otherwise.