### PR TITLE
Change {{ site.url }}/glide into {{ site.baseurl }}.

### DIFF
--- a/_posts/2015-05-15-download-setup.md
+++ b/_posts/2015-05-15-download-setup.md
@@ -102,4 +102,4 @@ See the [generated API][6] page for details.
 [3]: https://source.android.com/source/jack
 [4]: https://android-developers.googleblog.com/2017/03/future-of-java-8-language-feature.html
 [5]: https://developer.android.com/studio/write/java8-support.html
-[6]: {{ site.url }}/glide/doc/generatedapi.html#kotlin
+[6]: {{ site.baseurl }}/doc/generatedapi.html#kotlin

--- a/_posts/2015-05-17-getting-started.md
+++ b/_posts/2015-05-17-getting-started.md
@@ -89,10 +89,10 @@ By calling [``clear()``][4] or ``into(View)`` on the ``View``, you're cancelling
 
 Although the examples we've shown here are for RecyclerView, the same principles apply to ListView as well.
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/Glide.html#with-android.app.Fragment-
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#placeholder-int-
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#fallback-int-
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestManager.html#clear-com.bumptech.glide.request.target.Target-
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
-[7]: {{ site.url }}/glide/doc/generatedapi.html
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/Glide.html#with-android.app.Fragment-
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#placeholder-int-
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#fallback-int-
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestManager.html#clear-com.bumptech.glide.request.target.Target-
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
+[7]: {{ site.baseurl }}/doc/generatedapi.html

