### PR TITLE
Cleanup target api annotations

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -1,6 +1,5 @@
 package com.bumptech.glide;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ComponentCallbacks2;
 import android.content.Context;
@@ -10,7 +9,6 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
-import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
@@ -92,7 +90,6 @@ import java.util.Set;
  * {@link RequestBuilder} and maintaining an {@link Engine}, {@link BitmapPool},
  * {@link com.bumptech.glide.load.engine.cache.DiskCache} and {@link MemoryCache}.
  */
-@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class Glide implements ComponentCallbacks2 {
   private static final String DEFAULT_DISK_CACHE_DIR = "image_manager_disk_cache";
   private static final String TAG = "Glide";
@@ -294,7 +291,6 @@ public class Glide implements ComponentCallbacks2 {
     return result;
   }
 
-  @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   Glide(
       Context context,
       Engine engine,

--- a/library/src/main/java/com/bumptech/glide/GlideContext.java
+++ b/library/src/main/java/com/bumptech/glide/GlideContext.java
@@ -1,9 +1,7 @@
 package com.bumptech.glide;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.content.ContextWrapper;
-import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.NonNull;
@@ -21,7 +19,6 @@ import java.util.Map.Entry;
  * Global context for all loads in Glide containing and exposing the various registries and classes
  * required to load resources.
  */
-@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class GlideContext extends ContextWrapper {
   @VisibleForTesting
   static final TransitionOptions<?, ?> DEFAULT_TRANSITION_OPTIONS =

--- a/library/src/main/java/com/bumptech/glide/load/data/StreamLocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/StreamLocalUriFetcher.java
@@ -1,10 +1,8 @@
 package com.bumptech.glide.load.data;
 
-import android.annotation.TargetApi;
 import android.content.ContentResolver;
 import android.content.UriMatcher;
 import android.net.Uri;
-import android.os.Build;
 import android.provider.ContactsContract;
 import android.support.annotation.NonNull;
 import java.io.FileNotFoundException;
@@ -88,7 +86,6 @@ public class StreamLocalUriFetcher extends LocalUriFetcher<InputStream> {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   private InputStream openContactPhotoInputStream(ContentResolver contentResolver, Uri contactUri) {
     return ContactsContract.Contacts.openContactPhotoInputStream(contentResolver, contactUri,
         true /*preferHighres*/);

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/SizeConfigStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/SizeConfigStrategy.java
@@ -1,9 +1,9 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 
-import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.annotation.VisibleForTesting;
 import com.bumptech.glide.util.Synthetic;
 import com.bumptech.glide.util.Util;
@@ -23,7 +23,7 @@ import java.util.TreeMap;
  * the performance of applications. This class works around #301 by only allowing re-use of
  * {@link android.graphics.Bitmap Bitmaps} with a matching number of bytes per pixel. </p>
  */
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@RequiresApi(Build.VERSION_CODES.KITKAT)
 public class SizeConfigStrategy implements LruPoolStrategy {
   private static final int MAX_SIZE_MULTIPLE = 8;
   private static final Bitmap.Config[] ARGB_8888_IN_CONFIGS =

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/SizeStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/SizeStrategy.java
@@ -1,9 +1,9 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 
-import android.annotation.TargetApi;
 import android.graphics.Bitmap;
 import android.os.Build;
 import android.support.annotation.Nullable;
+import android.support.annotation.RequiresApi;
 import android.support.annotation.VisibleForTesting;
 import com.bumptech.glide.util.Synthetic;
 import com.bumptech.glide.util.Util;
@@ -15,7 +15,7 @@ import java.util.TreeMap;
  *
  * <p> Requires {@link Build.VERSION_CODES#KITKAT KitKat} or higher. </p>
  */
-@TargetApi(Build.VERSION_CODES.KITKAT)
+@RequiresApi(Build.VERSION_CODES.KITKAT)
 class SizeStrategy implements LruPoolStrategy {
   private static final int MAX_SIZE_MULTIPLE = 8;
   private final KeyPool keyPool = new KeyPool();

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/MemorySizeCalculator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/MemorySizeCalculator.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.cache;
 
+import android.annotation.TargetApi;
 import android.app.ActivityManager;
 import android.content.Context;
 import android.os.Build;
@@ -113,6 +114,7 @@ public final class MemorySizeCalculator {
     return Formatter.formatFileSize(context, bytes);
   }
 
+  @TargetApi(Build.VERSION_CODES.KITKAT)
   private static boolean isLowMemoryDevice(ActivityManager activityManager) {
     // Explicitly check with an if statement, on some devices both parts of boolean expressions
     // can be evaluated even if we'd normally expect a short circuit.

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -108,7 +108,7 @@ public final class Downsampler {
     }
 
     @Override
-    public void onDecodeComplete(BitmapPool bitmapPool, Bitmap downsampled) throws IOException {
+    public void onDecodeComplete(BitmapPool bitmapPool, Bitmap downsampled) {
       // Do nothing.
     }
   };

--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -317,7 +317,6 @@ public class RequestManagerRetriever implements Handler.Callback {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   RequestManagerFragment getRequestManagerFragment(
       final android.app.FragmentManager fm, android.app.Fragment parentHint) {
     RequestManagerFragment current = (RequestManagerFragment) fm.findFragmentByTag(FRAGMENT_TAG);

--- a/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
@@ -1,6 +1,5 @@
 package com.bumptech.glide.request.target;
 
-import android.annotation.TargetApi;
 import android.content.res.Resources;
 import android.graphics.Canvas;
 import android.graphics.ColorFilter;
@@ -11,6 +10,7 @@ import android.graphics.RectF;
 import android.graphics.drawable.Drawable;
 import android.os.Build;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.Synthetic;
 
@@ -90,7 +90,7 @@ public class FixedSizeDrawable extends Drawable {
     return wrapped.getCallback();
   }
 
-  @TargetApi(Build.VERSION_CODES.KITKAT)
+  @RequiresApi(Build.VERSION_CODES.KITKAT)
   @Override
   public int getAlpha() {
     return wrapped.getAlpha();

--- a/library/src/main/java/com/bumptech/glide/util/LogTime.java
+++ b/library/src/main/java/com/bumptech/glide/util/LogTime.java
@@ -9,7 +9,7 @@ import android.os.SystemClock;
  */
 public final class LogTime {
   private static final double MILLIS_MULTIPLIER =
-      Build.VERSION_CODES.JELLY_BEAN_MR1 <= Build.VERSION.SDK_INT ? 1d / Math.pow(10, 6) : 1d;
+      Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 ? 1d / Math.pow(10, 6) : 1d;
 
   private LogTime() {
     // Utility class.
@@ -21,7 +21,7 @@ public final class LogTime {
    */
   @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public static long getLogTime() {
-    if (Build.VERSION_CODES.JELLY_BEAN_MR1 <= Build.VERSION.SDK_INT) {
+    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1) {
       return SystemClock.elapsedRealtimeNanos();
     } else {
       return SystemClock.uptimeMillis();

--- a/library/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
@@ -8,8 +8,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import android.annotation.TargetApi;
-import android.os.Build;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.Set;
@@ -21,7 +19,6 @@ import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(manifest = Config.NONE, sdk = 18)
-@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class LruArrayPoolTest {
   private static final int MAX_SIZE = 10;
   private static final int MAX_PUT_SIZE = MAX_SIZE / 2;
@@ -30,7 +27,7 @@ public class LruArrayPoolTest {
   private LruArrayPool pool;
 
   @Before
-  public void setUp() throws Exception {
+  public void setUp() {
     pool = new LruArrayPool(MAX_SIZE);
   }
 

--- a/library/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
@@ -13,9 +13,7 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.content.ComponentCallbacks2;
-import android.os.Build;
 import android.support.annotation.NonNull;
 import com.bumptech.glide.load.Key;
 import com.bumptech.glide.load.engine.Resource;
@@ -26,7 +24,6 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
 public class LruResourceCacheTest {
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
@@ -6,9 +6,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.graphics.Bitmap;
-import android.os.Build;
 import com.bumptech.glide.load.EncodeStrategy;
 import com.bumptech.glide.load.Options;
 import com.bumptech.glide.load.engine.Resource;
@@ -57,7 +55,6 @@ public class BitmapEncoderTest {
   }
 
   @Test
-  @TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH)
   public void testEncoderObeysNonNullCompressFormat() throws IOException {
     Bitmap.CompressFormat format = Bitmap.CompressFormat.WEBP;
     harness.setFormat(format);

--- a/library/src/test/java/com/bumptech/glide/manager/Issue117Activity.java
+++ b/library/src/test/java/com/bumptech/glide/manager/Issue117Activity.java
@@ -2,11 +2,11 @@ package com.bumptech.glide.manager;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
 
-import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import android.support.v4.app.FragmentManager;
@@ -21,7 +21,7 @@ import com.bumptech.glide.Glide;
 /**
  * A test activity to reproduce Issue #117: https://github.com/bumptech/glide/issues/117.
  */
-@TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+@RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
 class Issue117Activity extends FragmentActivity {
   @Override
   protected void onCreate(Bundle savedInstanceState) {

--- a/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
+++ b/library/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
@@ -9,12 +9,12 @@ import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.Context;
 import android.content.ContextWrapper;
 import android.os.Build;
 import android.os.Looper;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
 import com.bumptech.glide.RequestManager;
@@ -309,7 +309,7 @@ public class RequestManagerRetrieverTest {
   }
 
   @Test
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+  @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testDoesNotThrowIfAskedToGetManagerForActivityPreJellYBeanMr1() {
     Util.setSdkVersionInt(Build.VERSION_CODES.JELLY_BEAN);
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();
@@ -320,7 +320,7 @@ public class RequestManagerRetrieverTest {
   }
 
   @Test
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
+  @RequiresApi(Build.VERSION_CODES.JELLY_BEAN_MR1)
   public void testDoesNotThrowIfAskedToGetManagerForFragmentPreJellyBeanMr1() {
     Util.setSdkVersionInt(Build.VERSION_CODES.JELLY_BEAN);
     Activity activity = Robolectric.buildActivity(Activity.class).create().start().resume().get();

--- a/samples/contacturi/src/main/java/com/bumptech/glide/samples/contacturi/MainActivity.java
+++ b/samples/contacturi/src/main/java/com/bumptech/glide/samples/contacturi/MainActivity.java
@@ -1,8 +1,5 @@
 package com.bumptech.glide.samples.contacturi;
 
-import static android.os.Build.VERSION;
-import static android.os.Build.VERSION_CODES;
-
 import android.Manifest;
 import android.app.Activity;
 import android.content.ContentUris;

--- a/samples/contacturi/src/main/java/com/bumptech/glide/samples/contacturi/MainActivity.java
+++ b/samples/contacturi/src/main/java/com/bumptech/glide/samples/contacturi/MainActivity.java
@@ -4,7 +4,6 @@ import static android.os.Build.VERSION;
 import static android.os.Build.VERSION_CODES;
 
 import android.Manifest;
-import android.annotation.TargetApi;
 import android.app.Activity;
 import android.content.ContentUris;
 import android.content.Intent;
@@ -45,11 +44,11 @@ public class MainActivity extends Activity {
     super.onCreate(savedInstanceState);
     setContentView(R.layout.activity_main);
 
-    imageViewContact = (ImageView) findViewById(R.id.image_contact);
-    imageViewLookup = (ImageView) findViewById(R.id.image_lookup);
-    imageViewPhoto = (ImageView) findViewById(R.id.image_photo);
-    imageViewDisplayPhoto = (ImageView) findViewById(R.id.image_display_photo);
-    numberEntry = (EditText) findViewById(R.id.number_entry);
+    imageViewContact = findViewById(R.id.image_contact);
+    imageViewLookup = findViewById(R.id.image_lookup);
+    imageViewPhoto = findViewById(R.id.image_photo);
+    imageViewDisplayPhoto = findViewById(R.id.image_display_photo);
+    numberEntry = findViewById(R.id.number_entry);
     // Make sure that user gives application required permissions
     if (ContextCompat.checkSelfPermission(
         getApplication(),
@@ -101,7 +100,6 @@ public class MainActivity extends Activity {
     super.onActivityResult(requestCode, resultCode, data);
   }
 
-  @TargetApi(VERSION_CODES.ICE_CREAM_SANDWICH)
   private void showContact(long id) {
     GlideRequests glideRequests = GlideApp.with(this);
     RequestOptions originalSize = new RequestOptions().override(Target.SIZE_ORIGINAL);
@@ -115,9 +113,7 @@ public class MainActivity extends Activity {
     Uri photoUri = Uri.withAppendedPath(contactUri, Contacts.Photo.CONTENT_DIRECTORY);
     glideRequests.load(photoUri).apply(originalSize).into(imageViewPhoto);
 
-    if (VERSION.SDK_INT >= VERSION_CODES.ICE_CREAM_SANDWICH) {
-      Uri displayPhotoUri = Uri.withAppendedPath(contactUri, Contacts.Photo.DISPLAY_PHOTO);
-      glideRequests.load(displayPhotoUri).apply(originalSize).into(imageViewDisplayPhoto);
-    }
+    Uri displayPhotoUri = Uri.withAppendedPath(contactUri, Contacts.Photo.DISPLAY_PHOTO);
+    glideRequests.load(displayPhotoUri).apply(originalSize).into(imageViewDisplayPhoto);
   }
 }

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.java
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.java
@@ -1,11 +1,11 @@
 package com.bumptech.glide.samples.gallery;
 
 import android.Manifest.permission;
-import android.annotation.TargetApi;
 import android.content.pm.PackageManager;
 import android.os.Build;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
+import android.support.annotation.RequiresApi;
 import android.support.v4.app.ActivityCompat;
 import android.support.v4.app.Fragment;
 import android.support.v4.app.FragmentActivity;
@@ -34,7 +34,7 @@ public class MainActivity extends FragmentActivity {
     }
   }
 
-  @TargetApi(Build.VERSION_CODES.JELLY_BEAN)
+  @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
   private void requestStoragePermission() {
      ActivityCompat.requestPermissions(this,
         new String[]{permission.READ_EXTERNAL_STORAGE},

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.java
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.java
@@ -16,6 +16,7 @@ import com.bumptech.glide.MemoryCategory;
 /**
  * Displays a {@link HorizontalGalleryFragment}.
  */
+@RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
 public class MainActivity extends FragmentActivity {
 
   private static final int REQUEST_READ_STORAGE = 0;
@@ -34,7 +35,6 @@ public class MainActivity extends FragmentActivity {
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.JELLY_BEAN)
   private void requestStoragePermission() {
      ActivityCompat.requestPermissions(this,
         new String[]{permission.READ_EXTERNAL_STORAGE},


### PR DESCRIPTION
Any reason to use `TargetApi`? Dunno why the support lib folks haven't just deprecated that annotation, but `RequiresApi` is the better one. Also, this PR removes target annotations for api 14 which is the min of this library anyway.