### PR TITLE
dont override the placeholder from xml if user didnt set it in Glide …

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
@@ -45,7 +45,7 @@ public abstract class ImageViewTarget<Z> extends ViewTarget<ImageView, Z> implem
      */
     @Override
     public void onLoadStarted(Drawable placeholder) {
-        if(placeholder != null){
+        if(placeholder != null && view.getDrawable() != null){
         view.setImageDrawable(placeholder);
         }
     }

--- a/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
@@ -45,11 +45,11 @@ public abstract class ImageViewTarget<Z> extends ViewTarget<ImageView, Z> implem
      */
     @Override
     public void onLoadStarted(Drawable placeholder) {
-        if(placeholder != null && view.getDrawable() != null){
-        view.setImageDrawable(placeholder);
+        if (placeholder == null && view.getDrawable() != null) {
+            return;
         }
+        view.setImageDrawable(placeholder);
     }
-
     /**
      * Sets the given {@link android.graphics.drawable.Drawable} on the view using
      * {@link android.widget.ImageView#setImageDrawable(android.graphics.drawable.Drawable)}.

--- a/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ImageViewTarget.java
@@ -45,7 +45,9 @@ public abstract class ImageViewTarget<Z> extends ViewTarget<ImageView, Z> implem
      */
     @Override
     public void onLoadStarted(Drawable placeholder) {
+        if(placeholder != null){
         view.setImageDrawable(placeholder);
+        }
     }
 
     /**


### PR DESCRIPTION
``
@Override
    public void onLoadStarted(Drawable placeholder) {
        if(placeholder != null){
        view.setImageDrawable(placeholder);
        }
    }
``
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
prevent glide for overriding placeholder when user didnt set the placeholder by using
``
placeholder(int res);
``
if user didnt set placeholder in Glide code, it will end up making imageview's drawable to null which leads the imageview to have 0 width and 0 height(if wrap_contnet)
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
if a user has a imageview which set to wrap_content for both width and height(with a placeholder in xml) , and he didnt add placeholder() method , he will end up having a imageview which is 0 width and 0 height. 
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->