### PR TITLE
Avoid redundant placeholder calls when replacing requests.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -635,10 +635,10 @@ public class Glide implements ComponentCallbacks2 {
     return registry;
   }
 
-  void removeFromManagers(Target<?> target) {
+  void removeFromManagers(Target<?> target, boolean setPlaceholder) {
     synchronized (managers) {
       for (RequestManager requestManager : managers) {
-        if (requestManager.untrack(target)) {
+        if (requestManager.untrack(target, setPlaceholder)) {
           return;
         }
       }

--- a/library/src/main/java/com/bumptech/glide/RequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/RequestBuilder.java
@@ -375,7 +375,10 @@ public class RequestBuilder<TranscodeType> implements Cloneable {
       return target;
     }
 
-    requestManager.clear(target);
+    // Avoid setting the placeholder here because it's redundant (the new load will set one) and
+    // doing so invalidates the view and triggers requestLayout() which can make our new request
+    // unnecessarily wait for a layout past, resulting in flashing.
+    requestManager.clear(target, false /*setPlaceholder*/);
     target.setRequest(request);
     requestManager.track(target, request);
 

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -410,12 +410,16 @@ public class RequestManager implements LifecycleListener {
    * @param target The Target to cancel loads for.
    */
   public void clear(@Nullable final Target<?> target) {
+    clear(target, true /*setPlaceholder*/);
+  }
+
+  void clear(@Nullable final Target<?> target, boolean setPlaceholder) {
     if (target == null) {
       return;
     }
 
     if (Util.isOnMainThread()) {
-      untrackOrDelegate(target);
+      untrackOrDelegate(target, setPlaceholder);
     } else {
       mainHandler.post(new Runnable() {
         @Override
@@ -426,21 +430,21 @@ public class RequestManager implements LifecycleListener {
     }
   }
 
-  private void untrackOrDelegate(Target<?> target) {
-    boolean isOwnedByUs = untrack(target);
+  private void untrackOrDelegate(Target<?> target, boolean setPlaceholder) {
+    boolean isOwnedByUs = untrack(target, setPlaceholder);
     if (!isOwnedByUs) {
-      glide.removeFromManagers(target);
+      glide.removeFromManagers(target, setPlaceholder);
     }
   }
 
-  boolean untrack(Target<?> target) {
+  boolean untrack(Target<?> target, boolean setPlaceholder) {
     Request request = target.getRequest();
     // If the Target doesn't have a request, it's already been cleared.
     if (request == null) {
       return true;
     }
 
-    if (requestTracker.clearRemoveAndRecycle(request)) {
+    if (requestTracker.clearRemoveAndRecycle(request, setPlaceholder)) {
       targetTracker.untrack(target);
       target.setRequest(null);
       return true;

--- a/library/src/main/java/com/bumptech/glide/manager/RequestTracker.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestTracker.java
@@ -51,7 +51,7 @@ public class RequestTracker {
    * Stops tracking the given request, clears, and recycles it, and returns {@code true} if the
    * request was removed or {@code false} if the request was not found.
    */
-  public boolean clearRemoveAndRecycle(Request request) {
+  public boolean clearRemoveAndRecycle(Request request, boolean setPlaceholder) {
     if (request == null) {
       return false;
     }
@@ -59,7 +59,7 @@ public class RequestTracker {
     // Avoid short circuiting.
     isOwnedByUs = pendingRequests.remove(request) || isOwnedByUs;
     if (isOwnedByUs) {
-      request.clear();
+      request.clear(setPlaceholder);
       request.recycle();
     }
     return isOwnedByUs;
@@ -105,7 +105,7 @@ public class RequestTracker {
    */
   public void clearRequests() {
     for (Request request : Util.getSnapshot(requests)) {
-      clearRemoveAndRecycle(request);
+      clearRemoveAndRecycle(request, true /*setPlaceholder*/);
     }
     pendingRequests.clear();
   }

--- a/library/src/main/java/com/bumptech/glide/request/Request.java
+++ b/library/src/main/java/com/bumptech/glide/request/Request.java
@@ -11,7 +11,7 @@ public interface Request {
   void begin();
 
   /**
-   * Identical to {@link #clear()} except that the request may later be restarted.
+   * Identical to {@link #clear(boolean)} except that the request may later be restarted.
    */
   void pause();
 
@@ -19,8 +19,11 @@ public interface Request {
    * Prevents any bitmaps being loaded from previous requests, releases any resources held by this
    * request, displays the current placeholder if one was provided, and marks the request as having
    * been cancelled.
+   *
+   * @param setPlaceholder {@code true} if the request should set a placeholder on its
+   * {@link com.bumptech.glide.request.target.Target} after cancelling the request.
    */
-  void clear();
+  void clear(boolean setPlaceholder);
 
   /**
    * Returns true if this request is paused and may be restarted.

--- a/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
@@ -219,7 +219,7 @@ public class RequestFutureTarget<R> implements FutureTarget<R>,
   @Override
   public void run() {
     if (request != null) {
-      request.clear();
+      request.clear(true /*setPlaceholder*/);
       request = null;
     }
   }

--- a/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
+++ b/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
@@ -257,7 +257,7 @@ public final class SingleRequest<R> implements Request,
    *
    * <p> Cancelled requests can be restarted with a subsequent call to {@link #begin()}. </p>
    *
-   * @see #clear()
+   * @see #clear(boolean)
    */
   void cancel() {
     stateVerifier.throwIfRecycled();
@@ -278,7 +278,7 @@ public final class SingleRequest<R> implements Request,
    * @see #cancel()
    */
   @Override
-  public void clear() {
+  public void clear(boolean setPlaceholder) {
     Util.assertMainThread();
     if (status == Status.CLEARED) {
       return;
@@ -288,7 +288,7 @@ public final class SingleRequest<R> implements Request,
     if (resource != null) {
       releaseResource(resource);
     }
-    if (canNotifyStatusChanged()) {
+    if (setPlaceholder && canNotifyStatusChanged()) {
       target.onLoadCleared(getPlaceholderDrawable());
     }
     // Must be after cancel().
@@ -302,7 +302,7 @@ public final class SingleRequest<R> implements Request,
 
   @Override
   public void pause() {
-    clear();
+    clear(true /*setPlaceholder*/);
     status = Status.PAUSED;
   }
 

--- a/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
+++ b/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
@@ -73,7 +73,7 @@ public class ThumbnailRequestCoordinator implements RequestCoordinator,
     // as a layer in a cross fade for example. The only way we know the thumb is not being
     // displayed and is therefore safe to clear is if the thumb request has not yet completed.
     if (!thumb.isComplete()) {
-      thumb.clear();
+      thumb.clear(false /*setPlaceholder*/);
     }
   }
 
@@ -102,14 +102,11 @@ public class ThumbnailRequestCoordinator implements RequestCoordinator,
     thumb.pause();
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
-  public void clear() {
+  public void clear(boolean setPlaceholder) {
     isRunning = false;
-    thumb.clear();
-    full.clear();
+    thumb.clear(setPlaceholder);
+    full.clear(setPlaceholder);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/request/target/Target.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/Target.java
@@ -66,11 +66,17 @@ public interface Target<R> extends LifecycleListener {
   void onResourceReady(R resource, Transition<? super R> transition);
 
   /**
-   * A lifecycle callback that is called when a load is cancelled and its resources are freed.
+   * A lifecycle callback that may be called when a load is cancelled and its resources are freed.
    *
    * <p>You must ensure that any current Drawable received in {@link #onResourceReady(Object,
    * Transition)} is no longer displayed before redrawing the container (usually a View) or
    * changing its visibility.
+   *
+   * <p>If a new load is started into the same or an equivalent {@link Target}, this method may not
+   * be called for the load load to avoid unnecessarily setting a placeholder twice (once for the
+   * cleared load and once for the new load). Setting a placeholder unnecessarily triggers
+   * invalidation and layout calls in View {@link Target}s that can be both expensive and force the
+   * new request to wait for layout to finish before starting the new request.
    *
    * @param placeholder The placeholder drawable to optionally show, or null.
    */

--- a/library/src/test/java/com/bumptech/glide/RequestBuilderTest.java
+++ b/library/src/test/java/com/bumptech/glide/RequestBuilderTest.java
@@ -74,7 +74,7 @@ public class RequestBuilderTest {
 
     getNullModelRequest().into(target);
 
-    verify(requestManager).clear(eq(target));
+    verify(requestManager).clear(eq(target), eq(false));
   }
 
   @Test(expected = NullPointerException.class)

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
@@ -3,6 +3,7 @@ package com.bumptech.glide.load.resource.gif;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyInt;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Matchers.isA;
@@ -223,7 +224,7 @@ public class GifFrameLoaderTest {
     loader.onFrameReady(previous);
     loader.onFrameReady(current);
 
-    verify(previousRequest, never()).clear();
+    verify(previousRequest, never()).clear(anyBoolean());
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/manager/RequestTrackerTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/RequestTrackerTest.java
@@ -3,6 +3,7 @@ package com.bumptech.glide.manager;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -34,22 +35,22 @@ public class RequestTrackerTest {
 
     tracker.clearRequests();
 
-    verify(request).clear();
+    verify(request).clear(true);
     verify(request).recycle();
   }
 
   @Test
   public void testClearRemoveAndRecycle_withNullRequest_doesNothingAndReturnsFalse() {
-    assertThat(tracker.clearRemoveAndRecycle(null)).isFalse();
+    assertThat(tracker.clearRemoveAndRecycle(null, true /*setPlaceholder*/)).isFalse();
   }
 
   @Test
   public void testClearRemoveAndRecycle_withUnTrackedRequest_doesNothingAndReturnsFalse() {
     Request request = mock(Request.class);
 
-    assertThat(tracker.clearRemoveAndRecycle(request)).isFalse();
+    assertThat(tracker.clearRemoveAndRecycle(request, true /*setPlaceholder*/)).isFalse();
 
-    verify(request, never()).clear();
+    verify(request, never()).clear(anyBoolean());
     verify(request, never()).recycle();
   }
 
@@ -58,8 +59,8 @@ public class RequestTrackerTest {
     Request request = mock(Request.class);
     tracker.addRequest(request);
 
-    assertThat(tracker.clearRemoveAndRecycle(request)).isTrue();
-    verify(request).clear();
+    assertThat(tracker.clearRemoveAndRecycle(request, true /*setPlaceholder*/)).isTrue();
+    verify(request).clear(true);
     verify(request).recycle();
   }
 
@@ -67,10 +68,10 @@ public class RequestTrackerTest {
   public void testClearRemoveAndRecycle_withAlreadyRemovedRequest_doesNothingAndReturnsFalse() {
     Request request = mock(Request.class);
     tracker.addRequest(request);
-    tracker.clearRemoveAndRecycle(request);
-    assertThat(tracker.clearRemoveAndRecycle(request)).isFalse();
+    tracker.clearRemoveAndRecycle(request, true /*setPlaceholder*/);
+    assertThat(tracker.clearRemoveAndRecycle(request, true /*setPlaceholder*/)).isFalse();
 
-    verify(request, times(1)).clear();
+    verify(request, times(1)).clear(true);
     verify(request, times(1)).recycle();
   }
 
@@ -78,11 +79,11 @@ public class RequestTrackerTest {
   public void testCanAddAndRemoveRequest() {
     Request request = mock(Request.class);
     tracker.addRequest(request);
-    tracker.clearRemoveAndRecycle(request);
+    tracker.clearRemoveAndRecycle(request, true /*setPlaceholder*/);
 
     tracker.clearRequests();
 
-    verify(request, times(1)).clear();
+    verify(request, times(1)).clear(true);
   }
 
   @Test
@@ -94,8 +95,8 @@ public class RequestTrackerTest {
 
     tracker.clearRequests();
 
-    verify(first).clear();
-    verify(second).clear();
+    verify(first).clear(true);
+    verify(second).clear(true);
   }
 
   @Test
@@ -117,7 +118,7 @@ public class RequestTrackerTest {
     when(request.isComplete()).thenReturn(true);
     tracker.pauseRequests();
 
-    verify(request, never()).clear();
+    verify(request, never()).clear(anyBoolean());
   }
 
   @Test
@@ -155,7 +156,7 @@ public class RequestTrackerTest {
 
     tracker.pauseRequests();
 
-    verify(request, never()).clear();
+    verify(request, never()).clear(anyBoolean());
   }
 
   @Test
@@ -235,7 +236,7 @@ public class RequestTrackerTest {
     Request first = mock(Request.class);
     Request second = mock(Request.class);
 
-    doAnswer(new ClearAndRemoveRequest(second)).when(first).clear();
+    doAnswer(new ClearAndRemoveRequest(second)).when(first).clear(anyBoolean());
 
     tracker.addRequest(mock(Request.class));
     tracker.addRequest(first);
@@ -350,7 +351,7 @@ public class RequestTrackerTest {
 
     @Override
     public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-      tracker.clearRemoveAndRecycle(toRemove);
+      tracker.clearRemoveAndRecycle(toRemove, true /*setPlaceholder*/);
       return null;
     }
   }

--- a/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
@@ -4,6 +4,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.anyLong;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
@@ -101,7 +102,7 @@ public class RequestFutureTargetTest {
   public void testClearsRequestOnRun() {
     future.run();
 
-    verify(request).clear();
+    verify(request).clear(true);
   }
 
   @Test
@@ -109,7 +110,7 @@ public class RequestFutureTargetTest {
     future.onResourceReady(new Object(), null);
     future.cancel(true);
 
-    verify(request, never()).clear();
+    verify(request, never()).clear(anyBoolean());
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
@@ -158,7 +158,7 @@ public class SingleRequestTest {
     SingleRequest<List> request = harness.getRequest();
 
     request.onResourceReady(null, DataSource.DATA_DISK_CACHE);
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
 
     assertFalse(request.isFailed());
   }
@@ -212,7 +212,7 @@ public class SingleRequestTest {
   public void testIsNotCompleteAfterClear() {
     SingleRequest<List> request = harness.getRequest();
     request.onResourceReady(harness.resource, DataSource.REMOTE);
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
 
     assertFalse(request.isComplete());
   }
@@ -220,7 +220,7 @@ public class SingleRequestTest {
   @Test
   public void testIsCancelledAfterClear() {
     SingleRequest<List> request = harness.getRequest();
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
 
     assertTrue(request.isCancelled());
   }
@@ -228,8 +228,8 @@ public class SingleRequestTest {
   @Test
   public void testDoesNotNotifyTargetTwiceIfClearedTwiceInARow() {
     SingleRequest<List> request = harness.getRequest();
-    request.clear();
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
+    request.clear(true /*setPlaceholder*/);
 
     verify(harness.target, times(1)).onLoadCleared(any(Drawable.class));
   }
@@ -316,7 +316,7 @@ public class SingleRequestTest {
     SingleRequest<List> request = harness.getRequest();
 
     request.onResourceReady(harness.resource, DataSource.REMOTE);
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
 
     verify(harness.engine).release(eq(harness.resource));
   }
@@ -437,7 +437,7 @@ public class SingleRequestTest {
   public void testIsNotRunningAfterClear() {
     SingleRequest<List> request = harness.getRequest();
     request.begin();
-    request.clear();
+    request.clear(true /*setPlaceholder*/);
 
     assertFalse(request.isRunning());
   }
@@ -749,6 +749,18 @@ public class SingleRequestTest {
             any(DiskCacheStrategy.class), eq(harness.transformations), anyBoolean(),
             anyBoolean(), any(Options.class), anyBoolean(), eq(Boolean.FALSE), anyBoolean(),
             any(ResourceCallback.class));
+  }
+
+  @Test
+  public void clear_withSetPlaceholderFalse_doesNotSetPlaceholder() {
+    harness.getRequest().clear(false /*setPlaceholder*/);
+    verify(harness.target, never()).onLoadCleared(any(Drawable.class));
+  }
+
+  @Test
+  public void clear_withSetPlaceholderTrue_setsPlaceholder() {
+    harness.getRequest().clear(true /*setPlaceholder*/);
+    verify(harness.target).onLoadCleared(any(Drawable.class));
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/request/ThumbnailRequestCoordinatorTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/ThumbnailRequestCoordinatorTest.java
@@ -3,6 +3,7 @@ package com.bumptech.glide.request;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyBoolean;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.inOrder;
@@ -90,7 +91,7 @@ public class ThumbnailRequestCoordinatorTest {
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocation) throws Throwable {
-        coordinator.clear();
+        coordinator.clear(true /*setPlaceholder*/);
 
         return null;
       }
@@ -103,10 +104,10 @@ public class ThumbnailRequestCoordinatorTest {
 
   @Test
   public void testCallsClearOnRequestsWhenCleared() {
-    coordinator.clear();
+    coordinator.clear(true /*setPlaceholder*/);
     InOrder order = inOrder(thumb, full);
-    order.verify(thumb).clear();
-    order.verify(full).clear();
+    order.verify(thumb).clear(true);
+    order.verify(full).clear(true);
   }
 
   @Test
@@ -290,7 +291,7 @@ public class ThumbnailRequestCoordinatorTest {
   @Test
   public void testClearsThumbRequestOnFullRequestComplete_withNullParent() {
     coordinator.onRequestSuccess(full);
-    verify(thumb).clear();
+    verify(thumb).clear(false);
   }
 
   @Test
@@ -306,20 +307,20 @@ public class ThumbnailRequestCoordinatorTest {
     coordinator = new ThumbnailRequestCoordinator(parent);
     coordinator.setRequests(full, thumb);
     coordinator.onRequestSuccess(full);
-    verify(thumb).clear();
+    verify(thumb).clear(false);
   }
 
   @Test
   public void testDoesNotClearThumbOnThumbRequestComplete() {
     coordinator.onRequestSuccess(thumb);
-    verify(thumb, never()).clear();
+    verify(thumb, never()).clear(anyBoolean());
   }
 
   @Test
   public void testDoesNotClearThumbOnFullComplete_whenThumbIsComplete() {
       when(thumb.isComplete()).thenReturn(true);
       coordinator.onRequestSuccess(full);
-      verify(thumb, never()).clear();
+      verify(thumb, never()).clear(anyBoolean());
   }
 
   @Test


### PR DESCRIPTION
When replacing an old Request with a new Request for a particular View or Target, avoid calling Target#onLoadCleared(Drawable).

The benefit is twofold:
1. We avoid the wasted work of setting a placeholder drawable in the old request (the new request will do so in onLoadStarted anyway).
2. We avoid calling requestLayout on the View, which allows us to use its old size to load the new image, instead of waiting for a layout pass. In some cases this delay can cause flashing while we wait for the unnecessary layout pass to complete.

The problem is that Targets may not get onLoadCleared when they expect to. I'm not sure that anyone really cares about this, but it's definitely a behavior change and if you were relying on onLoadCleared it would be hard to understand why it's not called. This behavior change also only really makes sense for ViewTarget implementations.