### PR TITLE
Fix all annotation testing issues on Windows

### DIFF
--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithExcludesTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithExcludesTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyLibraryModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
@@ -39,7 +40,7 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -47,7 +48,7 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -55,7 +56,7 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -63,7 +64,7 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -71,7 +72,8 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -79,7 +81,8 @@ public class AppGlideModuleWithExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithMultipleExcludesTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithMultipleExcludesTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
 import static com.google.testing.compile.CompilationSubject.assertThat;
@@ -39,7 +40,7 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -47,7 +48,7 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -55,7 +56,7 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -63,7 +64,7 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -71,7 +72,8 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -79,7 +81,8 @@ public class AppGlideModuleWithMultipleExcludesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyAppAndLibraryGlideModulesTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyAppAndLibraryGlideModulesTest.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.annotation;
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyLibraryModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
@@ -49,7 +50,7 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -57,7 +58,7 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -65,7 +66,7 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -73,7 +74,7 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -81,7 +82,8 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -89,7 +91,8 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   @Test
@@ -99,7 +102,7 @@ public class EmptyAppAndLibraryGlideModulesTest {
     assertThat(compilation)
         .generatedSourceFile(annotation(expectedClassName))
         .contentsAsUtf8String()
-        .isEqualTo(libraryResource(expectedClassName + ".java").getCharContent(true));
+        .isEqualTo(asUnixChars(libraryResource(expectedClassName + ".java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyAppGlideModuleTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyAppGlideModuleTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.annotation.compiler;
 
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
 import static com.google.testing.compile.CompilationSubject.assertThat;
@@ -42,7 +43,7 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -50,7 +51,7 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -58,7 +59,7 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -66,7 +67,7 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -74,7 +75,8 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -82,7 +84,8 @@ public class EmptyAppGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyLibraryGlideModuleTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/EmptyLibraryGlideModuleTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.annotation;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 
@@ -43,7 +44,7 @@ public class EmptyLibraryGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(annotation(expectedClassName))
         .contentsAsUtf8String()
-        .isEqualTo(forResource(expectedClassName + ".java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource(expectedClassName + ".java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionOptionsTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionOptionsTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.annotation.compiler;
 
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
 import static com.google.testing.compile.CompilationSubject.assertThat;
@@ -94,7 +95,7 @@ public class GlideExtensionOptionsTest {
   }
 
   private void runTest(String subDir, Subject subject) throws IOException {
-     Compilation compilation =
+    Compilation compilation =
         javac()
             .withProcessors(new GlideAnnotationProcessor())
             .compile(
@@ -105,7 +106,7 @@ public class GlideExtensionOptionsTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage(subject.name()))
         .contentsAsUtf8String()
-        .isEqualTo(forResource(subDir, subject.file()).getCharContent(true));
+        .isEqualTo(asUnixChars(forResource(subDir, subject.file()).getCharContent(true)));
   }
 
   private JavaFileObject extension(String subdir) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionWithOptionTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionWithOptionTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
@@ -46,7 +47,7 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -54,7 +55,7 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -62,7 +63,7 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -70,7 +71,7 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -78,7 +79,8 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -86,7 +88,8 @@ public class GlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionWithTypeTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/GlideExtensionWithTypeTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
@@ -45,7 +46,7 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -53,7 +54,7 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -61,7 +62,7 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -69,7 +70,7 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -77,7 +78,8 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -85,7 +87,8 @@ public class GlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionOptionsTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionOptionsTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.annotation.compiler;
 
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
 import static com.google.testing.compile.CompilationSubject.assertThat;
@@ -83,7 +84,7 @@ public class LegacyGlideExtensionOptionsTest {
   }
 
   private void runTest(String subDir, Subject subject) throws IOException {
-     Compilation compilation =
+    Compilation compilation =
         javac()
             .withProcessors(new GlideAnnotationProcessor())
             .compile(
@@ -94,7 +95,7 @@ public class LegacyGlideExtensionOptionsTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage(subject.name()))
         .contentsAsUtf8String()
-        .isEqualTo(forResource(subDir, subject.file()).getCharContent(true));
+        .isEqualTo(asUnixChars(forResource(subDir, subject.file()).getCharContent(true)));
   }
 
   private JavaFileObject extension(String subdir) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionWithOptionTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionWithOptionTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
@@ -52,7 +53,7 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -60,7 +61,7 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -68,7 +69,7 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -76,7 +77,7 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -84,7 +85,8 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -92,7 +94,8 @@ public class LegacyGlideExtensionWithOptionTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionWithTypeTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/LegacyGlideExtensionWithTypeTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.bumptech.glide.annotation.compiler.test.Util.emptyAppModule;
 import static com.bumptech.glide.annotation.compiler.test.Util.glide;
 import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
@@ -45,7 +46,7 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideOptions"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideOptions.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideOptions.java").getCharContent(true)));
   }
 
   @Test
@@ -53,7 +54,7 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequest"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideRequest.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
   }
 
   @Test
@@ -61,7 +62,7 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideRequests"))
         .contentsAsUtf8String()
-        .isEqualTo(forResource("GlideRequests.java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource("GlideRequests.java").getCharContent(true)));
   }
 
   @Test
@@ -69,7 +70,7 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(subpackage("GlideApp"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GlideApp.java").getCharContent(true));
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
   }
 
   @Test
@@ -77,7 +78,8 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
   }
 
   @Test
@@ -85,7 +87,8 @@ public class LegacyGlideExtensionWithTypeTest {
     assertThat(compilation)
         .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
         .contentsAsUtf8String()
-        .isEqualTo(appResource("GeneratedRequestManagerFactory.java").getCharContent(true));
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/MultipleEmptyLibraryGlideModuleTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/MultipleEmptyLibraryGlideModuleTest.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.test.Util.annotation;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
 import static com.google.testing.compile.CompilationSubject.assertThat;
 import static com.google.testing.compile.Compiler.javac;
 
@@ -45,7 +46,7 @@ public class MultipleEmptyLibraryGlideModuleTest {
     assertThat(compilation)
         .generatedSourceFile(annotation(expectedClassName))
         .contentsAsUtf8String()
-        .isEqualTo(forResource(expectedClassName + ".java").getCharContent(true));
+        .isEqualTo(asUnixChars(forResource(expectedClassName + ".java").getCharContent(true)));
   }
 
   private JavaFileObject forResource(String name) {

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/test/Util.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/test/Util.java
@@ -1,7 +1,6 @@
 package com.bumptech.glide.annotation.compiler.test;
 
 import com.google.testing.compile.JavaFileObjects;
-import java.io.File;
 import javax.tools.JavaFileObject;
 
 /** Test utilities. */
@@ -11,6 +10,12 @@ public final class Util {
   private static final String ANNOTATION_PACKAGE_NAME = "com.bumptech.glide.annotation.compiler";
   private static final String DEFAULT_APP_DIR_NAME = "EmptyAppGlideModuleTest";
   private static final String DEFAULT_LIBRARY_DIR_NAME = "EmptyLibraryGlideModuleTest";
+  /**
+   * Hardcoded file separator to workaround {@code JavaFileObjects.forResource(...)} defaulting to
+   * the unix one.
+   */
+  private static final String FILE_SEPARATOR = "/";
+  private static final String LINE_SEPARATOR = "\n";
 
   private Util() {
     // Utility class.
@@ -33,7 +38,7 @@ public final class Util {
   }
 
   public static JavaFileObject forResource(String directoryName, String name) {
-    return JavaFileObjects.forResource(directoryName + File.separator + name);
+    return JavaFileObjects.forResource(directoryName + FILE_SEPARATOR + name);
   }
 
   public static String annotation(String className) {
@@ -46,6 +51,10 @@ public final class Util {
 
   public static String glide(String className) {
     return qualified(GLIDE_PACKAGE_NAME, className);
+  }
+
+  public static CharSequence asUnixChars(CharSequence chars) {
+    return chars.toString().replace(System.lineSeparator(), LINE_SEPARATOR);
   }
 
   private static String qualified(String packageName, String className) {


### PR DESCRIPTION
Fixes #2709. It's a tad uglier than I would have liked, but running `./gradlew :annotation:compiler:test:test` is all green now! 😄 