### PR TITLE
Fix typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Or Maven:
   <version>r7</version>
 </dependency>
 <dependency>
-  <groupdId>com.github.bumptech.glide</groupId>
+  <groupId>com.github.bumptech.glide</groupId>
   <artifactId>compiler</artifactId>
   <version>4.0.0-RC1</version>
   <optional>true</optional>


### PR DESCRIPTION
The maven dependency had a `<groupdId>` tag instead of `<groupId>`.

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->