### PR TITLE
Include directions to include kotlin-kapt plugin

### DIFF
--- a/_posts/2015-05-15-download-setup.md
+++ b/_posts/2015-05-15-download-setup.md
@@ -94,6 +94,11 @@ dependencies {
   kapt 'com.github.bumptech.glide:compiler:4.1.1'
 }
 ```
+Note that you must also include the ``kotlin-kapt`` plugin in your ``build.gradle`` file:
+
+```groovy
+apply plugin: 'kotlin-kapt'
+```
 
 See the [generated API][6] page for details.
 


### PR DESCRIPTION
## Description
`kapt 'com.github.bumptech.glide:compiler:4.1.1'` will not work without including the `kotlin-kapt` plugin and this has [caused confusion](https://github.com/bumptech/glide/issues/2089) for some users, including msyelf.

## Motivation and Context
By adding this to the documentation, it will ensure less confusion for Glide Kotlin users, a demographic which will only increase with the ongoing adoption of Kotlin and ensure a good experience of Glide users.