### PR TITLE
Annotate getDataClass and getDataSource from DataFetcher as NonNull

### DIFF
--- a/integration/okhttp/build.gradle
+++ b/integration/okhttp/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     annotationProcessor project(':annotation:compiler')
 
     compile "com.squareup.okhttp:okhttp:2.7.1"
+    compile "com.android.support:support-annotations:{$SUPPORT_V4_VERSION}"
 }
 
 android {

--- a/integration/okhttp/src/main/java/com/bumptech/glide/integration/okhttp/OkHttpStreamFetcher.java
+++ b/integration/okhttp/src/main/java/com/bumptech/glide/integration/okhttp/OkHttpStreamFetcher.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.integration.okhttp;
 
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -89,11 +90,13 @@ public class OkHttpStreamFetcher implements DataFetcher<InputStream> {
     // TODO: call cancel on the client when this method is called on a background thread. See #257
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.REMOTE;

--- a/integration/okhttp3/build.gradle
+++ b/integration/okhttp3/build.gradle
@@ -5,6 +5,7 @@ dependencies {
     annotationProcessor project(':annotation:compiler')
 
     compile "com.squareup.okhttp3:okhttp:${OK_HTTP_VERSION}"
+    compile "com.android.support:support-annotations:{$SUPPORT_V4_VERSION}"
 }
 
 android {

--- a/integration/okhttp3/src/main/java/com/bumptech/glide/integration/okhttp3/OkHttpStreamFetcher.java
+++ b/integration/okhttp3/src/main/java/com/bumptech/glide/integration/okhttp3/OkHttpStreamFetcher.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.integration.okhttp3;
 
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -87,11 +88,13 @@ public class OkHttpStreamFetcher implements DataFetcher<InputStream> {
     }
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.REMOTE;

--- a/integration/volley/build.gradle
+++ b/integration/volley/build.gradle
@@ -3,6 +3,7 @@ apply plugin: 'com.android.library'
 dependencies {
     compile project(':library')
     compile "com.android.volley:volley:${VOLLEY_VERSION}"
+    compile "com.android.support:support-annotations:{$SUPPORT_V4_VERSION}"
     annotationProcessor project(':annotation:compiler')
 
     testCompile project(":testutil")

--- a/integration/volley/src/main/java/com/bumptech/glide/integration/volley/VolleyStreamFetcher.java
+++ b/integration/volley/src/main/java/com/bumptech/glide/integration/volley/VolleyStreamFetcher.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.integration.volley;
 
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.android.volley.AuthFailureError;
 import com.android.volley.NetworkResponse;
@@ -67,11 +68,13 @@ public class VolleyStreamFetcher implements DataFetcher<InputStream> {
     }
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.REMOTE;

--- a/library/src/main/java/com/bumptech/glide/load/data/AssetPathFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/AssetPathFetcher.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.load.data;
 
 import android.content.res.AssetManager;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -54,6 +55,7 @@ public abstract class AssetPathFetcher<T> implements DataFetcher<T> {
     // Do nothing.
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/data/DataFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/DataFetcher.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -91,10 +92,12 @@ public interface DataFetcher<T> {
   /**
    * Returns the class of the data this fetcher will attempt to obtain.
    */
+  @NonNull
   Class<T> getDataClass();
 
   /**
    * Returns the {@link com.bumptech.glide.load.DataSource} this fetcher will return data from.
    */
+  @NonNull
   DataSource getDataSource();
 }

--- a/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorAssetPathFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorAssetPathFetcher.java
@@ -2,6 +2,8 @@ package com.bumptech.glide.load.data;
 
 import android.content.res.AssetManager;
 import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
+
 import java.io.IOException;
 
 /**
@@ -23,6 +25,7 @@ public class FileDescriptorAssetPathFetcher extends AssetPathFetcher<ParcelFileD
     data.close();
   }
 
+  @NonNull
   @Override
   public Class<ParcelFileDescriptor> getDataClass() {
     return ParcelFileDescriptor.class;

--- a/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorLocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorLocalUriFetcher.java
@@ -4,6 +4,8 @@ import android.content.ContentResolver;
 import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -30,6 +32,7 @@ public class FileDescriptorLocalUriFetcher extends LocalUriFetcher<ParcelFileDes
     data.close();
   }
 
+  @NonNull
   @Override
   public Class<ParcelFileDescriptor> getDataClass() {
     return ParcelFileDescriptor.class;

--- a/library/src/main/java/com/bumptech/glide/load/data/HttpUrlFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/HttpUrlFetcher.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import android.util.Log;
 import com.bumptech.glide.Priority;
@@ -154,11 +155,13 @@ public class HttpUrlFetcher implements DataFetcher<InputStream> {
     isCancelled = true;
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.REMOTE;

--- a/library/src/main/java/com/bumptech/glide/load/data/LocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/LocalUriFetcher.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.load.data;
 
 import android.content.ContentResolver;
 import android.net.Uri;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -64,6 +65,7 @@ public abstract class LocalUriFetcher<T> implements DataFetcher<T> {
     // Do nothing.
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/data/StreamAssetPathFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/StreamAssetPathFetcher.java
@@ -1,6 +1,8 @@
 package com.bumptech.glide.load.data;
 
 import android.content.res.AssetManager;
+import android.support.annotation.NonNull;
+
 import java.io.IOException;
 import java.io.InputStream;
 
@@ -22,6 +24,7 @@ public class StreamAssetPathFetcher extends AssetPathFetcher<InputStream> {
     data.close();
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;

--- a/library/src/main/java/com/bumptech/glide/load/data/StreamLocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/StreamLocalUriFetcher.java
@@ -6,6 +6,8 @@ import android.content.UriMatcher;
 import android.net.Uri;
 import android.os.Build;
 import android.provider.ContactsContract;
+import android.support.annotation.NonNull;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -91,6 +93,7 @@ public class StreamLocalUriFetcher extends LocalUriFetcher<InputStream> {
     data.close();
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;

--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/ThumbFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/ThumbFetcher.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Priority;
@@ -96,11 +97,13 @@ public class ThumbFetcher implements DataFetcher<InputStream> {
     // Do nothing.
   }
 
+  @NonNull
   @Override
   public Class<InputStream> getDataClass() {
     return InputStream.class;
   }
 
+  @NonNull
   @Override
   public DataSource getDataSource() {
     return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/ByteArrayLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ByteArrayLoader.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.load.model;
 
+import android.support.annotation.NonNull;
+
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.Options;
@@ -69,11 +71,13 @@ public class ByteArrayLoader<Data> implements ModelLoader<byte[], Data> {
       // Do nothing.
     }
 
+    @NonNull
     @Override
     public Class<Data> getDataClass() {
       return converter.getDataClass();
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/ByteBufferFileLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ByteBufferFileLoader.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -78,11 +79,13 @@ public class ByteBufferFileLoader implements ModelLoader<File, ByteBuffer> {
       // Do nothing.
     }
 
+    @NonNull
     @Override
     public Class<ByteBuffer> getDataClass() {
       return ByteBuffer.class;
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/DataUrlLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/DataUrlLoader.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import android.support.annotation.NonNull;
 import android.util.Base64;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -90,11 +91,13 @@ public final class DataUrlLoader<Data> implements ModelLoader<String, Data> {
       // Do nothing.
     }
 
+    @NonNull
     @Override
     public Class<Data> getDataClass() {
       return reader.getDataClass();
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/FileLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/FileLoader.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.load.model;
 
 import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
 import android.util.Log;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -89,11 +90,13 @@ public class FileLoader<Data> implements ModelLoader<File, Data> {
       // Do nothing.
     }
 
+    @NonNull
     @Override
     public Class<Data> getDataClass() {
       return opener.getDataClass();
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/MediaStoreFileLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/MediaStoreFileLoader.java
@@ -4,6 +4,7 @@ import android.content.Context;
 import android.database.Cursor;
 import android.net.Uri;
 import android.provider.MediaStore;
+import android.support.annotation.NonNull;
 import android.text.TextUtils;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
@@ -81,11 +82,13 @@ public final class MediaStoreFileLoader implements ModelLoader<Uri, File>  {
       // Do nothing.
     }
 
+    @NonNull
     @Override
     public Class<File> getDataClass() {
       return File.class;
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoader.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v4.util.Pools.Pool;
 import com.bumptech.glide.Priority;
@@ -113,11 +114,13 @@ class MultiModelLoader<Model, Data> implements ModelLoader<Model, Data> {
       }
     }
 
+    @NonNull
     @Override
     public Class<Data> getDataClass() {
       return fetchers.get(0).getDataClass();
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return fetchers.get(0).getDataSource();

--- a/library/src/main/java/com/bumptech/glide/load/model/UnitModelLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/UnitModelLoader.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.load.model;
 
+import android.support.annotation.NonNull;
+
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.Options;
@@ -48,12 +50,14 @@ public class UnitModelLoader<Model> implements ModelLoader<Model, Model> {
       // Do nothing.
     }
 
+    @NonNull
     @SuppressWarnings("unchecked")
     @Override
     public Class<Model> getDataClass() {
       return (Class<Model>) resource.getClass();
     }
 
+    @NonNull
     @Override
     public DataSource getDataSource() {
       return DataSource.LOCAL;

--- a/library/src/test/java/com/bumptech/glide/load/data/LocalUriFetcherTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/data/LocalUriFetcherTest.java
@@ -8,6 +8,8 @@ import static org.mockito.Mockito.verify;
 import android.content.ContentResolver;
 import android.content.Context;
 import android.net.Uri;
+import android.support.annotation.NonNull;
+
 import com.bumptech.glide.Priority;
 import java.io.Closeable;
 import java.io.FileNotFoundException;
@@ -75,6 +77,7 @@ public class LocalUriFetcherTest {
       data.close();
     }
 
+    @NonNull
     @Override
     public Class<Closeable> getDataClass() {
       return Closeable.class;


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Annotate getDataClass and getDataSource from DataFetcher as NonNull
Returning null from those will trigger obscure crash in MultiClassKey, annotation helps preventing that.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

Help devs to avoid pitfalls :)
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->