### PR TITLE
Add reminder for applying kotlin-kapt in build.gradle in generatedapi

### DIFF
--- a/_posts/2017-04-17-generatedapi.md
+++ b/_posts/2017-04-17-generatedapi.md
@@ -73,6 +73,11 @@ If you're using Kotlin you can:
      kapt 'com.github.bumptech.glide:compiler:4.2.0'
    }
    ```
+  Note that you must also include the ``kotlin-kapt`` plugin in your ``build.gradle`` file:
+
+   ```groovy
+   apply plugin: 'kotlin-kapt'
+   ```
 
    To use ``kapt``, see the [official documentation][14].
 


### PR DESCRIPTION
Most of the people checked how to use Generated API from this page like me.
However, only "Download & Setup" mentioned about applying kotlin-kapt plugin for Kotlin.
Without that plugin, GlideApp would not generate.