### PR TITLE
Add probot stale configuration.

### DIFF
--- a/.github/stale.yml
+++ b/.github/stale.yml
@@ -1,0 +1,21 @@
+# Number of days of inactivity before an issue becomes stale
+daysUntilStale: 7
+# Number of days of inactivity before a stale issue is closed
+daysUntilClose: 7
+# Issues with these labels will never be considered stale
+exemptLabels:
+  - bug
+  - enhancement
+  - feature
+  - good first issue
+  - help wanted
+# Label to use when marking an issue as stale
+staleLabel: stale
+# Comment to post when marking an issue as stale. Set to `false` to disable
+markComment: >
+  This issue has been automatically marked as stale because it has not had
+  activity in the last seven days. It will be closed if no further activity 
+  occurs within the next seven days. Thank you for your contributions.
+# Comment to post when closing a stale issue. Set to `false` to disable
+closeComment: false
+unmarkComment: false


### PR DESCRIPTION
Progress towards #2549. This will comment on and automatically close stale issues that don't have a whitelisted set of tags.