### PR TITLE
External storage exists but not writable

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
@@ -52,7 +52,7 @@ public final class ExternalPreferredCacheDiskCacheFactory extends DiskLruCacheFa
         File cacheDirectory = context.getExternalCacheDir();
 
         // Shared storage is not available.
-        if (cacheDirectory == null) {
+        if ((cacheDirectory == null) || (!cacheDirectory.canWrite())){
           return internalCacheDirectory;
         }
         if (diskCacheName != null) {

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
@@ -52,7 +52,7 @@ public final class ExternalPreferredCacheDiskCacheFactory extends DiskLruCacheFa
         File cacheDirectory = context.getExternalCacheDir();
 
         // Shared storage is not available.
-        if ((cacheDirectory == null) || (!cacheDirectory.canWrite())){
+        if ((cacheDirectory == null) || (!cacheDirectory.canWrite())) {
           return internalCacheDirectory;
         }
         if (diskCacheName != null) {


### PR DESCRIPTION
The Huawei P9 lite is returning the external storage path as if it were available, but it is not writable, therefore, writes fail. This commit fixes the issue.