### PR TITLE
Fix crash because of wrong executor being created

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
@@ -140,7 +140,7 @@ public final class GlideExecutor extends ThreadPoolExecutor {
    */
   public static GlideExecutor newSourceExecutor(
           UncaughtThrowableStrategy uncaughtThrowableStrategy) {
-    return newDiskCacheExecutor(DEFAULT_DISK_CACHE_EXECUTOR_THREADS,
+    return newSourceExecutor(DEFAULT_DISK_CACHE_EXECUTOR_THREADS,
                                 DEFAULT_DISK_CACHE_EXECUTOR_NAME, uncaughtThrowableStrategy);
   }
 


### PR DESCRIPTION
We are having issues using the new API to set an UncaughtThrowableStrategy. There was a mistake in my latest PR.

Sorry about it. Can you give us an ETA to release the fix on central? We might have to reverse the change on our side if it's not published soon.

The crash is pretty simple: no images load (on Oreo devices ??? strange, it should always crash..). Anyway, yes, no images are loaded because we use an executor that can't go to the network.
 