### PR TITLE
Override default Encoders

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Registry.java
+++ b/library/src/main/java/com/bumptech/glide/Registry.java
@@ -23,6 +23,8 @@ import com.bumptech.glide.provider.ModelToResourceClassCache;
 import com.bumptech.glide.provider.ResourceDecoderRegistry;
 import com.bumptech.glide.provider.ResourceEncoderRegistry;
 import com.bumptech.glide.util.pool.FactoryPools;
+
+import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -69,7 +71,23 @@ public class Registry {
    * to replace Glide's default {@link Encoder}s.
    */
   public <Data> Registry register(Class<Data> dataClass, Encoder<Data> encoder) {
-    encoderRegistry.add(dataClass, encoder);
+    encoderRegistry.append(dataClass, encoder);
+    return this;
+  }
+
+  /**
+   * Prepends the given {@link Encoder} into the list of available {@link Encoder}s
+   * so that it is attempted before all later and default {@link Encoder}s for the given
+   * data class.
+   *
+   * <p>This method allows you to replace the default {@link Encoder} because it ensures
+   * the registered {@link Encoder} will run first. You can return false in
+   * {@link Encoder#encode(Object, File, Options)} to fall back to the default
+   * {@link Encoder}s if you only want to change the default functionality for certain
+   * data class.
+   */
+  public <Data> Registry prepend(Class<Data> dataClass, Encoder<Data> encoder) {
+    encoderRegistry.prepend(dataClass, encoder);
     return this;
   }
 
@@ -144,7 +162,27 @@ public class Registry {
    */
   public <TResource> Registry register(Class<TResource> resourceClass,
       ResourceEncoder<TResource> encoder) {
-    resourceEncoderRegistry.add(resourceClass, encoder);
+    resourceEncoderRegistry.append(resourceClass, encoder);
+    return this;
+  }
+
+  /**
+   * Registers a new {@link com.bumptech.glide.load.data.DataRewinder.Factory} to handle a
+   * non-default data type that can be rewind to allow for efficient reads of file headers.
+   *
+   * Prepends the given {@link ResourceEncoder} into the list of available {@link ResourceEncoder}s
+   * so that it is attempted before all later and default {@link ResourceEncoder}s for the given
+   * data type.
+   *
+   * <p>This method allows you to replace the default {@link ResourceEncoder} because it ensures
+   * the registered {@link ResourceEncoder} will run first. You can return false in
+   * {@link ResourceEncoder#encode(Object, File, Options)} to fall back to the default
+   * {@link ResourceEncoder}s if you only want to change the default functionality for certain
+   * types of data.
+   */
+  public <TResource> Registry prepend(Class<TResource> resourceClass,
+                                       ResourceEncoder<TResource> encoder) {
+    resourceEncoderRegistry.prepend(resourceClass, encoder);
     return this;
   }
 

--- a/library/src/main/java/com/bumptech/glide/Registry.java
+++ b/library/src/main/java/com/bumptech/glide/Registry.java
@@ -24,7 +24,6 @@ import com.bumptech.glide.provider.ResourceDecoderRegistry;
 import com.bumptech.glide.provider.ResourceEncoderRegistry;
 import com.bumptech.glide.util.pool.FactoryPools;
 
-import java.io.File;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -67,8 +66,7 @@ public class Registry {
    * {@link java.io.FileInputStream} and any other subclass.
    *
    * <p>If multiple {@link Encoder}s are registered for the same type or super type, the
-   * {@link Encoder} that is registered first will be used. As a result, it's not currently possible
-   * to replace Glide's default {@link Encoder}s.
+   * {@link Encoder} that is registered first will be used.
    */
   public <Data> Registry register(Class<Data> dataClass, Encoder<Data> encoder) {
     encoderRegistry.append(dataClass, encoder);
@@ -81,10 +79,8 @@ public class Registry {
    * data class.
    *
    * <p>This method allows you to replace the default {@link Encoder} because it ensures
-   * the registered {@link Encoder} will run first. You can return false in
-   * {@link Encoder#encode(Object, File, Options)} to fall back to the default
-   * {@link Encoder}s if you only want to change the default functionality for certain
-   * data class.
+   * the registered {@link Encoder} will run first. If multiple {@link Encoder}s are registered for
+   * the same type or super type, the {@link Encoder} that is registered first will be used.
    */
   public <Data> Registry prepend(Class<Data> dataClass, Encoder<Data> encoder) {
     encoderRegistry.prepend(dataClass, encoder);
@@ -157,8 +153,7 @@ public class Registry {
    * {@link com.bumptech.glide.load.resource.gif.GifDrawable} and any other subclass.
    *
    * <p>If multiple {@link ResourceEncoder}s are registered for the same type or super type, the
-   * {@link ResourceEncoder} that is registered first will be used. As a result, it's not currently
-   * possible to replace Glide's default {@link ResourceEncoder}s.
+   * {@link ResourceEncoder} that is registered first will be used.
    */
   public <TResource> Registry register(Class<TResource> resourceClass,
       ResourceEncoder<TResource> encoder) {
@@ -175,10 +170,9 @@ public class Registry {
    * data type.
    *
    * <p>This method allows you to replace the default {@link ResourceEncoder} because it ensures
-   * the registered {@link ResourceEncoder} will run first. You can return false in
-   * {@link ResourceEncoder#encode(Object, File, Options)} to fall back to the default
-   * {@link ResourceEncoder}s if you only want to change the default functionality for certain
-   * types of data.
+   * the registered {@link ResourceEncoder} will run first. If multiple {@link ResourceEncoder}s are
+   * registered for the same type or super type, the {@link ResourceEncoder} that is registered
+   * first will be used.
    */
   public <TResource> Registry prepend(Class<TResource> resourceClass,
                                        ResourceEncoder<TResource> encoder) {

--- a/library/src/main/java/com/bumptech/glide/provider/EncoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/provider/EncoderRegistry.java
@@ -7,7 +7,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Contains an unordered list of {@link Encoder}s capable of encoding arbitrary data types.
+ * Contains an ordered list of {@link Encoder}s capable of encoding arbitrary data types.
  */
 public class EncoderRegistry {
   // TODO: This registry should probably contain a put, rather than a list.

--- a/library/src/main/java/com/bumptech/glide/provider/EncoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/provider/EncoderRegistry.java
@@ -24,8 +24,12 @@ public class EncoderRegistry {
     return null;
   }
 
-  public synchronized <T> void add(Class<T> dataClass, Encoder<T> encoder) {
+  public synchronized <T> void append(Class<T> dataClass, Encoder<T> encoder) {
     encoders.add(new Entry<>(dataClass, encoder));
+  }
+
+  public synchronized <T> void prepend(Class<T> dataClass, Encoder<T> encoder) {
+    encoders.add(0, new Entry<>(dataClass, encoder));
   }
 
   private static final class Entry<T> {

--- a/library/src/main/java/com/bumptech/glide/provider/ResourceEncoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/provider/ResourceEncoderRegistry.java
@@ -1,8 +1,10 @@
 package com.bumptech.glide.provider;
 
 import android.support.annotation.Nullable;
+
 import com.bumptech.glide.load.ResourceEncoder;
 import com.bumptech.glide.util.Synthetic;
+
 import java.util.ArrayList;
 import java.util.List;
 
@@ -14,8 +16,12 @@ public class ResourceEncoderRegistry {
   // TODO: this should probably be a put.
   final List<Entry<?>> encoders = new ArrayList<>();
 
-  public synchronized <Z> void add(Class<Z> resourceClass, ResourceEncoder<Z> encoder) {
+  public synchronized <Z> void append(Class<Z> resourceClass, ResourceEncoder<Z> encoder) {
     encoders.add(new Entry<>(resourceClass, encoder));
+  }
+
+  public synchronized <Z> void prepend(Class<Z> resourceClass, ResourceEncoder<Z> encoder) {
+    encoders.add(0, new Entry<>(resourceClass, encoder));
   }
 
   @SuppressWarnings("unchecked")

--- a/library/src/main/java/com/bumptech/glide/provider/ResourceEncoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/provider/ResourceEncoderRegistry.java
@@ -9,7 +9,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 /**
- * Contains an unordered list of {@link ResourceEncoder}s capable of encoding arbitrary resource
+ * Contains an ordered list of {@link ResourceEncoder}s capable of encoding arbitrary resource
  * types.
  */
 public class ResourceEncoderRegistry {


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Override default Encoders for existing data classes. I've added prepend methods to Encoder and ResourceEncoder classes to achieve this.  

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
I want to encrypt images in Glide disk cache. To do that I need to be able to replace Encoders for existing data types like Bitmap, InputStream, Drawable, etc.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->