### PR TITLE
Add a shortcut to apply multiple transformations on a single request.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
@@ -9,6 +9,7 @@ import android.support.annotation.Nullable;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DecodeFormat;
 import com.bumptech.glide.load.Key;
+import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.load.Option;
 import com.bumptech.glide.load.Options;
 import com.bumptech.glide.load.Transformation;
@@ -871,6 +872,30 @@ public class RequestOptions implements Cloneable {
     }
 
     optionalTransform(transformation);
+    isTransformationRequired = true;
+    fields |= TRANSFORMATION_REQUIRED;
+    return selfOrThrowIfLocked();
+  }
+
+  /**
+   * Applies the given {@link Transformation}s in the given order for
+   * {@link Bitmap Bitmaps} to the default types ({@link Bitmap},
+   * {@link android.graphics.drawable.BitmapDrawable}, and
+   * {@link com.bumptech.glide.load.resource.gif.GifDrawable})
+   * and throws an exception if asked to transform an unknown type.
+   * <p>
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   * @param transformations One or more {@link Transformation}s for {@link Bitmap}s.
+   * @see #optionalTransform(Transformation)
+   * @see #optionalTransform(Class, Transformation)
+   */
+  public RequestOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    if (isAutoCloneEnabled) {
+      return clone().transforms(transformations);
+    }
+
+    optionalTransform(new MultiTransformation<>(transformations));
     isTransformationRequired = true;
     fields |= TRANSFORMATION_REQUIRED;
     return selfOrThrowIfLocked();

--- a/library/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
@@ -3,7 +3,12 @@ package com.bumptech.glide.request;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.graphics.Bitmap;
+
+import com.bumptech.glide.load.MultiTransformation;
 import com.bumptech.glide.load.Transformation;
+import com.bumptech.glide.load.resource.bitmap.CenterCrop;
+import com.bumptech.glide.load.resource.bitmap.CircleCrop;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -75,7 +80,7 @@ public class RequestOptionsTest {
     assertThat(options.getTransformations()).isEmpty();
   }
 
-@Test
+  @Test
   public void testApplyingTransformation_overridesDontTransform() {
     options.dontTransform();
     options.transform(transformation);
@@ -131,5 +136,14 @@ public class RequestOptionsTest {
     assertThat(options.isTransformationAllowed()).isTrue();
     assertThat(options.isTransformationRequired()).isTrue();
     assertThat(options.getTransformations()).containsEntry(Bitmap.class, transformation);
+  }
+
+  @Test
+  public void testApplyMultiTransform() {
+    options.transforms(new CircleCrop(), new CenterCrop());
+    assertThat(options.isTransformationRequired()).isTrue();
+    assertThat(options.getTransformations()).containsKey(Bitmap.class);
+    assertThat(options.getTransformations().get(Bitmap.class))
+      .isInstanceOf(MultiTransformation.class);
   }
 }


### PR DESCRIPTION
## Description
As per discussion here:
https://github.com/bumptech/glide/issues/2086

## Motivation and Context
Makes the possibility to apply multiple transformations easier discoverable via API.

I'd like to have broaden the test context a bit more, but this would have meant to introduce `@VisibleForTesting` getters to internals in a couple of places which I neglected to do for now.