### PR TITLE
fix some documents

### DIFF
--- a/_posts/2015-05-15-download-setup.md
+++ b/_posts/2015-05-15-download-setup.md
@@ -26,7 +26,7 @@ repositories {
 
 dependencies {
     compile 'com.github.bumptech.glide:glide:4.0.0-RC0'
-    compile 'com.github.bumptech.glide:compiler:4.0.0-RC0'
+    annotationProcessor 'com.github.bumptech.glide:compiler:4.0.0-RC0'
     compile 'com.android.support:support-v4:25.3.1'
 }
 ```

--- a/_posts/2017-03-14-configuration.md
+++ b/_posts/2017-03-14-configuration.md
@@ -31,7 +31,7 @@ public final class OkHttpLibraryGlideModule extends LibraryGlideModule {
 
 Using the [``@GlideModule``][5] annotation requires a dependency on Glide's annotations:
 ```groovy
-annotationProcessor 'com.github.bumptech.glide:annotation:4.0.0-RC0'
+compile 'com.github.bumptech.glide:annotations:4.0.0-RC0'
 ```
 
 #### Applications
@@ -55,7 +55,7 @@ public class FlickrGlideModule extends AppGlideModule {
 
 Including Glide's annotation processor requires dependencies on Glide's annotations and the annotation processor:
 ```groovy
-annotationProcessor 'com.github.bumptech.glide:annotation:4.0.0-RC0'
+compile 'com.github.bumptech.glide:annotations:4.0.0-RC0'
 annotationProcessor 'com.github.bumptech.glide:compiler:4.0.0-RC0'
 ```
 


### PR DESCRIPTION
## Description
- fix some incorrect documents on [gh-pages](https://github.com/bumptech/glide/tree/gh-pages)

## Motivation and Context
- `compile` -> `annotationProcessor`
    - `'com.github.bumptech.glide:compiler:4.0.0-RC0'` is depends on annotation processing
    - it must be called with `annotationProcessor`
- `annotation` -> `annotations`
    - first, I tried to integrate `annotationProcessor 'com.github.bumptech.glide:annotation:4.0.0-RC0'` on our project, however "Can't find source error" was happened
    - I tried to fix `annotation` to `annotations` and `annotationProcessor` to `compile`, then the error doesn't appear again
    - I could find correct source