### PR TITLE
clear all pixels when dispose is 3 but previousImage is null

### DIFF
--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -418,9 +418,17 @@ public class StandardGifDecoder implements GifDecoder {
     // Final location of blended pixels.
     final int[] dest = mainScratch;
 
-    // clear all pixels when meet first frame or dispose is 3 but previousImage is null
-    if (previousFrame == null || (previousFrame.dispose == DISPOSAL_PREVIOUS && previousImage == null)) {
+    // clear all pixels when meet first frame and drop prev image from last loop
+    if (previousFrame == null) {
       previousImage = null;
+      Arrays.fill(dest, COLOR_TRANSPARENT_BLACK);
+    }
+
+    // clear all pixels when dispose is 3 but previousImage is null.
+    // When DISPOSAL_PREVIOUS and previousImage didn't be set, new frame should draw on
+    // a empty image
+    if (previousFrame != null && previousFrame.dispose == DISPOSAL_PREVIOUS
+            && previousImage == null) {
       Arrays.fill(dest, COLOR_TRANSPARENT_BLACK);
     }
 

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -420,6 +420,9 @@ public class StandardGifDecoder implements GifDecoder {
 
     // clear all pixels when meet first frame and drop prev image from last loop
     if (previousFrame == null) {
+      if (previousImage != null) {
+        bitmapProvider.release(previousImage);
+      }
       previousImage = null;
       Arrays.fill(dest, COLOR_TRANSPARENT_BLACK);
     }

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -418,8 +418,9 @@ public class StandardGifDecoder implements GifDecoder {
     // Final location of blended pixels.
     final int[] dest = mainScratch;
 
-    // clear all pixels when meet first frame
-    if (previousFrame == null) {
+    // clear all pixels when meet first frame or dispose is 3 but previousImage is null
+    if (previousFrame == null || (previousFrame.dispose == DISPOSAL_PREVIOUS && previousImage == null)) {
+      previousImage = null;
       Arrays.fill(dest, COLOR_TRANSPARENT_BLACK);
     }
 


### PR DESCRIPTION
## Description
Fix Issues #2271 and part of #1094

## Motivation and Context
Dispose in frame should not be DISPOSAL_PREVIOUS when there did not save previous image. GIF like #2271 is wrong because the dispose is DISPOSAL_PREVIOUS in first frame.