### PR TITLE
Rename getLifecycle into getGlideLifecycle.

### DIFF
--- a/library/src/androidTest/java/com/bumptech/glide/manager/RequestManagerFragmentTest.java
+++ b/library/src/androidTest/java/com/bumptech/glide/manager/RequestManagerFragmentTest.java
@@ -226,7 +226,7 @@ public class RequestManagerFragmentTest {
 
         @Override
         public ActivityFragmentLifecycle getFragmentLifecycle() {
-            return fragment.getLifecycle();
+            return fragment.getGlideLifecycle();
         }
 
         @Override
@@ -284,7 +284,7 @@ public class RequestManagerFragmentTest {
 
         @Override
         public ActivityFragmentLifecycle getFragmentLifecycle() {
-            return supportFragment.getLifecycle();
+            return supportFragment.getGlideLifecycle();
         }
 
         @Override

--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
@@ -53,7 +53,7 @@ public class RequestManagerFragment extends Fragment {
         this.requestManager = requestManager;
     }
 
-    ActivityFragmentLifecycle getLifecycle() {
+    ActivityFragmentLifecycle getGlideLifecycle() {
         return lifecycle;
     }
 

--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -168,7 +168,8 @@ public class RequestManagerRetriever implements Handler.Callback {
         RequestManagerFragment current = getRequestManagerFragment(fm);
         RequestManager requestManager = current.getRequestManager();
         if (requestManager == null) {
-            requestManager = new RequestManager(context, current.getLifecycle(), current.getRequestManagerTreeNode());
+            requestManager = new RequestManager(context,
+                    current.getGlideLifecycle(), current.getRequestManagerTreeNode());
             current.setRequestManager(requestManager);
         }
         return requestManager;
@@ -195,7 +196,8 @@ public class RequestManagerRetriever implements Handler.Callback {
         SupportRequestManagerFragment current = getSupportRequestManagerFragment(fm);
         RequestManager requestManager = current.getRequestManager();
         if (requestManager == null) {
-            requestManager = new RequestManager(context, current.getLifecycle(), current.getRequestManagerTreeNode());
+            requestManager = new RequestManager(context,
+                    current.getGlideLifecycle(), current.getRequestManagerTreeNode());
             current.setRequestManager(requestManager);
         }
         return requestManager;

--- a/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
@@ -51,7 +51,7 @@ public class SupportRequestManagerFragment extends Fragment {
         this.requestManager = requestManager;
     }
 
-    ActivityFragmentLifecycle getLifecycle() {
+    ActivityFragmentLifecycle getGlideLifecycle() {
         return lifecycle;
     }
 


### PR DESCRIPTION
## Motivation and Context
"getLifecycle()" will be added to fragments from support library in 26*,
to avoid name conflicts getLifecycle in requestManagerFragment is
renamed.

