### PR TITLE
Change library dependencies configuration from api to compileOnly

### DIFF
--- a/integration/gifencoder/build.gradle
+++ b/integration/gifencoder/build.gradle
@@ -2,6 +2,7 @@ apply plugin: 'com.android.library'
 
 dependencies {
     implementation project(':library')
+    api "com.android.support:support-annotations:${ANDROID_SUPPORT_VERSION}"
 
     testImplementation project(":testutil")
     testImplementation "com.google.truth:truth:${TRUTH_VERSION}"

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -9,7 +9,7 @@ dependencies {
     api project(':third_party:gif_decoder')
     api project(':third_party:disklrucache')
     api project(':annotation')
-    api "com.android.support:support-fragment:${ANDROID_SUPPORT_VERSION}"
+    compileOnly "com.android.support:support-fragment:${ANDROID_SUPPORT_VERSION}"
     compileOnly "com.android.support:appcompat-v7:${ANDROID_SUPPORT_VERSION}"
     testImplementation project(':testutil')
     testImplementation 'com.google.guava:guava-testlib:18.0'


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
Library's dependencies' version is 27.0.2, this change can fix the conflict with version 26.1.0 support dependency in user's code.
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
fixed #2730 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->