--- a/_posts/2015-05-17-options.md
+++ b/_posts/2015-05-17-options.md
@@ -171,19 +171,19 @@ GlideApp.with(context)
   .into(imageView);
 ```
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#apply-com.bumptech.glide.request.RequestOptions-
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/CenterCrop.html
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Transformation.html
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/TransitionOptions.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
-[8]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#thumbnail-com.bumptech.glide.RequestBuilder-
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#transition-com.bumptech.glide.TransitionOptions-
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Option.html
-[12]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
-[14]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/ResourceEncoder.html
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Encoder.html
-[16]: {{ site.url }}/glide/doc/generatedapi.html
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#apply-com.bumptech.glide.request.RequestOptions-
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/CenterCrop.html
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Transformation.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/TransitionOptions.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
+[8]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#thumbnail-com.bumptech.glide.RequestBuilder-
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#transition-com.bumptech.glide.TransitionOptions-
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Option.html
+[12]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
+[14]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/ResourceEncoder.html
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Encoder.html
+[16]: {{ site.baseurl }}/doc/generatedapi.html

--- a/_posts/2015-05-19-placeholders.md
+++ b/_posts/2015-05-19-placeholders.md
@@ -90,7 +90,7 @@ No. Transformations are applied only to the requested resource, not to any place
 ##### Is it ok to use the same Drawable as a placeholder in multiple Views?
 Usually, but not always. Any non-stateful Drawable (like BitmapDrawable) is typically ok to display in multiple views at once. Stateful Drawables however, are typically not safe to display in multiple views at the same time because multiple Views will mutate the state at once. For stateful Drawables, pass in a resource id, or use ``newDrawable()`` to pass in a new copy to each request.
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#placeholder-int-
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#error-int-
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#fallback-int-
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#placeholder-int-
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#error-int-
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#fallback-int-
 [4]: generatedapi.html

--- a/_posts/2015-05-21-transformations.md
+++ b/_posts/2015-05-21-transformations.md
@@ -99,21 +99,21 @@ To ensure any ``Transformation`` you add to your ``RequestOptions`` is applied, 
 
 Glide can apply ``Bitmap`` ``Transformations`` to ``BitmapDrawable``, ``GifDrawable``, and ``Bitmap`` resources, so typically you only need to write and apply ``Bitmap`` ``Transformations``. However, if you add additional resource types you may need to consider sub-classing [``RequestOptions``][15] and always applying a ``Transformation`` for your custom resource type in addition to the built in ``Bitmap`` ``Transformations``.
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Transformation.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/FitCenter.html
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Transformation.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/FitCenter.html
 [3]: options.html
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/CenterCrop.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/CircleCrop.html
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/CenterCrop.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/CircleCrop.html
 [7]: http://developer.android.com/reference/android/widget/ImageView.html
 [8]: http://developer.android.com/reference/android/widget/ImageView.ScaleType.html
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#dontTransform--
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestManager.html#asDrawable--
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#dontTransform--
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestManager.html#asDrawable--
 [12]: http://developer.android.com/reference/android/graphics/drawable/BitmapDrawable.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/gif/GifDrawable.html
-[14]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#transform-java.lang.Class-com.bumptech.glide.load.Transformation-
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[16]: {{ site.url }}/glide/doc/generatedapi.html
-[17]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#transform-java.lang.Class-com.bumptech.glide.load.Transformation-
-[18]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/MultiTransformation.html
-[19]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/request/RequestOptions.html#transforms-com.bumptech.glide.load.Transformation...-
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/gif/GifDrawable.html
+[14]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#transform-java.lang.Class-com.bumptech.glide.load.Transformation-
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[16]: {{ site.baseurl }}/doc/generatedapi.html
+[17]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#transform-java.lang.Class-com.bumptech.glide.load.Transformation-
+[18]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/MultiTransformation.html
+[19]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/request/RequestOptions.html#transforms-com.bumptech.glide.load.Transformation...-

--- a/_posts/2015-05-26-targets.md
+++ b/_posts/2015-05-26-targets.md
@@ -136,17 +136,17 @@ In general Glide provides the fastest and most predictable results when explicit
 ##### Alternatives
 If in any case Glide seems to get View sizes wrong, you can always manually override the size, either by extending [``ViewTarget``][5] and implementing your own logic, or by using the [``override()``][13] method in ``RequestOptions``.
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/ImageViewTarget.html
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-Y-
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-android.widget.ImageView-
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/ViewTarget.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html#getRequest--
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html#setRequest-com.bumptech.glide.request.Request-
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/ImageViewTarget.html
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-Y-
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-android.widget.ImageView-
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/ViewTarget.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html#getRequest--
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html#setRequest-com.bumptech.glide.request.Request-
 [8]: https://developer.android.com/reference/android/view/View.html#getTag()
 [9]: https://developer.android.com/reference/android/view/View.html#setTag(java.lang.Object)
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/BaseTarget.html
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html#getSize-com.bumptech.glide.request.target.SizeReadyCallback-
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/BaseTarget.html
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html#getSize-com.bumptech.glide.request.target.SizeReadyCallback-
 [12]: https://developer.android.com/reference/android/view/ViewTreeObserver.OnPreDrawListener.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#override-int-int-
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#override-int-int-
 

--- a/_posts/2017-01-09-debugging.md
+++ b/_posts/2017-01-09-debugging.md
@@ -99,16 +99,16 @@ The [Android documentation][10] has a lot of good information on tracking and de
 
 To fix memory leaks, remove references to the destroyed ``Fragment`` or ``Activity`` at the appropriate point in the lifecycle to avoid retaining excessive objects. Use the heap dump to help find other ways your application retains memory and remove unnecessary references as you find them. It's often helpful to start by listing the shortest paths excluding weak references to all Bitmap objects (using [MAT][12] or another memory analyzer) and then looking for reference chains that seem suspicious. You can also check to make sure that you have no more than once instance of each ``Activity`` and only the expected number of instances of each ``Fragment`` by searching for them in your memory analyzer.
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/GlideBuilder.html#setLogLevel-int-
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-android.widget.ImageView-
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#submit-int-int-
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/Target.html#getSize-com.bumptech.glide.request.target.SizeReadyCallback-
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/target/ViewTarget.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#override-int-int-
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestListener.html
-[8]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#listener-com.bumptech.glide.request.RequestListener-
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/GlideBuilder.html#setLogLevel-int-
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-android.widget.ImageView-
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#submit-int-int-
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/Target.html#getSize-com.bumptech.glide.request.target.SizeReadyCallback-
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/target/ViewTarget.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#override-int-int-
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestListener.html
+[8]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#listener-com.bumptech.glide.request.RequestListener-
 [9]: https://github.com/bumptech/glide/blob/6b137c2b1d4b2ab187ea2aa56834dea039daa090/library/src/main/java/com/bumptech/glide/load/engine/Engine.java#L33
 [10]: https://developer.android.com/studio/profile/investigate-ram.html
 [11]: https://developer.android.com/studio/profile/investigate-ram.html#HeapDump
 [12]: http://www.eclipse.org/mat/
-[13]: {{ site.url }}/glide/doc/caching.html
+[13]: {{ site.baseurl }}/doc/caching.html

--- a/_posts/2017-02-13-transitions.md
+++ b/_posts/2017-02-13-transitions.md
@@ -64,28 +64,28 @@ you can inspect the [``DataSource``][23] passed in to the [``build()``][24] meth
 
 For an example, see [``DrawableCrossFadeFactory``][25].
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/transition/Transition.html
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/transition/Transition.html
 [2]: https://developer.android.com/reference/android/widget/ViewSwitcher.html
 [3]: https://developer.android.com/reference/android/widget/ImageView.html
 [4]: https://developer.android.com/reference/android/widget/ViewSwitcher.html#getNextView()
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestListener.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestListener.html
 [6]: https://developer.android.com/reference/android/widget/ViewAnimator.html#showNext()
 [7]: https://developer.android.com/training/animation/crossfade.html
 [8]: https://developer.android.com/reference/android/graphics/drawable/TransitionDrawable.html
 [9]: https://developer.android.com/reference/android/graphics/drawable/TransitionDrawable.html#setCrossFadeEnabled(boolean)
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/transition/DrawableCrossFadeFactory.html
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/TransitionOptions.html#transition-com.bumptech.glide.request.transition.TransitionFactory-
-[12]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/TransitionOptions.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#transition-com.bumptech.glide.TransitionOptions-
-[14]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
-[16]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
-[17]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/GenericTransitionOptions.html
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/transition/DrawableCrossFadeFactory.html
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/TransitionOptions.html#transition-com.bumptech.glide.request.transition.TransitionFactory-
+[12]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/TransitionOptions.html
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#transition-com.bumptech.glide.TransitionOptions-
+[14]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
+[16]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
+[17]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/GenericTransitionOptions.html
 [18]: /glide/doc/options.html#transitionoptions
 [19]: /glide/doc/targets.html#targets-and-automatic-cancellation
-[20]: {{ site.url }}/glide/transitions#custom-transitions
-[21]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/transition/TransitionFactory.html
-[22]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html#with-com.bumptech.glide.request.transition.TransitionFactory-
-[23]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/DataSource.html
-[24]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/transition/TransitionFactory.html#build-com.bumptech.glide.load.DataSource-boolean-
+[20]: {{ site.baseurl }}/transitions#custom-transitions
+[21]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/transition/TransitionFactory.html
+[22]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html#with-com.bumptech.glide.request.transition.TransitionFactory-
+[23]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/DataSource.html
+[24]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/transition/TransitionFactory.html#build-com.bumptech.glide.load.DataSource-boolean-
 [25]: https://github.com/bumptech/glide/blob/8f22bd9b82349bf748e335b4a31e70c9383fb15a/library/src/main/java/com/bumptech/glide/request/transition/DrawableCrossFadeFactory.java#L35 

--- a/_posts/2017-03-14-configuration.md
+++ b/_posts/2017-03-14-configuration.md
@@ -350,39 +350,39 @@ public final class MyAppGlideModule extends AppGlideModule {
 }
 ```
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideModule.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/compiler/GlideAnnotationProcessor.html
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideModule.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/compiler/GlideAnnotationProcessor.html
 [7]: https://github.com/bumptech/glide/blob/master/integration/okhttp3/src/main/java/com/bumptech/glide/integration/okhttp3/OkHttpLibraryGlideModule.java
 [8]: https://github.com/bumptech/glide/blob/master/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrGlideModule.java
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/MemoryCache.html
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/LruResourceCache.html
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/MemorySizeCalculator.html
-[12]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html#applyOptions-android.content.Context-com.bumptech.glide.GlideBuilder-
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapper.html
-[14]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.html
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.Factory.html#DEFAULT_DISK_CACHE_SIZE
-[16]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.Factory.html#DEFAULT_DISK_CACHE_DIR
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/MemoryCache.html
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/LruResourceCache.html
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/MemorySizeCalculator.html
+[12]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html#applyOptions-android.content.Context-com.bumptech.glide.GlideBuilder-
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapper.html
+[14]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.html
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.Factory.html#DEFAULT_DISK_CACHE_SIZE
+[16]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.Factory.html#DEFAULT_DISK_CACHE_DIR
 [17]: https://developer.android.com/reference/android/content/Context.html#getCacheDir()
 [18]: {{ site.url}}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.Factory.html
 [19]: https://developer.android.com/reference/android/os/StrictMode.html
