### PR TITLE
Replace http links with https in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ This is not an official Google product.
 
 [1]: https://github.com/bumptech/glide/releases
 [2]: https://github.com/bumptech/glide/wiki
-[3]: http://bumptech.github.io/glide/ref/javadocs.html
+[3]: https://bumptech.github.io/glide/ref/javadocs.html
 [4]: https://www.jetbrains.com/idea/download/
 [5]: https://github.com/bumptech/glide/blob/master/CONTRIBUTING.md
 [6]: https://groups.google.com/forum/#!forum/glidelibrary
@@ -217,6 +217,6 @@ This is not an official Google product.
 [17]: https://github.com/bumptech/glide/wiki/Snapshots
 [18]: https://github.com/bumptech/glide/issues?q=is%3Aissue+CircleImageView+OR+CircularImageView+OR+RoundedImageView
 [19]: https://github.com/wasabeef/glide-transformations
-[20]: http://bumptech.github.io/glide/
-[21]: http://bumptech.github.io/glide/doc/generatedapi.html
+[20]: https://bumptech.github.io/glide/
+[21]: https://bumptech.github.io/glide/doc/generatedapi.html
 [22]: https://muyangmin.github.io/glide-docs-cn/


### PR DESCRIPTION
## Description
few links are served over http, replacing with https

## Motivation and Context
#### Why is this change required? What problem does it solve?
Our links will be secure and serve over `SSL Protocol` and other links are already using https. I also checked in network, console panel in dev tools in case  any script is getting blocked, everything is working fine. Repository description link is also http, we have to change it too.