### PR TITLE
fix the emulator -no-window option issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,14 +20,17 @@ env:
   matrix:
     - COMPONENT=unit
     - COMPONENT=firebase
-      # TODO(#2738): Re-enable these when we find a fix.
-      #    - COMPONENT=instrumentation ANDROID_TARGET=16
-      #    - COMPONENT=instrumentation ANDROID_TARGET=17
-      #    - COMPONENT=instrumentation ANDROID_TARGET=18
+    - COMPONENT=instrumentation ANDROID_TARGET=16
+    - COMPONENT=instrumentation ANDROID_TARGET=17
+    - COMPONENT=instrumentation ANDROID_TARGET=18
     - COMPONENT=instrumentation ANDROID_TARGET=19
     - COMPONENT=instrumentation ANDROID_TARGET=21
     - COMPONENT=instrumentation ANDROID_TARGET=22
     - COMPONENT=samples
+
+before_install:
+  - sudo apt-get -qq update
+  - sudo apt-get install -y xvfb
 
 before_script:
   - ./scripts/travis_before_script.sh

--- a/scripts/travis_create_emulator.sh
+++ b/scripts/travis_create_emulator.sh
@@ -6,6 +6,14 @@ target="system-images;android-${ANDROID_TARGET};default;armeabi-v7a"
 echo y | sdkmanager --update
 echo y | sdkmanager --install $target
 avdmanager create avd --force -n test -k $target --device "Nexus 5X" -c 2000M
-QEMU_AUDIO_DRV=none $ANDROID_HOME/emulator/emulator -avd test -no-window -memory 2048 &
+
+if [ "$ANDROID_TARGET" == "16" ] || [ "$ANDROID_TARGET" == "17" ] || [ "$ANDROID_TARGET" == "18" ]; then
+  export DISPLAY=:99.0
+  /usr/bin/Xvfb :99 -screen 0 1280x1024x24 &
+  sleep 3 # give xvfb some time to start
+  QEMU_AUDIO_DRV=none $ANDROID_HOME/emulator/emulator -avd test -memory 2048 &
+else
+  QEMU_AUDIO_DRV=none $ANDROID_HOME/emulator/emulator -avd test -no-window -memory 2048 &
+fi
 
 exit 0

--- a/scripts/travis_samples.sh
+++ b/scripts/travis_samples.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+#installing xvfb needs accept android license
+echo y | sdkmanager --update
+
 ./gradlew :samples:flickr:build \
   :samples:giphy:build \
   :samples:contacturi:build \

--- a/scripts/travis_unit.sh
+++ b/scripts/travis_unit.sh
@@ -2,6 +2,9 @@
 
 set -e
 
+#installing xvfb needs accept android license
+echo y | sdkmanager --update
+
 ./gradlew build \
   -x :samples:flickr:build \
   -x :samples:giphy:build \


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Remove the -no-window option for android-16,17,18, and start a xvfb for them. 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
Fix #2738 
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->