-[20]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/Excludes.html
-[21]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/GlideModule.html
-[22]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html#isManifestParsingEnabled--
-[23]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/ModelLoaderFactory.html
-[24]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
-[25]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Encoder.html
-[26]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/transcode/ResourceTranscoder.html
-[27]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/ResourceEncoder.html
-[28]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/Registry.html
-[29]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#load-java.lang.Object-
-[30]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestManager.html#as-java.lang.Class-
-[31]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html#registerComponents-android.content.Context-com.bumptech.glide.Glide-com.bumptech.glide.Registry-
-[32]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/stream/BaseGlideUrlLoader.html
-[33]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/request/RequestOptions.html
-[34]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/RequestManager.html
-[35]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/RequestManager.html#applyDefaultRequestOptions-com.bumptech.glide.request.RequestOptions-
-[36]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/RequestManager.html#setDefaultRequestOptions-com.bumptech.glide.request.RequestOptions-
+[20]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/Excludes.html
+[21]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/GlideModule.html
+[22]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html#isManifestParsingEnabled--
+[23]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/ModelLoaderFactory.html
+[24]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/ResourceDecoder.html
+[25]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Encoder.html
+[26]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/transcode/ResourceTranscoder.html
+[27]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/ResourceEncoder.html
+[28]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/Registry.html
+[29]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#load-java.lang.Object-
+[30]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestManager.html#as-java.lang.Class-
+[31]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html#registerComponents-android.content.Context-com.bumptech.glide.Glide-com.bumptech.glide.Registry-
+[32]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/stream/BaseGlideUrlLoader.html
+[33]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/request/RequestOptions.html
+[34]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/RequestManager.html
+[35]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/RequestManager.html#applyDefaultRequestOptions-com.bumptech.glide.request.RequestOptions-
+[36]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/RequestManager.html#setDefaultRequestOptions-com.bumptech.glide.request.RequestOptions-

