### PR TITLE
Prevent NullPointerException by not setting the static instance

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -167,10 +167,11 @@ public class Glide {
                     for (GlideModule module : modules) {
                         module.applyOptions(applicationContext, builder);
                     }
-                    glide = builder.createGlide();
+                    Glide glide = builder.createGlide();
                     for (GlideModule module : modules) {
                         module.registerComponents(applicationContext, glide);
                     }
+                    Glide.glide = glide;
                 }
             }
         }


### PR DESCRIPTION
until registration is complete

## Description
The Glide instance is not completely thread safe as another thread may get an instance which have not had the components registered

## Motivation and Context
With the current code, Thread 2 may get a glide instance because this.glide != null, but registration in Thread 1 has not completed yet

Thread 1- (Does initialization)
GlideApp.with(context).load(<url>).into(imageView);

Thread 2-
Loader loader = Glide.get(context).getLoaderFactory().buildModelLoader(modelClass, resourceClass);
Glide.with(mAppContext)
                .using(modelLoader, OrbResource.class)
                .from(OrbModel.class)




06-21 14:54:44.301: E/AndroidRuntime(29121): java.lang.NullPointerException: ModelLoader must not be null
06-21 14:54:44.301: E/AndroidRuntime(29121): 	at com.bumptech.glide.provider.FixedLoadProvider.<init>(FixedLoadProvider.java:28)
06-21 14:54:44.301: E/AndroidRuntime(29121): 	at com.bumptech.glide.GenericTranscodeRequest.build(GenericTranscodeRequest.java:42)
06-21 14:54:44.301: E/AndroidRuntime(29121): 	at com.bumptech.glide.GenericTranscodeRequest.<init>(GenericTranscodeRequest.java:60)
06-21 14:54:44.301: E/AndroidRuntime(29121): 	at com.bumptech.glide.RequestManager$GenericModelRequest$GenericTypeRequest.as(RequestManager.java:768)
etc...

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->