### PR TITLE
Use Iterator.remove when trimming cache 

### DIFF
--- a/library/src/main/java/com/bumptech/glide/util/LruCache.java
+++ b/library/src/main/java/com/bumptech/glide/util/LruCache.java
@@ -169,7 +169,7 @@ public class LruCache<T, Y> {
   protected synchronized void trimToSize(int size) {
     Map.Entry<T, Y> last;
     final Iterator<Map.Entry<T, Y>> cacheIterator = cache.entrySet().iterator();
-    while (currentSize > size) {
+    while (currentSize > size && cacheIterator.hasNext()) {
       last = cacheIterator.next();
       final Y toRemove = last.getValue();
       currentSize -= getSize(toRemove);

--- a/library/src/main/java/com/bumptech/glide/util/LruCache.java
+++ b/library/src/main/java/com/bumptech/glide/util/LruCache.java
@@ -1,6 +1,8 @@
 package com.bumptech.glide.util;
 
 import android.support.annotation.Nullable;
+
+import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.Map;
 
@@ -166,12 +168,13 @@ public class LruCache<T, Y> {
    */
   protected synchronized void trimToSize(int size) {
     Map.Entry<T, Y> last;
+    final Iterator<Map.Entry<T, Y>> cacheIterator = cache.entrySet().iterator();
     while (currentSize > size) {
-      last = cache.entrySet().iterator().next();
+      last = cacheIterator.next();
       final Y toRemove = last.getValue();
       currentSize -= getSize(toRemove);
       final T key = last.getKey();
-      cache.remove(key);
+      cacheIterator.remove();
       onItemEvicted(key, toRemove);
     }
   }

--- a/library/src/main/java/com/bumptech/glide/util/LruCache.java
+++ b/library/src/main/java/com/bumptech/glide/util/LruCache.java
@@ -168,8 +168,9 @@ public class LruCache<T, Y> {
    */
   protected synchronized void trimToSize(int size) {
     Map.Entry<T, Y> last;
-    final Iterator<Map.Entry<T, Y>> cacheIterator = cache.entrySet().iterator();
-    while (currentSize > size && cacheIterator.hasNext()) {
+    Iterator<Map.Entry<T, Y>> cacheIterator;
+    while (currentSize > size) {
+      cacheIterator  = cache.entrySet().iterator();
       last = cacheIterator.next();
       final Y toRemove = last.getValue();
       currentSize -= getSize(toRemove);


### PR DESCRIPTION

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Instead of explicitly removing a key from the LruCache (which fails if the key class violates the equals() contract) call remove() on the iterator instead.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
Using this even cache keys violating equals() can be used here. Fixes #2532.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->