### PR TITLE
Add multi language documentation link support.

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -17,6 +17,11 @@ navigation: 2
 # URL to source code, used in _includes/footer.html
 codeurl: 'https://github.com/bumptech/glide'
 
+# URL to documentation for other language(s), used in _includes/header.html
+otherlang: [
+  ['中文版', 'https://muyangmin.github.io/glide-docs-cn']
+]
+
 # Default categories (in order) to appear in the navigation
 sections: [
     ['doc', 'Documentation'],

--- a/_includes/header.html
+++ b/_includes/header.html
@@ -1,4 +1,10 @@
 <h4><a class=brand href="{{ site.baseurl }}/">{{ site.title }}</a>
     {% if site.subtitle %}<small>{{ site.subtitle }}</small>{% endif %}
+
+    {% if site.otherlang %}
+        {% for language in site.otherlang %}
+        &nbsp;&nbsp;<small><a href="{{ language[1] }}">{{ language[0] }}</a></small>
+        {% endfor %}
+    {% endif %}
 </h4>
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->
Hi, I've add a link to Chinese doc in header.html, as is advised in #2405 . I think maybe this is the best position to put global links. 

Also for future *possible* other language translations, I treat the config as an array(as shown below):
```YAML
# in config.yml
# URL to documentation for other language(s), used in _includes/header.html
otherlang: [
  ['中文版', 'https://muyangmin.github.io/glide-docs-cn']
]
```
To add another language version, just add a row in this file is enough.

<!-- ## Description -->
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

<!--## Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->