### PR TITLE
Add the Google's maven repo to get the support-annotations library

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ Or use Gradle:
 ```gradle
 repositories {
   mavenCentral() // jcenter() works as well because it pulls from Maven Central
+  maven { url 'https://maven.google.com' }
 }
 
 dependencies {


### PR DESCRIPTION
If not, Gradle doesn't succeed. And that doesn't help copypasting (the common way to get Glide :·)