### PR TITLE
Update proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Depending on your ProGuard (DexGuard) config and usage, you may need to include 
 
 ```pro
 -keep public class * implements com.bumptech.glide.module.GlideModule
--keep public class * extends com.bumptech.glide.AppGlideModule
+-keep public class * extends com.bumptech.glide.module.AppGlideModule
 -keep public enum com.bumptech.glide.load.resource.bitmap.ImageHeaderParser$** {
   **[] $VALUES;
   public *;


### PR DESCRIPTION
## Description
It seems that was wrong class name and warning says
```
Note: the configuration refers to the unknown class 'com.bumptech.glide.AppGlideModule'
      Maybe you meant the fully qualified name 'com.bumptech.glide.module.AppGlideModule'?
```