--- a/_posts/2017-04-17-generatedapi.md
+++ b/_posts/2017-04-17-generatedapi.md
@@ -221,16 +221,16 @@ Methods annotated with ``GlideType`` must take a [``RequestBuilder<T>``][2] as t
 
 
 [1]: https://docs.oracle.com/javase/8/docs/api/javax/annotation/processing/Processor.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideModule.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideExtension.html
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideOption.html
-[8]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideType.html
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Option.html
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestManager.html
-[12]: {{ site.url }}/glide/doc/download-setup.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideModule.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideExtension.html
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideOption.html
+[8]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideType.html
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Option.html
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestManager.html
+[12]: {{ site.baseurl }}/doc/download-setup.html
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
 [14]: https://kotlinlang.org/docs/reference/kapt.html

--- a/_posts/2017-04-20-migrating.md
+++ b/_posts/2017-04-20-migrating.md
@@ -423,37 +423,37 @@ The [``using()``][23] API was removed in Glide 4 to encourage users to [register
 
 To make sure you only use your ``ModelLoader`` for certain models, implement ``handles()`` as shown above to inspect each model and return true only if your ``ModelLoader`` should be used.
 
-[1]: {{ site.url }}/glide/javadocs/360/com/bumptech/glide/module/GlideModule.html
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
+[1]: {{ site.baseurl }}/javadocs/360/com/bumptech/glide/module/GlideModule.html
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/AppGlideModule.html
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/module/LibraryGlideModule.html
 [4]: configuration.html
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#thumbnail-com.bumptech.glide.RequestBuilder-
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#listener-com.bumptech.glide.request.RequestListener-
-[8]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-Y-
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#preload-int-int-
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#thumbnail-com.bumptech.glide.RequestBuilder-
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#listener-com.bumptech.glide.request.RequestListener-
+[8]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#into-Y-
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#preload-int-int-
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
 [11]: generatedapi.html
-[12]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/annotation/GlideExtension.html
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
-[14]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/GenericTransitionOptions.html
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
-[16]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
-[17]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/TransitionOptions.html#dontTransition--
+[12]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/annotation/GlideExtension.html
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
+[14]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/GenericTransitionOptions.html
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.html
+[16]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.html
+[17]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/TransitionOptions.html#dontTransition--
 [18]: https://developer.android.com/reference/android/graphics/drawable/Drawable.html
 [19]: https://developer.android.com/reference/android/graphics/drawable/BitmapDrawable.html
 [20]: https://developer.android.com/reference/android/graphics/drawable/Animatable.html
-[21]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestListener.html
-[22]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestManager.html
-[23]: {{ site.url }}/glide/javadocs/380/com/bumptech/glide/RequestManager.html#using(com.bumptech.glide.load.model.stream.StreamByteArrayLoader)
-[24]: {{ site.url }}/glide/doc/generatedapi.html
-[25]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/RequestBuilder.html#load-java.lang.Object-
-[26]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
-[27]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/model/ModelLoader.LoadData.html
-[28]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/load/Transformation.html
-[29]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/request/RequestOptions.html#transforms-com.bumptech.glide.load.Transformation...-
-[30]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/load/DecodeFormat.html
-[31]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/load/DecodeFormat.html#PREFER_RGB_565
+[21]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestListener.html
+[22]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestManager.html
+[23]: {{ site.baseurl }}/javadocs/380/com/bumptech/glide/RequestManager.html#using(com.bumptech.glide.load.model.stream.StreamByteArrayLoader)
+[24]: {{ site.baseurl }}/doc/generatedapi.html
+[25]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/RequestBuilder.html#load-java.lang.Object-
+[26]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/ModelLoader.html
+[27]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/model/ModelLoader.LoadData.html
+[28]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/load/Transformation.html
+[29]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/request/RequestOptions.html#transforms-com.bumptech.glide.load.Transformation...-
+[30]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/load/DecodeFormat.html
+[31]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/load/DecodeFormat.html#PREFER_RGB_565
 [32]: https://developer.android.com/reference/android/graphics/Bitmap.Config.html#RGB_565
 [33]: https://developer.android.com/reference/android/graphics/Bitmap.Config.html#ARGB_8888
 [34]: download-setup.html

--- a/_posts/2017-05-10-recyclerview.md
+++ b/_posts/2017-05-10-recyclerview.md
@@ -247,13 +247,13 @@ Glide's [sample apps][11] contain a couple of example usages of [``RecyclerViewP
 * [https://github.com/bumptech/glide/tree/master/integration/recyclerview][1]
 
 [1]: https://github.com/bumptech/glide/tree/master/integration/recyclerview
-[2]: {{ site.url }}/glide/javadocs/420/com/bumptech/glide/integration/recyclerview/RecyclerViewPreloader.html
-[3]: {{ site.url }}/glide/javadocs/420/com/bumptech/glide/ListPreloader.PreloadSizeProvider.html
-[4]: {{ site.url }}/glide/javadocs/420/com/bumptech/glide/util/ViewPreloadSizeProvider.html
-[5]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/util/FixedPreloadSizeProvider.html
-[6]: {{ site.url }}/glide/javadocs/410/com/bumptech/glide/ListPreloader.PreloadModelProvider.html
+[2]: {{ site.baseurl }}/javadocs/420/com/bumptech/glide/integration/recyclerview/RecyclerViewPreloader.html
+[3]: {{ site.baseurl }}/javadocs/420/com/bumptech/glide/ListPreloader.PreloadSizeProvider.html
+[4]: {{ site.baseurl }}/javadocs/420/com/bumptech/glide/util/ViewPreloadSizeProvider.html
+[5]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/util/FixedPreloadSizeProvider.html
+[6]: {{ site.baseurl }}/javadocs/410/com/bumptech/glide/ListPreloader.PreloadModelProvider.html
 [7]: /glide/doc/debugging.html#unexpected-cache-misses
-[8]: {{ site.url }}/glide/javadocs/420/com/bumptech/glide/integration/recyclerview/RecyclerToListViewScrollListener.html
+[8]: {{ site.baseurl }}/javadocs/420/com/bumptech/glide/integration/recyclerview/RecyclerToListViewScrollListener.html
 [9]: https://developer.android.com/reference/android/support/v7/widget/LinearLayoutManager.html
 [10]: https://developer.android.com/reference/android/support/v7/widget/RecyclerView.OnScrollListener.html
 [11]: /glide/ref/samples.html

--- a/_posts/2017-05-24-caching.md
+++ b/_posts/2017-05-24-caching.md
@@ -244,27 +244,27 @@ new AsyncTask<Void, Void, Void> {
 
 
 
-[1]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#signature-com.bumptech.glide.load.Key-
-[2]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Option.html
-[3]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/signature/MediaStoreSignature.html
-[4]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/signature/ObjectKey.html
-[5]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/Key.html
-[6]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#diskCacheStrategy-com.bumptech.glide.load.engine.DiskCacheStrategy-
-[7]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#NONE
-[8]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#onlyRetrieveFromCache-boolean-
-[9]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html
-[10]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html
-[11]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#diskCacheStrategy-com.bumptech.glide.load.engine.DiskCacheStrategy-
-[12]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#AUTOMATIC
-[13]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.html
-[14]: {{ site.url }}/glide/doc/configuration.html#disk-cache
-[15]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/request/RequestOptions.html#skipMemoryCache-boolean-
-[16]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#NONE
-[17]: {{ site.url }}/glide/doc/caching.html#cache-invalidation
-[18]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPool.html
-[19]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/Glide.html#clearMemory--
+[1]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#signature-com.bumptech.glide.load.Key-
+[2]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Option.html
+[3]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/signature/MediaStoreSignature.html
+[4]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/signature/ObjectKey.html
+[5]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/Key.html
+[6]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#diskCacheStrategy-com.bumptech.glide.load.engine.DiskCacheStrategy-
+[7]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#NONE
+[8]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#onlyRetrieveFromCache-boolean-
+[9]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html
+[10]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html
+[11]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#diskCacheStrategy-com.bumptech.glide.load.engine.DiskCacheStrategy-
+[12]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#AUTOMATIC
+[13]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/cache/DiskCache.html
+[14]: {{ site.baseurl }}/doc/configuration.html#disk-cache
+[15]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/request/RequestOptions.html#skipMemoryCache-boolean-
+[16]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/DiskCacheStrategy.html#NONE
+[17]: {{ site.baseurl }}/doc/caching.html#cache-invalidation
+[18]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPool.html
+[19]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/Glide.html#clearMemory--
 [20]: http://d.android.com/reference/android/content/ComponentCallbacks2.html?is-external=true
-[21]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/Glide.html#setMemoryCategory-com.bumptech.glide.MemoryCategory-
-[22]: {{ site.url }}/glide/doc/configuration.html#memory-cache
-[23]: {{ site.url }}/glide/javadocs/400/com/bumptech/glide/Glide.html#clearDiskCache--
-[24]: {{ site.url }}/glide/doc/configuration.html#disk-cache
+[21]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/Glide.html#setMemoryCategory-com.bumptech.glide.MemoryCategory-
+[22]: {{ site.baseurl }}/doc/configuration.html#memory-cache
+[23]: {{ site.baseurl }}/javadocs/400/com/bumptech/glide/Glide.html#clearDiskCache--
+[24]: {{ site.baseurl }}/doc/configuration.html#disk-cache


### PR DESCRIPTION
## Description
Hello @sjudd , I've changed all links that started with `{{ site.url}}/glide` to `{{ site.baseurl }}`.
**This change does not affect glide official documentation pages, but it solves a problem when migrating to other languages**. The problem detail is described as below.

## Motivation and Context
In current version of glide documentation, there are two way to link to javadoc:
1. [javadocs.md](https://raw.githubusercontent.com/bumptech/glide/gh-pages/_posts/2015-05-17-javadocs.md)
```Text
[1]:{{ site.baseurl }}{% link /javadocs/410/index.html %}
```
2. [download-setup.md](https://raw.githubusercontent.com/bumptech/glide/gh-pages/_posts/2015-05-15-download-setup.md) 
```Text
[6]: {{ site.url }}/glide/doc/generatedapi.html#kotlin
```

Both of them works well in sjudd.io and bumptech.io, since the doc site is happen to be the same as hardcoded `glide`.

Unfoturenately our Simplified Chinese project is named `glide-docs-cn`, and the gh-pages is not enabled on the fork, we'll get a **404** error while trying  to click the second type of links. But `site.baseurl` will work as expected.

In hack maybe I can copy a `javadocs` directory in my `glide` fork, or even change the Chinese doc repo to `glide`, but obviously that changes the semantic of fork repo and bringing new maintain costs. 

So I just change those links and have tried it in both local and github pages, and by the way suggest to use baseurl pattern in the future docs. 

If any trouble this PR will introduce, please figure out, thank you very much.