### PR TITLE
Prevent crash due to late calls to DataCallback by clients

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/DataCacheGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DataCacheGenerator.java
@@ -88,11 +88,16 @@ class DataCacheGenerator implements DataFetcherGenerator,
 
   @Override
   public void onDataReady(Object data) {
-    cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.DATA_DISK_CACHE, sourceKey);
+    if (loadData != null) {
+      cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.DATA_DISK_CACHE,
+          sourceKey);
+    }
   }
 
   @Override
   public void onLoadFailed(Exception e) {
-    cb.onDataFetcherFailed(sourceKey, e, loadData.fetcher, DataSource.DATA_DISK_CACHE);
+    if (loadData != null) {
+      cb.onDataFetcherFailed(sourceKey, e, loadData.fetcher, DataSource.DATA_DISK_CACHE);
+    }
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/ResourceCacheGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/ResourceCacheGenerator.java
@@ -97,12 +97,16 @@ class ResourceCacheGenerator implements DataFetcherGenerator,
 
   @Override
   public void onDataReady(Object data) {
-    cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE,
-        currentKey);
+    if (loadData != null) {
+      cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE,
+          currentKey);
+    }
   }
 
   @Override
   public void onLoadFailed(Exception e) {
-    cb.onDataFetcherFailed(currentKey, e, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE);
+    if (loadData != null) {
+      cb.onDataFetcherFailed(currentKey, e, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE);
+    }
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/SourceGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/SourceGenerator.java
@@ -101,6 +101,9 @@ class SourceGenerator implements DataFetcherGenerator,
 
   @Override
   public void onDataReady(Object data) {
+    if (loadData == null || loadData.fetcher == null) {
+      return;
+    }
     DiskCacheStrategy diskCacheStrategy = helper.getDiskCacheStrategy();
     if (data != null && diskCacheStrategy.isDataCacheable(loadData.fetcher.getDataSource())) {
       dataToCache = data;
@@ -115,7 +118,10 @@ class SourceGenerator implements DataFetcherGenerator,
 
   @Override
   public void onLoadFailed(Exception e) {
-    cb.onDataFetcherFailed(originalKey, e, loadData.fetcher, loadData.fetcher.getDataSource());
+    if (loadData != null && loadData.fetcher != null) {
+      cb.onDataFetcherFailed(originalKey, e, loadData.fetcher,
+          loadData.fetcher.getDataSource());
+    }
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoader.java
@@ -125,7 +125,7 @@ class MultiModelLoader<Model, Data> implements ModelLoader<Model, Data> {
 
     @Override
     public void onDataReady(Data data) {
-      if (data != null) {
+      if (data != null && callback != null) {
         callback.onDataReady(data);
       } else {
         startNextOrFail();
@@ -134,7 +134,9 @@ class MultiModelLoader<Model, Data> implements ModelLoader<Model, Data> {
 
     @Override
     public void onLoadFailed(Exception e) {
-      exceptions.add(e);
+      if (exceptions != null) {
+        exceptions.add(e);
+      }
       startNextOrFail();
     }
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Prevent crash due to late calls to DataCallback by clients
(https://github.com/bumptech/glide/issues/2204)
## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

Errors generated by too late calls are really hard to find.
This solution prevent the problem by securing the calls.

Another approach may be to throw a proper error to help devs find the root cause, but as crashing on those points triggers really strange things afterwards it's not really something I can address for now.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->