### PR TITLE
Fix documentation: registerComponents method signature

### DIFF
--- a/_posts/2017-03-14-configuration.md
+++ b/_posts/2017-03-14-configuration.md
@@ -23,7 +23,7 @@ An example [``LibraryGlideModule``][2] from Glide's [OkHttp integration library]
 @GlideModule
 public final class OkHttpLibraryGlideModule extends LibraryGlideModule {
   @Override
-  public void registerComponents(Context context, Registry registry) {
+  public void registerComponents(Context context, Glide glide, Registry registry) {
     registry.replace(GlideUrl.class, InputStream.class, new OkHttpUrlLoader.Factory());
   }
 }
@@ -47,7 +47,7 @@ An example [``AppGlideModule``][1] from Glide's [Flickr sample app][8] looks lik
 @GlideModule
 public class FlickrGlideModule extends AppGlideModule {
   @Override
-  public void registerComponents(Context context, Registry registry) {
+  public void registerComponents(Context context, Glide glide, Registry registry) {
     registry.append(Photo.class, InputStream.class, new FlickrModelLoader.Factory());
   }
 }
@@ -181,7 +181,7 @@ Components are registered using the [``Registry``][28] class. For example, to ad
 @GlideModule
 public class YourAppGlideModule extends AppGlideModule {
   @Override
-  public void registerComponents(Context context, Registry registry) {
+  public void registerComponents(Context context, Glide glide, Registry registry) {
     registry.append(Photo.class, InputStream.class, new CustomModelLoader.Factory());
   }
 }

--- a/_posts/2017-04-20-migrating.md
+++ b/_posts/2017-04-20-migrating.md
@@ -238,8 +238,8 @@ public class GiphyGlideModule implements GlideModule {
   }
 
   @Override
-  public void registerComponents(Context context, Registry registry) {
-    registry.append(Api.GifResult.class, InputStream.class, new GiphyModelLoader.Factory());
+  public void registerComponents(Context context, Glide glide) {
+    glide.register(Api.GifResult.class, InputStream.class, new GiphyModelLoader.Factory());
   }
 }
 ```
@@ -255,7 +255,7 @@ public class GiphyGlideModule extends AppGlideModule {
   }
 
   @Override
-  public void registerComponents(Context context, Registry registry) {
+  public void registerComponents(Context context, Glide glide, Registry registry) {
     registry.append(Api.GifResult.class, InputStream.class, new GiphyModelLoader.Factory());
   }
 }
@@ -279,8 +279,8 @@ public class VolleyGlideModule implements GlideModule {
   }
 
   @Override
-  public void registerComponents(Context context, Registry registry) {
-    registry.replace(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(context));
+  public void registerComponents(Context context, Glide glide) {
+    glide.register(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(context));
   }
 }
 ```
@@ -291,7 +291,7 @@ Can be converted to a ``LibraryGlideModule`` in v4:
 @GlideModule
 public class VolleyLibraryGlideModule extends LibraryGlideModule {
   @Override
-  public void registerComponents(Context context, Registry registry) {
+  public void registerComponents(Context context, Glide glide, Registry registry) {
     registry.replace(GlideUrl.class, InputStream.class, new VolleyUrlLoader.Factory(context));
   }
 }


### PR DESCRIPTION
## Description
Fix documentation related with `LibraryGlideModule.registerComponents`.
Glide v4 `registerComponents` accepts 3 parameters: Context, Glide, and 
Registry ([link](http://bumptech.github.io/glide/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html#registerComponents-android.content.Context-com.bumptech.glide.Glide-com.bumptech.glide.Registry-)) and v3 accepts 2: Context and Glide ([link](https://github.com/bumptech/glide/blob/3.0/library/src/main/java/com/bumptech/glide/module/GlideModule.java)).
