### PR TITLE
Use long value so that cache sizes greater than 2Gigabytes can be supported.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPool.java
@@ -11,7 +11,7 @@ public interface BitmapPool {
   /**
    * Returns the current maximum size of the pool in bytes.
    */
-  int getMaxSize();
+  long getMaxSize();
 
   /**
    * Multiplies the initial size of the pool by the given multiplier to dynamically and

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPoolAdapter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPoolAdapter.java
@@ -10,7 +10,7 @@ import android.support.annotation.NonNull;
  */
 public class BitmapPoolAdapter implements BitmapPool {
   @Override
-  public int getMaxSize() {
+  public long getMaxSize() {
     return 0;
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
@@ -26,18 +26,18 @@ public class LruBitmapPool implements BitmapPool {
 
   private final LruPoolStrategy strategy;
   private final Set<Bitmap.Config> allowedConfigs;
-  private final int initialMaxSize;
+  private final long initialMaxSize;
   private final BitmapTracker tracker;
 
-  private int maxSize;
-  private int currentSize;
+  private long maxSize;
+  private long currentSize;
   private int hits;
   private int misses;
   private int puts;
   private int evictions;
 
   // Exposed for testing only.
-  LruBitmapPool(int maxSize, LruPoolStrategy strategy, Set<Bitmap.Config> allowedConfigs) {
+  LruBitmapPool(long maxSize, LruPoolStrategy strategy, Set<Bitmap.Config> allowedConfigs) {
     this.initialMaxSize = maxSize;
     this.maxSize = maxSize;
     this.strategy = strategy;
@@ -50,7 +50,7 @@ public class LruBitmapPool implements BitmapPool {
    *
    * @param maxSize The initial maximum size of the pool in bytes.
    */
-  public LruBitmapPool(int maxSize) {
+  public LruBitmapPool(long maxSize) {
     this(maxSize, getDefaultStrategy(), getDefaultAllowedConfigs());
   }
 
@@ -62,12 +62,12 @@ public class LruBitmapPool implements BitmapPool {
    *                       allowed to be put into the pool. Configs not in the allowed put will be
    *                       rejected.
    */
-  public LruBitmapPool(int maxSize, Set<Bitmap.Config> allowedConfigs) {
+  public LruBitmapPool(long maxSize, Set<Bitmap.Config> allowedConfigs) {
     this(maxSize, getDefaultStrategy(), allowedConfigs);
   }
 
   @Override
-  public int getMaxSize() {
+  public long getMaxSize() {
     return maxSize;
   }
 
@@ -216,7 +216,7 @@ public class LruBitmapPool implements BitmapPool {
     }
   }
 
-  private synchronized void trimToSize(int size) {
+  private synchronized void trimToSize(long size) {
     while (currentSize > size) {
       final Bitmap removed = strategy.removeLast();
       // TODO: This shouldn't ever happen, see #331.

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/DiskLruCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/DiskLruCacheFactory.java
@@ -7,10 +7,10 @@ import java.io.File;
  * disk cache directory.
  *
  * <p>If you need to make I/O access before returning the cache directory use the {@link
- * DiskLruCacheFactory#DiskLruCacheFactory(CacheDirectoryGetter, int)} constructor variant.
+ * DiskLruCacheFactory#DiskLruCacheFactory(CacheDirectoryGetter, long)} constructor variant.
  */
 public class DiskLruCacheFactory implements DiskCache.Factory {
-  private final int diskCacheSize;
+  private final long diskCacheSize;
   private final CacheDirectoryGetter cacheDirectoryGetter;
 
   /**
@@ -20,7 +20,7 @@ public class DiskLruCacheFactory implements DiskCache.Factory {
     File getCacheDirectory();
   }
 
-  public DiskLruCacheFactory(final String diskCacheFolder, int diskCacheSize) {
+  public DiskLruCacheFactory(final String diskCacheFolder, long diskCacheSize) {
     this(new CacheDirectoryGetter() {
       @Override
       public File getCacheDirectory() {
@@ -30,7 +30,7 @@ public class DiskLruCacheFactory implements DiskCache.Factory {
   }
 
   public DiskLruCacheFactory(final String diskCacheFolder, final String diskCacheName,
-      int diskCacheSize) {
+                             long diskCacheSize) {
     this(new CacheDirectoryGetter() {
       @Override
       public File getCacheDirectory() {
@@ -46,7 +46,7 @@ public class DiskLruCacheFactory implements DiskCache.Factory {
    * @param cacheDirectoryGetter Interface called out of UI thread to get the cache folder.
    * @param diskCacheSize        Desired max bytes size for the LRU disk cache.
    */
-  public DiskLruCacheFactory(CacheDirectoryGetter cacheDirectoryGetter, int diskCacheSize) {
+  public DiskLruCacheFactory(CacheDirectoryGetter cacheDirectoryGetter, long diskCacheSize) {
     this.diskCacheSize = diskCacheSize;
     this.cacheDirectoryGetter = cacheDirectoryGetter;
   }

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapper.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapper.java
@@ -15,7 +15,7 @@ import java.io.IOException;
  * The default DiskCache implementation. There must be no more than one active instance for a given
  * directory at a time.
  *
- * @see #get(java.io.File, int)
+ * @see #get(java.io.File, long)
  */
 public class DiskLruCacheWrapper implements DiskCache {
   private static final String TAG = "DiskLruCacheWrapper";
@@ -26,7 +26,7 @@ public class DiskLruCacheWrapper implements DiskCache {
 
   private final SafeKeyGenerator safeKeyGenerator;
   private final File directory;
-  private final int maxSize;
+  private final long maxSize;
   private final DiskCacheWriteLocker writeLocker = new DiskCacheWriteLocker();
   private DiskLruCache diskLruCache;
 
@@ -39,7 +39,7 @@ public class DiskLruCacheWrapper implements DiskCache {
    * @param maxSize   The max size for the disk cache
    * @return The new disk cache with the given arguments, or the current cache if one already exists
    */
-  public static synchronized DiskCache get(File directory, int maxSize) {
+  public static synchronized DiskCache get(File directory, long maxSize) {
     // TODO calling twice with different arguments makes it return the cache for the same
     // directory, it's public!
     if (wrapper == null) {
@@ -48,7 +48,7 @@ public class DiskLruCacheWrapper implements DiskCache {
     return wrapper;
   }
 
-  protected DiskLruCacheWrapper(File directory, int maxSize) {
+  protected DiskLruCacheWrapper(File directory, long maxSize) {
     this.directory = directory;
     this.maxSize = maxSize;
     this.safeKeyGenerator = new SafeKeyGenerator();

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
@@ -18,12 +18,12 @@ public final class ExternalPreferredCacheDiskCacheFactory extends DiskLruCacheFa
         DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE);
   }
 
-  public ExternalPreferredCacheDiskCacheFactory(Context context, int diskCacheSize) {
+  public ExternalPreferredCacheDiskCacheFactory(Context context, long diskCacheSize) {
     this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR, diskCacheSize);
   }
 
   public ExternalPreferredCacheDiskCacheFactory(final Context context, final String diskCacheName,
-                                                final int diskCacheSize) {
+                                                final long diskCacheSize) {
     super(new CacheDirectoryGetter() {
       @Nullable
       private File getInternalCacheDirectory() {

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDiskCacheFactory.java
@@ -14,12 +14,12 @@ public final class InternalCacheDiskCacheFactory extends DiskLruCacheFactory {
         DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE);
   }
 
-  public InternalCacheDiskCacheFactory(Context context, int diskCacheSize) {
+  public InternalCacheDiskCacheFactory(Context context, long diskCacheSize) {
     this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR, diskCacheSize);
   }
 
   public InternalCacheDiskCacheFactory(final Context context, final String diskCacheName,
-      int diskCacheSize) {
+                                       long diskCacheSize) {
     super(new CacheDirectoryGetter() {
       @Override
       public File getCacheDirectory() {

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
@@ -16,7 +16,7 @@ public class LruResourceCache extends LruCache<Key, Resource<?>> implements Memo
    *
    * @param size The maximum size in bytes the in memory cache can use.
    */
-  public LruResourceCache(int size) {
+  public LruResourceCache(long size) {
     super(size);
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/MemoryCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/MemoryCache.java
@@ -18,12 +18,12 @@ public interface MemoryCache {
   /**
    * Returns the sum of the sizes of all the contents of the cache in bytes.
    */
-  int getCurrentSize();
+  long getCurrentSize();
 
   /**
    * Returns the current maximum size in bytes of the cache.
    */
-  int getMaxSize();
+  long getMaxSize();
 
   /**
    * Adjust the maximum size of the cache by multiplying the original size of the cache by the given

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/MemoryCacheAdapter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/MemoryCacheAdapter.java
@@ -11,12 +11,12 @@ public class MemoryCacheAdapter implements MemoryCache {
   private ResourceRemovedListener listener;
 
   @Override
-  public int getCurrentSize() {
+  public long getCurrentSize() {
     return 0;
   }
 
   @Override
-  public int getMaxSize() {
+  public long getMaxSize() {
     return 0;
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunner.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunner.java
@@ -123,7 +123,7 @@ final class BitmapPreFillRunner implements Runnable {
     return clock.now() - startTimeMs >= MAX_DURATION_MS;
   }
 
-  private int getFreeMemoryCacheBytes() {
+  private long getFreeMemoryCacheBytes() {
     return memoryCache.getMaxSize() - memoryCache.getCurrentSize();
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/prefill/BitmapPreFiller.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/prefill/BitmapPreFiller.java
@@ -55,7 +55,7 @@ public final class BitmapPreFiller {
 
   // Visible for testing.
   PreFillQueue generateAllocationOrder(PreFillType... preFillSizes) {
-    final int maxSize =
+    final long maxSize =
         memoryCache.getMaxSize() - memoryCache.getCurrentSize() + bitmapPool.getMaxSize();
 
     int totalWeight = 0;

--- a/library/src/main/java/com/bumptech/glide/load/model/ModelCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ModelCache.java
@@ -23,7 +23,7 @@ public class ModelCache<A, B> {
     this(DEFAULT_SIZE);
   }
 
-  public ModelCache(int size) {
+  public ModelCache(long size) {
     cache = new LruCache<ModelKey<A>, B>(size) {
       @Override
       protected void onItemEvicted(ModelKey<A> key, B item) {

--- a/library/src/main/java/com/bumptech/glide/util/LruCache.java
+++ b/library/src/main/java/com/bumptech/glide/util/LruCache.java
@@ -14,9 +14,9 @@ import java.util.Map;
  */
 public class LruCache<T, Y> {
   private final LinkedHashMap<T, Y> cache = new LinkedHashMap<>(100, 0.75f, true);
-  private final int initialMaxSize;
-  private int maxSize;
-  private int currentSize = 0;
+  private final long initialMaxSize;
+  private long maxSize;
+  private long currentSize = 0;
 
   /**
    * Constructor for LruCache.
@@ -24,7 +24,7 @@ public class LruCache<T, Y> {
    * @param size The maximum size of the cache, the units must match the units used in {@link
    *             #getSize(Object)}.
    */
-  public LruCache(int size) {
+  public LruCache(long size) {
     this.initialMaxSize = size;
     this.maxSize = size;
   }
@@ -75,14 +75,14 @@ public class LruCache<T, Y> {
   /**
    * Returns the current maximum size of the cache in bytes.
    */
-  public synchronized int getMaxSize() {
+  public synchronized long getMaxSize() {
     return maxSize;
   }
 
   /**
    * Returns the sum of the sizes of all items in the cache.
    */
-  public synchronized int getCurrentSize() {
+  public synchronized long getCurrentSize() {
     return currentSize;
   }
 
@@ -164,7 +164,7 @@ public class LruCache<T, Y> {
    *
    * @param size The size the cache should be less than.
    */
-  protected synchronized void trimToSize(int size) {
+  protected synchronized void trimToSize(long size) {
     Map.Entry<T, Y> last;
     while (currentSize > size) {
       last = cache.entrySet().iterator().next();

--- a/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
@@ -195,7 +195,7 @@ public class BitmapPreFillRunnerTest {
   @Test
   public void testAddsBitmapsToMemoryCacheIfMemoryCacheHasEnoughSpaceRemaining() {
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    when(cache.getMaxSize()).thenReturn(Util.getBitmapByteSize(bitmap));
+    when(cache.getMaxSize()).thenReturn(Long.valueOf(Util.getBitmapByteSize(bitmap)));
 
     PreFillType size =
         new PreFillType.Builder(bitmap.getWidth(), bitmap.getHeight()).setConfig(bitmap.getConfig())
@@ -214,7 +214,7 @@ public class BitmapPreFillRunnerTest {
   @Test
   public void testAddsBitmapsToBitmapPoolIfMemoryCacheIsFull() {
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    when(cache.getMaxSize()).thenReturn(0);
+    when(cache.getMaxSize()).thenReturn(0L);
 
     PreFillType size =
         new PreFillType.Builder(bitmap.getWidth(), bitmap.getHeight()).setConfig(bitmap.getConfig())
@@ -233,7 +233,7 @@ public class BitmapPreFillRunnerTest {
   @Test
   public void testAddsBitmapsToPoolIfMemoryCacheIsNotFullButCannotFitBitmap() {
     Bitmap bitmap = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-    when(cache.getMaxSize()).thenReturn(Util.getBitmapByteSize(bitmap) / 2);
+    when(cache.getMaxSize()).thenReturn((long) Util.getBitmapByteSize(bitmap) / 2);
 
     PreFillType size =
         new PreFillType.Builder(bitmap.getWidth(), bitmap.getHeight()).setConfig(bitmap.getConfig())

--- a/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillerTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillerTest.java
@@ -41,9 +41,9 @@ public class BitmapPreFillerTest {
   private final Bitmap.Config defaultBitmapConfig = PreFillType.DEFAULT_CONFIG;
   private final Bitmap defaultBitmap =
       Bitmap.createBitmap(DEFAULT_BITMAP_WIDTH, DEFAULT_BITMAP_HEIGHT, defaultBitmapConfig);
-  private final int defaultBitmapSize = Util.getBitmapByteSize(defaultBitmap);
-  private final int poolSize = BITMAPS_IN_CACHE * defaultBitmapSize;
-  private final int cacheSize = BITMAPS_IN_POOL * defaultBitmapSize;
+  private final long defaultBitmapSize = Util.getBitmapByteSize(defaultBitmap);
+  private final long poolSize = BITMAPS_IN_CACHE * defaultBitmapSize;
+  private final long cacheSize = BITMAPS_IN_POOL * defaultBitmapSize;
 
   @Mock BitmapPool pool;
   @Mock MemoryCache cache;
@@ -88,7 +88,7 @@ public class BitmapPreFillerTest {
     }
 
     int expectedSize = 0;
-    int maxSize = poolSize + cacheSize;
+    long maxSize = poolSize + cacheSize;
     for (PreFillType current : sizes) {
       int currentSize =
           Util.getBitmapByteSize(current.getWidth(), current.getHeight(), current.getConfig());
@@ -108,7 +108,7 @@ public class BitmapPreFillerTest {
         new PreFillType.Builder(DEFAULT_BITMAP_WIDTH, DEFAULT_BITMAP_HEIGHT / 2)
             .setConfig(defaultBitmapConfig).build() });
 
-    int byteSize = 0;
+    long byteSize = 0;
     while (!allocationOrder.isEmpty()) {
       PreFillType current = allocationOrder.remove();
       byteSize +=
@@ -128,7 +128,7 @@ public class BitmapPreFillerTest {
         new PreFillType.Builder(DEFAULT_BITMAP_WIDTH, DEFAULT_BITMAP_HEIGHT / 3)
             .setConfig(defaultBitmapConfig).setWeight(3).build() });
 
-    int byteSize = 0;
+    long byteSize = 0;
     while (!allocationOrder.isEmpty()) {
       PreFillType current = allocationOrder.remove();
       byteSize +=


### PR DESCRIPTION
## Description
I want to be able to set cache sizes greater than 2 gigabytes which is the max value supported by the int primitive type, my approact to achieving this is to change the type used for maintaing cache size to long, so that cache with greater than 2 gigabyte can be used since these days phones are getting bulkier I think its fair to also let developers use more of the phone to improve User experience.

Issue Reference:
https://github.com/bumptech/glide/issues/2022

## Motivation and Context
Bigger cache sizes equals better user experiences! 