### PR TITLE
Fix order of calls in fluent api documentation #1975

### DIFF
--- a/_posts/2015-05-17-getting-started.md
+++ b/_posts/2015-05-17-getting-started.md
@@ -43,9 +43,9 @@ The API is generated in the same package as the [``AppGlideModule``][6] and is n
 
 ```java
 GlideApp.with(fragment)
+   .load(myUrl)
    .placeholder(placeholder)
    .fitCenter()
-   .load(myUrl)
    .into(imageView);
 ```
 

--- a/_posts/2015-05-17-options.md
+++ b/_posts/2015-05-17-options.md
@@ -25,8 +25,8 @@ For example, to apply a [``CenterCrop``][3] [``Transformation``][4], you'd use t
 import static com.bumptech.glide.request.RequestOptions.centerCropTransform;
 
 Glide.with(fragment)
-    .apply(centerCropTransform(context))
     .load(url)
+    .apply(centerCropTransform(context))
     .into(imageView);
 ```
 
@@ -38,8 +38,8 @@ If you'd like to share options consistently in loads across different parts of y
 RequestOptions cropOptions = new RequestOptions().centerCrop(context);
 ...
 Glide.with(fragment)
-    .apply(cropOptions)
     .load(url)
+    .apply(cropOptions)
     .into(imageView);
 ```
 
@@ -115,6 +115,7 @@ RequestBuilders can also be re-used to start multiple loads:
 ```java
 RequestBuilder<Drawable> requestBuilder =
         Glide.with(fragment)
+            .asDrawable()
             .apply(requestOptions);
 
 for (int i = 0; i < numViews; i++) {

--- a/_posts/2015-05-19-placeholders.md
+++ b/_posts/2015-05-19-placeholders.md
@@ -32,8 +32,8 @@ Or:
 
 ```java
 GlideApp.with(fragment)
-  .placeholder(new ColorDrawable(Color.BLACK))
   .load(url)
+  .placeholder(new ColorDrawable(Color.BLACK))
   .into(view);
 ```
 

--- a/_posts/2015-05-26-targets.md
+++ b/_posts/2015-05-26-targets.md
@@ -19,8 +19,8 @@ To make it easier to use custom Targets, the ``into()`` methods return the Targe
 
 ```java
 Target<Bitmap> target = Glide.with(fragment)
-        .load(url)
         .asBitmap()
+        .load(url)
         .into(imageView);
 ...
 // Some time later:

--- a/_posts/2017-04-17-generatedapi.md
+++ b/_posts/2017-04-17-generatedapi.md
@@ -39,9 +39,9 @@ The API is generated in the same package as the [``AppGlideModule``][4] implemen
 
 ```java
 GlideApp.with(fragment)
+   .load(myUrl)
    .placeholder(R.drawable.placeholder)
    .fitCenter()
-   .load(myUrl)
    .into(imageView);
 ```
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
this resolves the documentation issue described here #1975
where calls in fluent api were documented in wrong order, resulting that methods of `RequestBuilder` were called directly on `RequestManage`

<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->