### PR TITLE
PMD exclude cleanup

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/test/ConcurrencyHelper.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/test/ConcurrencyHelper.java
@@ -143,13 +143,13 @@ public class ConcurrencyHelper {
           }
 
           @Override
-          public void getSize(@NonNull SizeReadyCallback cb) {
-            target.getSize(cb);
+          public void getSize(@NonNull SizeReadyCallback callback) {
+            target.getSize(callback);
           }
 
           @Override
-          public void removeCallback(@NonNull SizeReadyCallback cb) {
-            target.removeCallback(cb);
+          public void removeCallback(@NonNull SizeReadyCallback callback) {
+            target.removeCallback(callback);
           }
 
           @Override
@@ -218,13 +218,13 @@ public class ConcurrencyHelper {
           }
 
           @Override
-          public void getSize(@NonNull SizeReadyCallback cb) {
-            target.getSize(cb);
+          public void getSize(@NonNull SizeReadyCallback callback) {
+            target.getSize(callback);
           }
 
           @Override
-          public void removeCallback(@NonNull SizeReadyCallback cb) {
-            target.removeCallback(cb);
+          public void removeCallback(@NonNull SizeReadyCallback callback) {
+            target.removeCallback(callback);
           }
 
           @Override

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -51,10 +51,7 @@
       <exclude name="OnlyOneReturn" />
       <!-- Obfuscated code is best code? -->
       <exclude name="LongVariable" />
-      <!-- This is not always true. -->
-      <exclude name="ShortClassName" />
       <!-- A good idea but we have tons of violations. FIXME. -->
-      <exclude name="ShortMethodName" />
       <exclude name="ShortVariable" />
       <!-- We don't use in and out to mean modified or not modified by the method, it's useful to match framework methods. -->
       <exclude name="AvoidPrefixingMethodParameters" />
@@ -73,6 +70,18 @@
       <properties>
         <!-- Allow if commented -->
         <property name="violationSuppressXPath" value="Block[@containsComment='true']" />
+      </properties>
+    </rule>
+    <rule ref="category/java/codestyle.xml/ShortClassName">
+      <properties>
+        <!-- Consider a few short class names valid. -->
+        <property name="violationSuppressRegex" value="^.*like \b(Util)\b.*$"/>
+        <!-- Globally allow `static class Key implements Poolable` as a convention. -->
+        <property name="violationSuppressXPath"
+                  value=".[@Image = 'Key']
+                          [@Nested = 'true' and @Static = 'true']
+                          [ImplementsList/ClassOrInterfaceType[@Image='Poolable']]
+                        " />
       </properties>
     </rule>
     <rule ref="category/java/performance.xml" >

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -57,8 +57,6 @@
       <exclude name="AvoidFinalLocalVariable" />
       <!-- These are often useful for clarity and explicitly suggested by Google's code style. -->
       <exclude name="UselessParentheses" />
-      <!-- Theoretically this might be reasonable but the number of imports probably varies from class to class and this doesn't seem worth the overhead to maintain. -->
-      <exclude name="TooManyStaticImports" />
       <!-- Lots of existing violations, not clear that the overhead is worthwhile though there are some cases where we definitely need to call super. FIXME. -->
       <exclude name="CallSuperInConstructor" />
       <!-- This is a reasonable idea, but in practice often the != null case is the expected case and it makes sense for it to come first. -->

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -13,7 +13,6 @@
     -->
 
     <rule ref="category/java/errorprone.xml">
-        <exclude name="AvoidBranchingStatementAsLastInLoop"/>
         <!-- Not using beans. -->
         <exclude name="BeanMembersShouldSerialize" />
         <!-- wat -->

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -4,6 +4,13 @@
          xsi:schemaLocation="http://pmd.sourceforge.net/ruleset/2.0.0 http://pmd.sourceforge.net/ruleset_2_0_0.xsd">
 
     <description>Check for flaws in Glide's codebase.</description>
+    <!-- Useful tool for getting a violation count per rule in the PMD HTML report (Chrome Console):
+        var violations = {};
+        $$('table tr td:last-child a').forEach(a => {
+            var key = a.attributes['href'].value;
+            violations[key] = (violations[key] || 0) + 1;
+        }); violations
+    -->
 
     <rule ref="category/java/errorprone.xml">
         <exclude name="AvoidBranchingStatementAsLastInLoop"/>

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -51,8 +51,6 @@
       <exclude name="OnlyOneReturn" />
       <!-- Obfuscated code is best code? -->
       <exclude name="LongVariable" />
-      <!-- A good idea but we have tons of violations. FIXME. -->
-      <exclude name="ShortVariable" />
       <!-- We don't use in and out to mean modified or not modified by the method, it's useful to match framework methods. -->
       <exclude name="AvoidPrefixingMethodParameters" />
       <!-- No idea what this is supposed to accomplish. -->
@@ -70,6 +68,37 @@
       <properties>
         <!-- Allow if commented -->
         <property name="violationSuppressXPath" value="Block[@containsComment='true']" />
+      </properties>
+    </rule>
+    <rule ref="category/java/codestyle.xml/ShortVariable">
+      <properties>
+        <!-- Allow some short variable names which are frequently used. -->
+        <property name="violationSuppressXPath" value=".[
+          (
+            @Image='sb' and typeof('java.lang.StringBuilder')
+            and ancestor::LocalVariableDeclaration
+          ) or (
+            @Image='ID' and typeof('java.lang.String')
+            and ancestor::FieldDeclaration[@Static='true' and @Final='true']
+          ) or (
+            @Image='o' and typeof('java.lang.Object')
+            and ancestor::FormalParameter
+            and ancestor::MethodDeclarator[@Image='equals' or @Image='isEquivalentTo']
+            and ancestor::MethodDeclaration[@Public='true' and ResultType/Type/PrimitiveType[@Image='boolean']]
+          ) or (
+            (@Image='t' or @Image='e')
+            and ancestor::FormalParameter
+            and (
+              typeof('java.lang.Exception')
+              or typeof('java.lang.Throwable')
+              or ../Type//ClassOrInterfaceType[@Image='GlideException']
+            )
+          ) or (
+            @Image='is' and typeof('java.io.InputStream')
+          ) or (
+            @Image='os' and typeof('java.io.OutputStream')
+          )
+        ]" />
       </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/ShortClassName">

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -28,8 +28,6 @@
         <exclude name="AvoidFieldNameMatchingMethodName" />
         <!-- There are enough cases where this makes sense (typically related to logic around the number of items in a collection) that a blanket ban doesn't seem like a good idea. -->
         <exclude name="AvoidLiteralsInIfCondition" />
-        <!-- It's clear that this is bad, but we have a number of cases where it makes sense and a blanket ban is irritating. -->
-        <exclude name="AvoidCatchingThrowable" />
     </rule>
     <rule ref="category/java/errorprone.xml/AvoidDuplicateLiterals">
       <properties>
@@ -144,8 +142,12 @@
         <exclude name="ExcessiveMethodLength" />
         <exclude name="ExcessiveClassLength" />
         <exclude name="ExcessivePublicCount" />
+    </rule>
+    <rule ref="category/java/design.xml/AvoidCatchingGenericException">
+      <properties>
         <!-- This is redundant, also caught with AvoidCatchingNPEs. -->
-        <exclude name="AvoidCatchingGenericException" />
+        <property name="violationSuppressXPath" value=".[@Image='NullPointerException']"/>
+      </properties>
     </rule>
 
     <rule ref="category/java/multithreading.xml">

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -181,9 +181,6 @@
         <!-- TODO: explore these further. -->
         <exclude name="CyclomaticComplexity" />
         <exclude name="NPathComplexity" />
-        <exclude name="ExcessiveMethodLength" />
-        <exclude name="ExcessiveClassLength" />
-        <exclude name="ExcessivePublicCount" />
     </rule>
     <rule ref="category/java/design.xml/AvoidCatchingGenericException">
       <properties>

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -167,7 +167,6 @@
         <exclude name="GodClass" />
         <!-- No idea how you reasonably define this. -->
         <exclude name="ExcessiveImports" />
-        <exclude name="CouplingBetweenObjects" />
         <exclude name="TooManyMethods" />
         <exclude name="LawOfDemeter" />
         <exclude name="NcssCount" />

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -42,8 +42,6 @@
       <!-- Don't need to annotate package private methods. -->
       <exclude name="DefaultPackage" />
       <exclude name="CommentDefaultAccessModifier" />
-      <!-- Optionally implemented default empty methods are fine. -->
-      <exclude name="EmptyMethodInAbstractClassShouldBeAbstract" />
       <!-- Why make generics less clear by using shorter names? -->
       <exclude name="GenericsNaming" />
       <!-- No need to enforce final if it's not necessary. -->
@@ -70,6 +68,12 @@
       <exclude name="CallSuperInConstructor" />
       <!-- This is a reasonable idea, but in practice often the != null case is the expected case and it makes sense for it to come first. -->
       <exclude name="ConfusingTernary" />
+    </rule>
+    <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract">
+      <properties>
+        <!-- Allow if commented -->
+        <property name="violationSuppressXPath" value="Block[@containsComment='true']" />
+      </properties>
     </rule>
     <rule ref="category/java/performance.xml" >
       <!-- Android may not behave the same as java VMs, using short can be clearer when working with binary data. -->

--- a/library/pmd-ruleset.xml
+++ b/library/pmd-ruleset.xml
@@ -56,10 +56,15 @@
       <exclude name="AvoidFinalLocalVariable" />
       <!-- These are often useful for clarity and explicitly suggested by Google's code style. -->
       <exclude name="UselessParentheses" />
-      <!-- Lots of existing violations, not clear that the overhead is worthwhile though there are some cases where we definitely need to call super. FIXME. -->
-      <exclude name="CallSuperInConstructor" />
       <!-- This is a reasonable idea, but in practice often the != null case is the expected case and it makes sense for it to come first. -->
       <exclude name="ConfusingTernary" />
+    </rule>
+    <rule ref="category/java/codestyle.xml/CallSuperInConstructor">
+      <properties>
+        <!-- Ignore classes implicitly extending Object.
+             TODO report why is this not default? see definition: `count (ExtendsList/*) > 0` -->
+        <property name="violationSuppressXPath" value="ancestor::ClassOrInterfaceDeclaration[not(child::ExtendsList)]" />
+      </properties>
     </rule>
     <rule ref="category/java/codestyle.xml/EmptyMethodInAbstractClassShouldBeAbstract">
       <properties>

--- a/library/src/main/java/com/bumptech/glide/DefaultRegistryFactory.java
+++ b/library/src/main/java/com/bumptech/glide/DefaultRegistryFactory.java
@@ -1,0 +1,297 @@
+package com.bumptech.glide;
+
+import android.content.ContentResolver;
+import android.content.Context;
+import android.content.res.AssetFileDescriptor;
+import android.content.res.Resources;
+import android.graphics.Bitmap;
+import android.graphics.drawable.BitmapDrawable;
+import android.graphics.drawable.Drawable;
+import android.net.Uri;
+import android.os.ParcelFileDescriptor;
+import android.support.annotation.NonNull;
+import com.bumptech.glide.gifdecoder.GifDecoder;
+import com.bumptech.glide.load.ImageHeaderParser;
+import com.bumptech.glide.load.ResourceDecoder;
+import com.bumptech.glide.load.data.InputStreamRewinder;
+import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.bumptech.glide.load.model.AssetUriLoader;
+import com.bumptech.glide.load.model.ByteArrayLoader;
+import com.bumptech.glide.load.model.ByteBufferEncoder;
+import com.bumptech.glide.load.model.ByteBufferFileLoader;
+import com.bumptech.glide.load.model.DataUrlLoader;
+import com.bumptech.glide.load.model.FileLoader;
+import com.bumptech.glide.load.model.GlideUrl;
+import com.bumptech.glide.load.model.MediaStoreFileLoader;
+import com.bumptech.glide.load.model.ResourceLoader;
+import com.bumptech.glide.load.model.StreamEncoder;
+import com.bumptech.glide.load.model.StringLoader;
+import com.bumptech.glide.load.model.UnitModelLoader;
+import com.bumptech.glide.load.model.UriLoader;
+import com.bumptech.glide.load.model.UrlUriLoader;
+import com.bumptech.glide.load.model.stream.HttpGlideUrlLoader;
+import com.bumptech.glide.load.model.stream.HttpUriLoader;
+import com.bumptech.glide.load.model.stream.MediaStoreImageThumbLoader;
+import com.bumptech.glide.load.model.stream.MediaStoreVideoThumbLoader;
+import com.bumptech.glide.load.model.stream.UrlLoader;
+import com.bumptech.glide.load.resource.bitmap.BitmapDrawableDecoder;
+import com.bumptech.glide.load.resource.bitmap.BitmapDrawableEncoder;
+import com.bumptech.glide.load.resource.bitmap.BitmapEncoder;
+import com.bumptech.glide.load.resource.bitmap.ByteBufferBitmapDecoder;
+import com.bumptech.glide.load.resource.bitmap.DefaultImageHeaderParser;
+import com.bumptech.glide.load.resource.bitmap.Downsampler;
+import com.bumptech.glide.load.resource.bitmap.ResourceBitmapDecoder;
+import com.bumptech.glide.load.resource.bitmap.StreamBitmapDecoder;
+import com.bumptech.glide.load.resource.bitmap.UnitBitmapDecoder;
+import com.bumptech.glide.load.resource.bitmap.VideoDecoder;
+import com.bumptech.glide.load.resource.bytes.ByteBufferRewinder;
+import com.bumptech.glide.load.resource.drawable.ResourceDrawableDecoder;
+import com.bumptech.glide.load.resource.drawable.UnitDrawableDecoder;
+import com.bumptech.glide.load.resource.file.FileDecoder;
+import com.bumptech.glide.load.resource.gif.ByteBufferGifDecoder;
+import com.bumptech.glide.load.resource.gif.GifDrawable;
+import com.bumptech.glide.load.resource.gif.GifDrawableEncoder;
+import com.bumptech.glide.load.resource.gif.GifFrameResourceDecoder;
+import com.bumptech.glide.load.resource.gif.StreamGifDecoder;
+import com.bumptech.glide.load.resource.transcode.BitmapBytesTranscoder;
+import com.bumptech.glide.load.resource.transcode.BitmapDrawableTranscoder;
+import com.bumptech.glide.load.resource.transcode.DrawableBytesTranscoder;
+import com.bumptech.glide.load.resource.transcode.GifDrawableBytesTranscoder;
+import java.io.File;
+import java.io.InputStream;
+import java.net.URL;
+import java.nio.ByteBuffer;
+import java.util.List;
+
+class DefaultRegistryFactory {
+
+  private final @NonNull Context context;
+  private final @NonNull BitmapPool bitmapPool;
+  private final @NonNull ArrayPool arrayPool;
+  private final @NonNull Resources resources;
+
+  private Registry registry;
+  private ByteBufferGifDecoder byteBufferGifDecoder;
+  private ResourceDecoder<ParcelFileDescriptor, Bitmap> parcelFileDescriptorVideoDecoder;
+  private ByteBufferBitmapDecoder byteBufferBitmapDecoder;
+  private StreamBitmapDecoder streamBitmapDecoder;
+  private ResourceDrawableDecoder resourceDrawableDecoder;
+  private ResourceLoader.StreamFactory resourceLoaderStreamFactory;
+  private ResourceLoader.UriFactory resourceLoaderUriFactory;
+  private ResourceLoader.FileDescriptorFactory resourceLoaderFileDescriptorFactory;
+  private ResourceLoader.AssetFileDescriptorFactory resourceLoaderAssetFileDescriptorFactory;
+  private BitmapEncoder bitmapEncoder;
+  private BitmapBytesTranscoder bitmapBytesTranscoder;
+  private GifDrawableBytesTranscoder gifDrawableBytesTranscoder;
+  private final ContentResolver contentResolver;
+
+  DefaultRegistryFactory(
+      @NonNull Context context, @NonNull BitmapPool bitmapPool, @NonNull ArrayPool arrayPool) {
+    this.context = context;
+    this.bitmapPool = bitmapPool;
+    this.arrayPool = arrayPool;
+    this.resources = context.getResources();
+    this.contentResolver = context.getContentResolver();
+  }
+
+  @NonNull
+  Registry create() {
+    registry = new Registry();
+    init();
+    registerBasics();
+    registerBitmaps();
+    registerBitmapDrawables();
+    registerGifs();
+    registerGifFrames();
+    registerDrawables();
+    registerFiles();
+    registerModels();
+    registerTranscoders();
+    return registry;
+  }
+
+  private void init() {
+    registry.register(new DefaultImageHeaderParser());
+
+    List<ImageHeaderParser> imageHeaderParsers = registry.getImageHeaderParsers();
+    Downsampler downsampler =
+        new Downsampler(imageHeaderParsers, resources.getDisplayMetrics(), bitmapPool, arrayPool);
+    byteBufferGifDecoder =
+        new ByteBufferGifDecoder(context, imageHeaderParsers, bitmapPool, arrayPool);
+    parcelFileDescriptorVideoDecoder = VideoDecoder.parcel(bitmapPool);
+    byteBufferBitmapDecoder = new ByteBufferBitmapDecoder(downsampler);
+    streamBitmapDecoder = new StreamBitmapDecoder(downsampler, arrayPool);
+    resourceDrawableDecoder = new ResourceDrawableDecoder(context);
+    resourceLoaderStreamFactory = new ResourceLoader.StreamFactory(resources);
+    resourceLoaderUriFactory = new ResourceLoader.UriFactory(resources);
+    resourceLoaderFileDescriptorFactory = new ResourceLoader.FileDescriptorFactory(resources);
+    resourceLoaderAssetFileDescriptorFactory =
+        new ResourceLoader.AssetFileDescriptorFactory(resources);
+    bitmapEncoder = new BitmapEncoder();
+
+    bitmapBytesTranscoder = new BitmapBytesTranscoder();
+    gifDrawableBytesTranscoder = new GifDrawableBytesTranscoder();
+  }
+
+  private void registerBasics() {
+    registry
+        .append(ByteBuffer.class, new ByteBufferEncoder())
+        .append(InputStream.class, new StreamEncoder(arrayPool));
+  }
+
+  private void registerBitmaps() {
+    registry
+        .append(Registry.BUCKET_BITMAP, ByteBuffer.class, Bitmap.class, byteBufferBitmapDecoder)
+        .append(Registry.BUCKET_BITMAP, InputStream.class, Bitmap.class, streamBitmapDecoder)
+        .append(
+            Registry.BUCKET_BITMAP,
+            ParcelFileDescriptor.class,
+            Bitmap.class,
+            parcelFileDescriptorVideoDecoder)
+        .append(
+            Registry.BUCKET_BITMAP,
+            AssetFileDescriptor.class,
+            Bitmap.class,
+            VideoDecoder.asset(bitmapPool))
+        .append(Bitmap.class, Bitmap.class, UnitModelLoader.Factory.<Bitmap>getInstance())
+        .append(
+            Registry.BUCKET_BITMAP, Bitmap.class, Bitmap.class, new UnitBitmapDecoder())
+        .append(Bitmap.class, bitmapEncoder);
+  }
+
+  private void registerBitmapDrawables() {
+    registry
+        .append(
+            Registry.BUCKET_BITMAP_DRAWABLE,
+            ByteBuffer.class,
+            BitmapDrawable.class,
+            new BitmapDrawableDecoder<>(resources, byteBufferBitmapDecoder))
+        .append(
+            Registry.BUCKET_BITMAP_DRAWABLE,
+            InputStream.class,
+            BitmapDrawable.class,
+            new BitmapDrawableDecoder<>(resources, streamBitmapDecoder))
+        .append(
+            Registry.BUCKET_BITMAP_DRAWABLE,
+            ParcelFileDescriptor.class,
+            BitmapDrawable.class,
+            new BitmapDrawableDecoder<>(resources, parcelFileDescriptorVideoDecoder))
+        .append(BitmapDrawable.class, new BitmapDrawableEncoder(bitmapPool, bitmapEncoder));
+  }
+
+  private void registerGifs() {
+    registry
+        .append(
+            Registry.BUCKET_GIF,
+            InputStream.class,
+            GifDrawable.class,
+            new StreamGifDecoder(registry.getImageHeaderParsers(), byteBufferGifDecoder, arrayPool))
+        .append(Registry.BUCKET_GIF, ByteBuffer.class, GifDrawable.class, byteBufferGifDecoder)
+        .append(GifDrawable.class, new GifDrawableEncoder());
+  }
+
+  private void registerGifFrames() {
+    registry
+        // Compilation with Gradle requires the type to be specified for UnitModelLoader here.
+        .append(
+            GifDecoder.class, GifDecoder.class, UnitModelLoader.Factory.<GifDecoder>getInstance())
+        .append(
+            Registry.BUCKET_BITMAP,
+            GifDecoder.class,
+            Bitmap.class,
+            new GifFrameResourceDecoder(bitmapPool));
+  }
+
+  private void registerDrawables() {
+    registry
+        .append(Uri.class, Drawable.class, resourceDrawableDecoder)
+        .append(Uri.class, Bitmap.class,
+            new ResourceBitmapDecoder(resourceDrawableDecoder, bitmapPool));
+  }
+
+  private void registerFiles() {
+    registry
+        .register(new ByteBufferRewinder.Factory())
+        .append(File.class, ByteBuffer.class, new ByteBufferFileLoader.Factory())
+        .append(File.class, InputStream.class, new FileLoader.StreamFactory())
+        .append(File.class, File.class, new FileDecoder())
+        .append(File.class, ParcelFileDescriptor.class, new FileLoader.FileDescriptorFactory())
+        // Compilation with Gradle requires the type to be specified for UnitModelLoader here.
+        .append(File.class, File.class, UnitModelLoader.Factory.<File>getInstance());
+  }
+
+  private void registerModels() {
+    registry
+        .register(new InputStreamRewinder.Factory(arrayPool))
+        .append(int.class, InputStream.class, resourceLoaderStreamFactory)
+        .append(
+            int.class,
+            ParcelFileDescriptor.class,
+            resourceLoaderFileDescriptorFactory)
+        .append(Integer.class, InputStream.class, resourceLoaderStreamFactory)
+        .append(
+            Integer.class,
+            ParcelFileDescriptor.class,
+            resourceLoaderFileDescriptorFactory)
+        .append(Integer.class, Uri.class, resourceLoaderUriFactory)
+        .append(
+            int.class,
+            AssetFileDescriptor.class,
+            resourceLoaderAssetFileDescriptorFactory)
+        .append(
+            Integer.class,
+            AssetFileDescriptor.class,
+            resourceLoaderAssetFileDescriptorFactory)
+        .append(int.class, Uri.class, resourceLoaderUriFactory)
+        .append(String.class, InputStream.class, new DataUrlLoader.StreamFactory())
+        .append(String.class, InputStream.class, new StringLoader.StreamFactory())
+        .append(String.class, ParcelFileDescriptor.class, new StringLoader.FileDescriptorFactory())
+        .append(
+            String.class, AssetFileDescriptor.class, new StringLoader.AssetFileDescriptorFactory())
+        .append(Uri.class, InputStream.class, new HttpUriLoader.Factory())
+        .append(Uri.class, InputStream.class, new AssetUriLoader.StreamFactory(context.getAssets()))
+        .append(
+            Uri.class,
+            ParcelFileDescriptor.class,
+            new AssetUriLoader.FileDescriptorFactory(context.getAssets()))
+        .append(Uri.class, InputStream.class, new MediaStoreImageThumbLoader.Factory(context))
+        .append(Uri.class, InputStream.class, new MediaStoreVideoThumbLoader.Factory(context))
+        .append(
+            Uri.class,
+            InputStream.class,
+            new UriLoader.StreamFactory(contentResolver))
+        .append(
+            Uri.class,
+            ParcelFileDescriptor.class,
+            new UriLoader.FileDescriptorFactory(contentResolver))
+        .append(
+            Uri.class,
+            AssetFileDescriptor.class,
+            new UriLoader.AssetFileDescriptorFactory(contentResolver))
+        .append(Uri.class, InputStream.class, new UrlUriLoader.StreamFactory())
+        .append(URL.class, InputStream.class, new UrlLoader.StreamFactory())
+        .append(Uri.class, File.class, new MediaStoreFileLoader.Factory(context))
+        .append(GlideUrl.class, InputStream.class, new HttpGlideUrlLoader.Factory())
+        .append(byte[].class, ByteBuffer.class, new ByteArrayLoader.ByteBufferFactory())
+        .append(byte[].class, InputStream.class, new ByteArrayLoader.StreamFactory())
+        .append(Uri.class, Uri.class, UnitModelLoader.Factory.<Uri>getInstance())
+        .append(Drawable.class, Drawable.class, UnitModelLoader.Factory.<Drawable>getInstance())
+        .append(Drawable.class, Drawable.class, new UnitDrawableDecoder());
+  }
+
+  private void registerTranscoders() {
+    registry
+        .register(
+            Bitmap.class,
+            BitmapDrawable.class,
+            new BitmapDrawableTranscoder(resources))
+        .register(Bitmap.class, byte[].class, bitmapBytesTranscoder)
+        .register(
+            Drawable.class,
+            byte[].class,
+            new DrawableBytesTranscoder(
+                bitmapPool, bitmapBytesTranscoder, gifDrawableBytesTranscoder))
+        .register(GifDrawable.class, byte[].class, gifDrawableBytesTranscoder);
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/GeneratedAppGlideModule.java
+++ b/library/src/main/java/com/bumptech/glide/GeneratedAppGlideModule.java
@@ -20,7 +20,5 @@ abstract class GeneratedAppGlideModule extends AppGlideModule {
   abstract Set<Class<?>> getExcludedModuleClasses();
 
   @Nullable
-  RequestManagerRetriever.RequestManagerFactory getRequestManagerFactory() {
-    return null;
-  }
+  abstract RequestManagerRetriever.RequestManagerFactory getRequestManagerFactory();
 }

--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -257,12 +257,12 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
     }
 
     @Override
-    public void getSize(@NonNull SizeReadyCallback cb) {
-      cb.onSizeReady(photoWidth, photoHeight);
+    public void getSize(@NonNull SizeReadyCallback callback) {
+      callback.onSizeReady(photoWidth, photoHeight);
     }
 
     @Override
-    public void removeCallback(@NonNull SizeReadyCallback cb) {
+    public void removeCallback(@NonNull SizeReadyCallback callback) {
       // Do nothing because we don't retain references to SizeReadyCallbacks.
     }
   }

--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -154,7 +154,7 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
     preload(start, start + (increasing ? maxPreload : -maxPreload));
   }
 
-  private void preload(int from, int to) {
+  private void preload(int from, @SuppressWarnings("PMD.ShortVariable") int to) {
     int start;
     int end;
     if (from < to) {

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -543,6 +543,7 @@ public class RequestManager implements LifecycleListener,
    */
   @NonNull
   @CheckResult
+  @SuppressWarnings("PMD.ShortMethodName")
   public <ResourceType> RequestBuilder<ResourceType> as(
       @NonNull Class<ResourceType> resourceClass) {
     return new RequestBuilder<>(glide, this, resourceClass, context);

--- a/library/src/main/java/com/bumptech/glide/load/Key.java
+++ b/library/src/main/java/com/bumptech/glide/load/Key.java
@@ -12,6 +12,7 @@ import java.security.MessageDigest;
  * #updateDiskCacheKey(java.security.MessageDigest)}}, although this requirement is not as strict
  * for partial cache key signatures.
  */
+@SuppressWarnings("PMD.ShortClassName")
 public interface Key {
   String STRING_CHARSET_NAME = "UTF-8";
   Charset CHARSET = Charset.forName(STRING_CHARSET_NAME);

--- a/library/src/main/java/com/bumptech/glide/load/Options.java
+++ b/library/src/main/java/com/bumptech/glide/load/Options.java
@@ -56,7 +56,7 @@ public final class Options implements Key {
   }
 
   @SuppressWarnings("unchecked")
-  private static <T> void updateDiskCacheKey(Option<T> option, Object value, MessageDigest md) {
-    option.update((T) value, md);
+  private static <T> void updateDiskCacheKey(Option<T> option, Object value, MessageDigest digest) {
+    option.update((T) value, digest);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/data/ExifOrientationStream.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/ExifOrientationStream.java
@@ -63,8 +63,8 @@ public final class ExifOrientationStream extends FilterInputStream {
   private final byte orientation;
   private int position;
 
-  public ExifOrientationStream(InputStream in, int orientation) {
-    super(in);
+  public ExifOrientationStream(InputStream is, int orientation) {
+    super(is);
     if (orientation < -1 || orientation > 8) {
       throw new IllegalArgumentException("Cannot add invalid orientation: " + orientation);
     }

--- a/library/src/main/java/com/bumptech/glide/load/engine/ActiveResources.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/ActiveResources.java
@@ -49,7 +49,7 @@ final class ActiveResources {
   private Thread cleanReferenceQueueThread;
   private volatile boolean isShutdown;
   @Nullable
-  private volatile DequeuedResourceCallback cb;
+  private volatile DequeuedResourceCallback callback;
 
   ActiveResources(boolean isActiveResourceRetentionAllowed) {
     this.isActiveResourceRetentionAllowed = isActiveResourceRetentionAllowed;
@@ -132,7 +132,7 @@ final class ActiveResources {
         mainHandler.obtainMessage(MSG_CLEAN_REF, ref).sendToTarget();
 
         // This section for testing only.
-        DequeuedResourceCallback current = cb;
+        DequeuedResourceCallback current = callback;
         if (current != null) {
           current.onResourceDequeued();
         }
@@ -144,8 +144,8 @@ final class ActiveResources {
   }
 
   @VisibleForTesting
-  void setDequeuedResourceCallback(DequeuedResourceCallback cb) {
-    this.cb = cb;
+  void setDequeuedResourceCallback(DequeuedResourceCallback callback) {
+    this.callback = callback;
   }
 
   @VisibleForTesting

--- a/library/src/main/java/com/bumptech/glide/load/engine/DataCacheGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DataCacheGenerator.java
@@ -18,7 +18,7 @@ class DataCacheGenerator implements DataFetcherGenerator,
 
   private final List<Key> cacheKeys;
   private final DecodeHelper<?> helper;
-  private final FetcherReadyCallback cb;
+  private final FetcherReadyCallback callback;
 
   private int sourceIdIndex = -1;
   private Key sourceKey;
@@ -30,16 +30,16 @@ class DataCacheGenerator implements DataFetcherGenerator,
   @SuppressWarnings("PMD.SingularField")
   private File cacheFile;
 
-  DataCacheGenerator(DecodeHelper<?> helper, FetcherReadyCallback cb) {
-    this(helper.getCacheKeys(), helper, cb);
+  DataCacheGenerator(DecodeHelper<?> helper, FetcherReadyCallback callback) {
+    this(helper.getCacheKeys(), helper, callback);
   }
 
   // In some cases we may want to load a specific cache key (when loading from source written to
   // cache), so we accept a list of keys rather than just obtain the list from the helper.
-  DataCacheGenerator(List<Key> cacheKeys, DecodeHelper<?> helper, FetcherReadyCallback cb) {
+  DataCacheGenerator(List<Key> cacheKeys, DecodeHelper<?> helper, FetcherReadyCallback callback) {
     this.cacheKeys = cacheKeys;
     this.helper = helper;
-    this.cb = cb;
+    this.callback = callback;
   }
 
   @Override
@@ -92,11 +92,12 @@ class DataCacheGenerator implements DataFetcherGenerator,
 
   @Override
   public void onDataReady(Object data) {
-    cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.DATA_DISK_CACHE, sourceKey);
+    callback.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.DATA_DISK_CACHE,
+        sourceKey);
   }
 
   @Override
   public void onLoadFailed(@NonNull Exception e) {
-    cb.onDataFetcherFailed(sourceKey, e, loadData.fetcher, DataSource.DATA_DISK_CACHE);
+    callback.onDataFetcherFailed(sourceKey, e, loadData.fetcher, DataSource.DATA_DISK_CACHE);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
@@ -228,7 +228,7 @@ class DecodeJob<R> implements DataFetcherGenerator.FetcherReadyCallback,
         return;
       }
       runWrapped();
-    } catch (Throwable t) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingThrowable") Throwable t) {
       // Catch Throwable and not Exception to handle OOMs. Throwables are swallowed by our
       // usage of .submit() in GlideExecutor so we're not silently hiding crashes by doing this. We
       // are however ensuring that our callbacks are always notified when a load fails. Without this

--- a/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DecodeJob.java
@@ -316,8 +316,9 @@ class DecodeJob<R> implements DataFetcherGenerator.FetcherReadyCallback,
 
   private void notifyFailed() {
     setNotifiedOrThrow();
-    GlideException e = new GlideException("Failed to load resource", new ArrayList<>(throwables));
-    callback.onLoadFailed(e);
+    GlideException allFailuresException =
+        new GlideException("Failed to load resource", new ArrayList<>(throwables));
+    callback.onLoadFailed(allFailuresException);
     onLoadFailed();
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/DecodePath.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/DecodePath.java
@@ -68,9 +68,10 @@ public class DecodePath<DataType, ResourceType, Transcode> {
           data = rewinder.rewindAndGet();
           result = decoder.decode(data, width, height, options);
         }
-        // Some decoders throw unexpectedly. If they do, we shouldn't fail the entire load path, but
-        // instead log and continue. See #2406 for an example.
-      } catch (IOException | RuntimeException | OutOfMemoryError e) {
+      } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException")
+          IOException | RuntimeException | OutOfMemoryError e) {
+        // Some decoders throw unexpectedly. See #2406 for an example.
+        // If they do, we shouldn't fail the entire load path, but instead log and continue.
         if (Log.isLoggable(TAG, Log.VERBOSE)) {
           Log.v(TAG, "Failed to decode data for " + decoder, e);
         }

--- a/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
@@ -33,7 +33,7 @@ public class Engine implements EngineJobListener,
     EngineResource.ResourceListener {
   private static final String TAG = "Engine";
   private static final int JOB_POOL_SIZE = 150;
-  private final Jobs jobs;
+  private final EngineJobs jobs;
   private final EngineKeyFactory keyFactory;
   private final MemoryCache cache;
   private final EngineJobFactory engineJobFactory;
@@ -73,7 +73,7 @@ public class Engine implements EngineJobListener,
       GlideExecutor sourceExecutor,
       GlideExecutor sourceUnlimitedExecutor,
       GlideExecutor animationExecutor,
-      Jobs jobs,
+      EngineJobs jobs,
       EngineKeyFactory keyFactory,
       ActiveResources activeResources,
       EngineJobFactory engineJobFactory,
@@ -95,7 +95,7 @@ public class Engine implements EngineJobListener,
     this.keyFactory = keyFactory;
 
     if (jobs == null) {
-      jobs = new Jobs();
+      jobs = new EngineJobs();
     }
     this.jobs = jobs;
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/EngineJobs.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/EngineJobs.java
@@ -6,7 +6,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 
-final class Jobs {
+final class EngineJobs {
   private final Map<Key, EngineJob<?>> jobs = new HashMap<>();
   private final Map<Key, EngineJob<?>> onlyCacheJobs = new HashMap<>();
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
@@ -37,6 +37,7 @@ public final class GlideException extends Exception {
   }
 
   public GlideException(String detailMessage, List<Throwable> causes) {
+    super(detailMessage, null);
     this.detailMessage = detailMessage;
     setStackTrace(EMPTY_ELEMENTS);
     this.causes = causes;

--- a/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
@@ -214,13 +214,13 @@ public final class GlideException extends Exception {
     }
 
     @Override
-    public Appendable append(char c) throws IOException {
+    public Appendable append(char chr) throws IOException {
       if (printedNewLine) {
         printedNewLine = false;
         appendable.append(INDENT);
       }
-      printedNewLine = c == '\n';
-      appendable.append(c);
+      printedNewLine = chr == '\n';
+      appendable.append(chr);
       return this;
     }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/ResourceCacheGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/ResourceCacheGenerator.java
@@ -17,7 +17,7 @@ import java.util.List;
 class ResourceCacheGenerator implements DataFetcherGenerator,
     DataFetcher.DataCallback<Object> {
 
-  private final FetcherReadyCallback cb;
+  private final FetcherReadyCallback callback;
   private final DecodeHelper<?> helper;
 
   private int sourceIdIndex;
@@ -32,9 +32,9 @@ class ResourceCacheGenerator implements DataFetcherGenerator,
   private File cacheFile;
   private ResourceCacheKey currentKey;
 
-  ResourceCacheGenerator(DecodeHelper<?> helper, FetcherReadyCallback cb) {
+  ResourceCacheGenerator(DecodeHelper<?> helper, FetcherReadyCallback callback) {
     this.helper = helper;
-    this.cb = cb;
+    this.callback = callback;
   }
 
   @Override
@@ -107,12 +107,12 @@ class ResourceCacheGenerator implements DataFetcherGenerator,
 
   @Override
   public void onDataReady(Object data) {
-    cb.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE,
+    callback.onDataFetcherReady(sourceKey, data, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE,
         currentKey);
   }
 
   @Override
   public void onLoadFailed(@NonNull Exception e) {
-    cb.onDataFetcherFailed(currentKey, e, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE);
+    callback.onDataFetcherFailed(currentKey, e, loadData.fetcher, DataSource.RESOURCE_DISK_CACHE);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/SourceGenerator.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/SourceGenerator.java
@@ -25,7 +25,7 @@ class SourceGenerator implements DataFetcherGenerator,
   private static final String TAG = "SourceGenerator";
 
   private final DecodeHelper<?> helper;
-  private final FetcherReadyCallback cb;
+  private final FetcherReadyCallback callback;
 
   private int loadDataListIndex;
   private DataCacheGenerator sourceCacheGenerator;
@@ -33,9 +33,9 @@ class SourceGenerator implements DataFetcherGenerator,
   private volatile ModelLoader.LoadData<?> loadData;
   private DataCacheKey originalKey;
 
-  SourceGenerator(DecodeHelper<?> helper, FetcherReadyCallback cb) {
+  SourceGenerator(DecodeHelper<?> helper, FetcherReadyCallback callback) {
     this.helper = helper;
-    this.cb = cb;
+    this.callback = callback;
   }
 
   @Override
@@ -107,16 +107,17 @@ class SourceGenerator implements DataFetcherGenerator,
       dataToCache = data;
       // We might be being called back on someone else's thread. Before doing anything, we should
       // reschedule to get back onto Glide's thread.
-      cb.reschedule();
+      callback.reschedule();
     } else {
-      cb.onDataFetcherReady(loadData.sourceKey, data, loadData.fetcher,
+      callback.onDataFetcherReady(loadData.sourceKey, data, loadData.fetcher,
           loadData.fetcher.getDataSource(), originalKey);
     }
   }
 
   @Override
   public void onLoadFailed(@NonNull Exception e) {
-    cb.onDataFetcherFailed(originalKey, e, loadData.fetcher, loadData.fetcher.getDataSource());
+    DataFetcher<?> fetcher = loadData.fetcher;
+    callback.onDataFetcherFailed(originalKey, e, fetcher, fetcher.getDataSource());
   }
 
   @Override
@@ -132,12 +133,13 @@ class SourceGenerator implements DataFetcherGenerator,
       DataSource dataSource, Key attemptedKey) {
     // This data fetcher will be loading from a File and provide the wrong data source, so override
     // with the data source of the original fetcher
-    cb.onDataFetcherReady(sourceKey, data, fetcher, loadData.fetcher.getDataSource(), sourceKey);
+    DataSource originalDataSource = loadData.fetcher.getDataSource();
+    callback.onDataFetcherReady(sourceKey, data, fetcher, originalDataSource, sourceKey);
   }
 
   @Override
   public void onDataFetcherFailed(Key sourceKey, Exception e, DataFetcher<?> fetcher,
       DataSource dataSource) {
-    cb.onDataFetcherFailed(sourceKey, e, fetcher, loadData.fetcher.getDataSource());
+    callback.onDataFetcherFailed(sourceKey, e, fetcher, loadData.fetcher.getDataSource());
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
@@ -444,7 +444,8 @@ public final class GlideExecutor implements ExecutorService {
           }
           try {
             super.run();
-          } catch (Throwable t) {
+          } catch (@SuppressWarnings("PMD.AvoidCatchingThrowable") Throwable t) {
+            // TODO consider using result.setUncaughtExceptionHandler instead
             uncaughtThrowableStrategy.handle(t);
           }
         }

--- a/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
@@ -242,9 +242,9 @@ public final class LazyHeaders implements Headers {
       int length = defaultUserAgent.length();
       StringBuilder sb = new StringBuilder(defaultUserAgent.length());
       for (int i = 0; i < length; i++) {
-        char c = defaultUserAgent.charAt(i);
-        if ((c > '\u001f' || c == '\t') && c < '\u007f') {
-          sb.append(c);
+        char chr = defaultUserAgent.charAt(i);
+        if ((chr > '\u001f' || chr == '\t') && chr < '\u007f') {
+          sb.append(chr);
         } else {
           sb.append('?');
         }

--- a/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoaderFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoaderFactory.java
@@ -225,13 +225,13 @@ public class MultiModelLoaderFactory {
 
     @Nullable
     @Override
-    public LoadData<Object> buildLoadData(@NonNull Object o, int width, int height,
+    public LoadData<Object> buildLoadData(@NonNull Object model, int width, int height,
         @NonNull Options options) {
       return null;
     }
 
     @Override
-    public boolean handles(@NonNull Object o) {
+    public boolean handles(@NonNull Object model) {
       return false;
     }
   }

--- a/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoaderFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/MultiModelLoaderFactory.java
@@ -108,7 +108,8 @@ public class MultiModelLoaderFactory {
         }
       }
       return loaders;
-    } catch (Throwable t) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingThrowable") Throwable t) {
+      // PMD.AvoidCatchingThrowable clean up is needed only when an error happened
       alreadyUsedEntries.clear();
       throw t;
     }
@@ -161,7 +162,8 @@ public class MultiModelLoaderFactory {
           throw new NoModelLoaderAvailableException(modelClass, dataClass);
         }
       }
-    } catch (Throwable t) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingThrowable") Throwable t) {
+      // PMD.AvoidCatchingThrowable clean up is needed only when an error happened
       alreadyUsedEntries.clear();
       throw t;
     }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
@@ -1,11 +1,5 @@
 package com.bumptech.glide.load.resource.bitmap;
 
-import static com.bumptech.glide.load.ImageHeaderParser.ImageType.GIF;
-import static com.bumptech.glide.load.ImageHeaderParser.ImageType.JPEG;
-import static com.bumptech.glide.load.ImageHeaderParser.ImageType.PNG;
-import static com.bumptech.glide.load.ImageHeaderParser.ImageType.PNG_A;
-import static com.bumptech.glide.load.ImageHeaderParser.ImageType.UNKNOWN;
-
 import android.util.Log;
 import com.bumptech.glide.load.ImageHeaderParser;
 import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
@@ -83,7 +77,7 @@ public final class DefaultImageHeaderParser implements ImageHeaderParser {
 
     // JPEG.
     if (firstTwoBytes == EXIF_MAGIC_NUMBER) {
-      return JPEG;
+      return ImageType.JPEG;
     }
 
     final int firstFourBytes = (firstTwoBytes << 16 & 0xFFFF0000) | (reader.getUInt16() & 0xFFFF);
@@ -94,30 +88,30 @@ public final class DefaultImageHeaderParser implements ImageHeaderParser {
       reader.skip(25 - 4);
       int alpha = reader.getByte();
       // A RGB indexed PNG can also have transparency. Better safe than sorry!
-      return alpha >= 3 ? PNG_A : PNG;
+      return alpha >= 3 ? ImageType.PNG_A : ImageType.PNG;
     }
 
     // GIF from first 3 bytes.
     if (firstFourBytes >> 8 == GIF_HEADER) {
-      return GIF;
+      return ImageType.GIF;
     }
 
     // WebP (reads up to 21 bytes). See https://developers.google.com/speed/webp/docs/riff_container
     // for details.
     if (firstFourBytes != RIFF_HEADER) {
-      return UNKNOWN;
+      return ImageType.UNKNOWN;
     }
     // Bytes 4 - 7 contain length information. Skip these.
     reader.skip(4);
     final int thirdFourBytes =
         (reader.getUInt16() << 16 & 0xFFFF0000) | (reader.getUInt16() & 0xFFFF);
     if (thirdFourBytes != WEBP_HEADER) {
-      return UNKNOWN;
+      return ImageType.UNKNOWN;
     }
     final int fourthFourBytes =
         (reader.getUInt16() << 16 & 0xFFFF0000) | (reader.getUInt16() & 0xFFFF);
     if ((fourthFourBytes & VP8_HEADER_MASK) != VP8_HEADER) {
-      return UNKNOWN;
+      return ImageType.UNKNOWN;
     }
     if ((fourthFourBytes & VP8_HEADER_TYPE_MASK) == VP8_HEADER_TYPE_EXTENDED) {
       // Skip some more length bytes and check for transparency/alpha flag.

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
@@ -240,6 +240,7 @@ public final class DefaultImageHeaderParser implements ImageHeaderParser {
     }
   }
 
+  @SuppressWarnings("PMD.AvoidBranchingStatementAsLastInLoop")
   private static int parseExifSegment(RandomAccessReader segmentData) {
     final int headerOffsetSize = JPEG_EXIF_SEGMENT_PREAMBLE.length();
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
@@ -61,7 +61,7 @@ public abstract class DownsampleStrategy {
   /**
    * Performs no downsampling or scaling.
    */
-  public static final DownsampleStrategy NONE = new None();
+  public static final DownsampleStrategy NONE = new NoScaling();
 
   /**
    * Default strategy, currently {@link #CENTER_OUTSIDE}.
@@ -183,10 +183,10 @@ public abstract class DownsampleStrategy {
     }
   }
 
-  private static class None extends DownsampleStrategy {
+  private static class NoScaling extends DownsampleStrategy {
 
     @Synthetic
-    None() { }
+    NoScaling() { }
 
     @Override
     public float getScaleFactor(int sourceWidth, int sourceHeight, int requestedWidth,

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStream.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStream.java
@@ -65,14 +65,14 @@ public class RecyclableBufferedInputStream extends FilterInputStream {
   private int pos;
   private final ArrayPool byteArrayPool;
 
-  public RecyclableBufferedInputStream(InputStream in, ArrayPool byteArrayPool) {
-    this(in, byteArrayPool, ArrayPool.STANDARD_BUFFER_SIZE_BYTES);
+  public RecyclableBufferedInputStream(InputStream is, ArrayPool byteArrayPool) {
+    this(is, byteArrayPool, ArrayPool.STANDARD_BUFFER_SIZE_BYTES);
   }
 
   @VisibleForTesting
-  RecyclableBufferedInputStream(InputStream in, ArrayPool byteArrayPool,
+  RecyclableBufferedInputStream(InputStream is, ArrayPool byteArrayPool,
       int bufferSize) {
-    super(in);
+    super(is);
     this.byteArrayPool = byteArrayPool;
     buf = byteArrayPool.get(bufferSize, byte[].class);
   }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RoundedCorners.java
@@ -22,6 +22,7 @@ public final class RoundedCorners extends BitmapTransformation {
    * @throws IllegalArgumentException if rounding radius is 0 or less.
    */
   public RoundedCorners(int roundingRadius) {
+    super();
     Preconditions.checkArgument(roundingRadius > 0, "roundingRadius must be greater than 0.");
     this.roundingRadius = roundingRadius;
   }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -254,6 +254,7 @@ public final class TransformationUtils {
    *                        returned unmodified.
    * @return The oriented bitmap. May be the imageToOrient without modification, or a new Bitmap.
    */
+  // TODO why do we have this method, it's not used? @Deprecate and remove?
   public static Bitmap rotateImage(@NonNull Bitmap imageToOrient, int degreesToRotate) {
     Bitmap result = imageToOrient;
     try {
@@ -263,7 +264,8 @@ public final class TransformationUtils {
         result = Bitmap.createBitmap(imageToOrient, 0, 0, imageToOrient.getWidth(),
             imageToOrient.getHeight(), matrix, true /*filter*/);
       }
-    } catch (Exception e) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException e) {
+      // Any failure we ignore, but log the problem.
       if (Log.isLoggable(TAG, Log.ERROR)) {
         Log.e(TAG, "Exception when trying to orient image", e);
       }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -120,28 +120,28 @@ public final class TransformationUtils {
       return inBitmap;
     }
     // From ImageView/Bitmap.createScaledBitmap.
-    final float scale;
-    final float dx;
-    final float dy;
-    Matrix m = new Matrix();
+    final float scaleFactor;
+    final float translateDeltaX;
+    final float translateDeltaY;
+    Matrix matrix = new Matrix();
     if (inBitmap.getWidth() * height > width * inBitmap.getHeight()) {
-      scale = (float) height / (float) inBitmap.getHeight();
-      dx = (width - inBitmap.getWidth() * scale) * 0.5f;
-      dy = 0;
+      scaleFactor = (float) height / (float) inBitmap.getHeight();
+      translateDeltaX = (width - inBitmap.getWidth() * scaleFactor) * 0.5f;
+      translateDeltaY = 0;
     } else {
-      scale = (float) width / (float) inBitmap.getWidth();
-      dx = 0;
-      dy = (height - inBitmap.getHeight() * scale) * 0.5f;
+      scaleFactor = (float) width / (float) inBitmap.getWidth();
+      translateDeltaX = 0;
+      translateDeltaY = (height - inBitmap.getHeight() * scaleFactor) * 0.5f;
     }
 
-    m.setScale(scale, scale);
-    m.postTranslate((int) (dx + 0.5f), (int) (dy + 0.5f));
+    matrix.setScale(scaleFactor, scaleFactor);
+    matrix.postTranslate((int) (translateDeltaX + 0.5f), (int) (translateDeltaY + 0.5f));
 
     Bitmap result = pool.get(width, height, getSafeConfig(inBitmap));
     // We don't add or remove alpha, so keep the alpha setting of the Bitmap we were given.
     TransformationUtils.setAlpha(inBitmap, result);
 
-    applyMatrix(inBitmap, result, m);
+    applyMatrix(inBitmap, result, matrix);
     return result;
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/VideoDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/VideoDecoder.java
@@ -151,7 +151,7 @@ public class VideoDecoder<T> implements ResourceDecoder<T, Bitmap> {
       initializer.initialize(mediaMetadataRetriever, resource);
       result =
           decodeFrame(mediaMetadataRetriever, frameTimeMicros, frameOption, outWidth, outHeight);
-    } catch (RuntimeException e) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException e) {
       // MediaMetadataRetriever APIs throw generic runtime exceptions when given invalid data.
       throw new IOException(e);
     } finally {

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableDecoderCompat.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableDecoderCompat.java
@@ -15,6 +15,7 @@ import android.support.v7.content.res.AppCompatResources;
  */
 public final class DrawableDecoderCompat {
   private static volatile boolean shouldCallAppCompatResources = true;
+
   private DrawableDecoderCompat() {
     // Utility class.
   }
@@ -22,8 +23,8 @@ public final class DrawableDecoderCompat {
   /**
    * See {@code getDrawable(Context, int, Theme)}.
    */
-  public static Drawable getDrawable(Context context, @DrawableRes int id) {
-    return getDrawable(context, id, /*theme=*/ null);
+  public static Drawable getDrawable(Context context, @DrawableRes int drawableId) {
+    return getDrawable(context, drawableId, /*theme=*/ null);
   }
 
   /**
@@ -31,14 +32,15 @@ public final class DrawableDecoderCompat {
    * otherwise, depending on whether or not the v7 support library is included in the application.
    *
    * @param theme Used instead of the {@link Theme} returned from the given {@link Context} if
-   * non-null when loading the {@link Drawable}.
+   *              non-null when loading the {@link Drawable}.
    */
-  public static Drawable getDrawable(Context context, @DrawableRes int id, @Nullable Theme theme) {
+  public static Drawable getDrawable(
+      Context context, @DrawableRes int drawableId, @Nullable Theme theme) {
     try {
       // Race conditions may cause us to attempt to load using v7 more than once. That's ok since
       // this check is a modest optimization and the output will be correct anyway.
       if (shouldCallAppCompatResources) {
-        return loadDrawableV7(context, id);
+        return loadDrawableV7(context, drawableId);
       }
     } catch (NoClassDefFoundError error) {
       shouldCallAppCompatResources = false;
@@ -47,16 +49,16 @@ public final class DrawableDecoderCompat {
       // that decode attempt fails, we still want to try with the v4 ResourcesCompat below.
     }
 
-    return loadDrawableV4(context, id, theme != null ? theme : context.getTheme());
+    return loadDrawableV4(context, drawableId, theme != null ? theme : context.getTheme());
   }
 
-  private static Drawable loadDrawableV7(Context context, @DrawableRes int id) {
-    return AppCompatResources.getDrawable(context, id);
+  private static Drawable loadDrawableV7(Context context, @DrawableRes int drawableId) {
+    return AppCompatResources.getDrawable(context, drawableId);
   }
 
   private static Drawable loadDrawableV4(
-      Context context, @DrawableRes int id, @Nullable Theme theme) {
+      Context context, @DrawableRes int drawableId, @Nullable Theme theme) {
     Resources resources = context.getResources();
-    return ResourcesCompat.getDrawable(resources, id, theme);
+    return ResourcesCompat.getDrawable(resources, drawableId, theme);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -298,8 +298,8 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
   }
 
   @Override
-  public void setAlpha(int i) {
-    getPaint().setAlpha(i);
+  public void setAlpha(int alpha) {
+    getPaint().setAlpha(alpha);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -148,6 +148,7 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
   }
 
   GifDrawable(GifState state) {
+    super();
     this.state = Preconditions.checkNotNull(state);
   }
 
@@ -395,6 +396,7 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
     final GifFrameLoader frameLoader;
 
     GifState(GifFrameLoader frameLoader) {
+      super();
       this.frameLoader = frameLoader;
     }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
@@ -273,8 +273,8 @@ class GifFrameLoader {
       // The callbacks may unregister when onFrameReady is called, so iterate in reverse to avoid
       // concurrent modifications.
       for (int i = callbacks.size() - 1; i >= 0; i--) {
-        FrameCallback cb = callbacks.get(i);
-        cb.onFrameReady();
+        FrameCallback callback = callbacks.get(i);
+        callback.onFrameReady();
       }
       if (previous != null) {
         handler.obtainMessage(FrameLoaderCallback.MSG_CLEAR, previous).sendToTarget();

--- a/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitor.java
+++ b/library/src/main/java/com/bumptech/glide/manager/DefaultConnectivityMonitor.java
@@ -82,14 +82,14 @@ final class DefaultConnectivityMonitor implements ConnectivityMonitor {
     NetworkInfo networkInfo;
     try {
       networkInfo = connectivityManager.getActiveNetworkInfo();
-    } catch (RuntimeException e) {
+    } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException e) {
       // #1405 shows that this throws a SecurityException.
       // b/70869360 shows that this throws NullPointerException on APIs 22, 23, and 24.
       // b/70869360 also shows that this throws RuntimeException on API 24 and 25.
       if (Log.isLoggable(TAG, Log.WARN)) {
         Log.w(TAG, "Failed to determine connectivity status when connectivity changed", e);
       }
-      // Default to true;
+      // Default to true; i.e. assume we're connected, otherwise RequestManager may misbehave.
       return true;
     }
     return networkInfo != null && networkInfo.isConnected();

--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerFragment.java
@@ -41,6 +41,7 @@ public class RequestManagerFragment extends Fragment {
   // For testing only.
   @SuppressLint("ValidFragment")
   RequestManagerFragment(ActivityFragmentLifecycle lifecycle) {
+    super();
     this.lifecycle = lifecycle;
   }
 

--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -279,8 +279,9 @@ public class RequestManagerRetriever implements Handler.Callback {
       android.app.Fragment fragment = null;
       try {
         fragment = fragmentManager.getFragment(tempBundle, FRAGMENT_INDEX_KEY);
-      } catch (Exception e) {
-        // This generates log spam from FragmentManager anyway.
+      } catch (@SuppressWarnings("PMD.AvoidCatchingGenericException") RuntimeException e) {
+        // Ignore any exceptions; this generates log spam from FragmentManager anyway.
+        // See android.app.FragmentManagerImpl#throwException.
       }
       if (fragment == null) {
         break;

--- a/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
@@ -40,6 +40,7 @@ public class SupportRequestManagerFragment extends Fragment {
   // For testing only.
   @SuppressLint("ValidFragment")
   public SupportRequestManagerFragment(ActivityFragmentLifecycle lifecycle) {
+    super();
     this.lifecycle = lifecycle;
   }
 

--- a/library/src/main/java/com/bumptech/glide/request/ErrorRequestCoordinator.java
+++ b/library/src/main/java/com/bumptech/glide/request/ErrorRequestCoordinator.java
@@ -87,9 +87,9 @@ public final class ErrorRequestCoordinator implements RequestCoordinator,
   }
 
   @Override
-  public boolean isEquivalentTo(Request o) {
-    if (o instanceof ErrorRequestCoordinator) {
-      ErrorRequestCoordinator other = (ErrorRequestCoordinator) o;
+  public boolean isEquivalentTo(Request request) {
+    if (request instanceof ErrorRequestCoordinator) {
+      ErrorRequestCoordinator other = (ErrorRequestCoordinator) request;
       return primary.isEquivalentTo(other.primary) && error.isEquivalentTo(other.error);
     }
     return false;

--- a/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
@@ -128,12 +128,12 @@ public class RequestFutureTarget<R> implements FutureTarget<R>,
    * A callback that should never be invoked directly.
    */
   @Override
-  public void getSize(@NonNull SizeReadyCallback cb) {
-    cb.onSizeReady(width, height);
+  public void getSize(@NonNull SizeReadyCallback callback) {
+    callback.onSizeReady(width, height);
   }
 
   @Override
-  public void removeCallback(@NonNull SizeReadyCallback cb) {
+  public void removeCallback(@NonNull SizeReadyCallback callback) {
     // Do nothing because we do not retain references to SizeReadyCallbacks.
   }
 

--- a/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
@@ -40,7 +40,14 @@ import java.util.Map;
 /**
  * Provides type independent options to customize loads with Glide.
  */
-@SuppressWarnings({"PMD.UseUtilityClass", "unused"})
+@SuppressWarnings({
+    // Glide has a lot of options that can customize the load, it's not feasible to split this.
+    "PMD.ExcessivePublicCount",
+    "PMD.ExcessiveClassLength",
+    "PMD.ExcessiveImports",
+    "PMD.TooManyMethods",
+    "PMD.TooManyFields"
+})
 public class RequestOptions implements Cloneable {
   private static final int UNSET = -1;
   private static final int SIZE_MULTIPLIER = 1 << 1;

--- a/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
+++ b/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
@@ -623,20 +623,20 @@ public final class SingleRequest<R> implements Request,
   }
 
   @Override
-  public boolean isEquivalentTo(Request o) {
-    if (o instanceof SingleRequest) {
-      SingleRequest<?> that = (SingleRequest<?>) o;
-      return overrideWidth == that.overrideWidth
-          && overrideHeight == that.overrideHeight
-          && Util.bothModelsNullEquivalentOrEquals(model, that.model)
-          && transcodeClass.equals(that.transcodeClass)
-          && requestOptions.equals(that.requestOptions)
-          && priority == that.priority
+  public boolean isEquivalentTo(Request request) {
+    if (request instanceof SingleRequest) {
+      SingleRequest<?> other = (SingleRequest<?>) request;
+      return overrideWidth == other.overrideWidth
+          && overrideHeight == other.overrideHeight
+          && Util.bothModelsNullEquivalentOrEquals(model, other.model)
+          && transcodeClass.equals(other.transcodeClass)
+          && requestOptions.equals(other.requestOptions)
+          && priority == other.priority
           // We do not want to require that RequestListeners implement equals/hashcode, so we don't
           // compare them using equals(). We can however, at least assert that the request listener
           // is either present or not present in both requests.
           && (requestListener != null
-          ? that.requestListener != null : that.requestListener == null);
+          ? other.requestListener != null : other.requestListener == null);
     }
     return false;
   }

--- a/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
+++ b/library/src/main/java/com/bumptech/glide/request/ThumbnailRequestCoordinator.java
@@ -180,11 +180,11 @@ public class ThumbnailRequestCoordinator implements RequestCoordinator,
   }
 
   @Override
-  public boolean isEquivalentTo(Request o) {
-    if (o instanceof ThumbnailRequestCoordinator) {
-      ThumbnailRequestCoordinator that = (ThumbnailRequestCoordinator) o;
-      return (full == null ? that.full == null : full.isEquivalentTo(that.full))
-          && (thumb == null ? that.thumb == null : thumb.isEquivalentTo(that.thumb));
+  public boolean isEquivalentTo(Request request) {
+    if (request instanceof ThumbnailRequestCoordinator) {
+      ThumbnailRequestCoordinator other = (ThumbnailRequestCoordinator) request;
+      return (full == null ? other.full == null : full.isEquivalentTo(other.full))
+          && (thumb == null ? other.thumb == null : thumb.isEquivalentTo(other.thumb));
     }
     return false;
   }

--- a/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
@@ -35,6 +35,7 @@ public class FixedSizeDrawable extends Drawable {
   }
 
   FixedSizeDrawable(State state, Drawable wrapped) {
+    super();
     this.state = Preconditions.checkNotNull(state);
     this.wrapped = Preconditions.checkNotNull(wrapped);
 
@@ -209,6 +210,7 @@ public class FixedSizeDrawable extends Drawable {
     }
 
     State(ConstantState wrapped, int width, int height) {
+      super();
       this.wrapped = wrapped;
       this.width = width;
       this.height = height;

--- a/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/FixedSizeDrawable.java
@@ -169,8 +169,8 @@ public class FixedSizeDrawable extends Drawable {
   }
 
   @Override
-  public void setAlpha(int i) {
-    wrapped.setAlpha(i);
+  public void setAlpha(int alpha) {
+    wrapped.setAlpha(alpha);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
@@ -92,21 +92,21 @@ public abstract class SimpleTarget<Z> extends BaseTarget<Z> {
   /**
    * Immediately calls the given callback with the sizes given in the constructor.
    *
-   * @param cb {@inheritDoc}
+   * @param callback {@inheritDoc}
    */
   @Override
-  public final void getSize(@NonNull SizeReadyCallback cb) {
+  public final void getSize(@NonNull SizeReadyCallback callback) {
     if (!Util.isValidDimensions(width, height)) {
       throw new IllegalArgumentException(
           "Width and height must both be > 0 or Target#SIZE_ORIGINAL, but given" + " width: "
               + width + " and height: " + height + ", either provide dimensions in the constructor"
               + " or call override()");
     }
-    cb.onSizeReady(width, height);
+    callback.onSizeReady(width, height);
   }
 
   @Override
-  public void removeCallback(@NonNull SizeReadyCallback cb) {
+  public void removeCallback(@NonNull SizeReadyCallback callback) {
     // Do nothing, we never retain a reference to the callback.
   }
 }

--- a/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/SimpleTarget.java
@@ -85,6 +85,7 @@ public abstract class SimpleTarget<Z> extends BaseTarget<Z> {
   // Public API.
   @SuppressWarnings("WeakerAccess")
   public SimpleTarget(int width, int height) {
+    super();
     this.width = width;
     this.height = height;
   }

--- a/library/src/main/java/com/bumptech/glide/request/target/Target.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/Target.java
@@ -80,16 +80,16 @@ public interface Target<R> extends LifecycleListener {
   /**
    * A method to retrieve the size of this target.
    *
-   * @param cb The callback that must be called when the size of the target has been determined
+   * @param callback will be called when the size of the target has been determined
    */
-  void getSize(@NonNull SizeReadyCallback cb);
+  void getSize(@NonNull SizeReadyCallback callback);
 
   /**
    * Removes the given callback from the pending set if it's still retained.
    *
-   * @param cb The callback to remove.
+   * @param callback to remove
    */
-  void removeCallback(@NonNull SizeReadyCallback cb);
+  void removeCallback(@NonNull SizeReadyCallback callback);
 
   /**
    * Sets the current request for this target to retain, should not be called outside of Glide.

--- a/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
@@ -110,12 +110,12 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
     }
     attachStateListener = new OnAttachStateChangeListener() {
       @Override
-      public void onViewAttachedToWindow(View v) {
+      public void onViewAttachedToWindow(View view) {
         resumeMyRequest();
       }
 
       @Override
-      public void onViewDetachedFromWindow(View v) {
+      public void onViewDetachedFromWindow(View view) {
         pauseMyRequest();
       }
     };

--- a/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
@@ -207,18 +207,18 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
    * zero, it then adds an {@link android.view.ViewTreeObserver.OnPreDrawListener} which waits until
    * the view has been measured before calling the callback with the view's drawn width and height.
    *
-   * @param cb {@inheritDoc}
+   * @param callback {@inheritDoc}
    */
   @CallSuper
   @Override
-  public void getSize(@NonNull SizeReadyCallback cb) {
-    sizeDeterminer.getSize(cb);
+  public void getSize(@NonNull SizeReadyCallback callback) {
+    sizeDeterminer.getSize(callback);
   }
 
   @CallSuper
   @Override
-  public void removeCallback(@NonNull SizeReadyCallback cb) {
-    sizeDeterminer.removeCallback(cb);
+  public void removeCallback(@NonNull SizeReadyCallback callback) {
+    sizeDeterminer.removeCallback(callback);
   }
 
   @CallSuper
@@ -355,8 +355,8 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
       // need a copy of the list to avoid a concurrent modification exception. One place this
       // happens is when a full request completes from the in memory cache while its thumbnail is
       // still being loaded asynchronously. See #2237.
-      for (SizeReadyCallback cb : new ArrayList<>(cbs)) {
-        cb.onSizeReady(width, height);
+      for (SizeReadyCallback callback : new ArrayList<>(cbs)) {
+        callback.onSizeReady(width, height);
       }
     }
 
@@ -376,18 +376,18 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
       clearCallbacksAndListener();
     }
 
-    void getSize(@NonNull SizeReadyCallback cb) {
+    void getSize(@NonNull SizeReadyCallback callback) {
       int currentWidth = getTargetWidth();
       int currentHeight = getTargetHeight();
       if (isViewStateAndSizeValid(currentWidth, currentHeight)) {
-        cb.onSizeReady(currentWidth, currentHeight);
+        callback.onSizeReady(currentWidth, currentHeight);
         return;
       }
 
       // We want to notify callbacks in the order they were added and we only expect one or two
       // callbacks to be added a time, so a List is a reasonable choice.
-      if (!cbs.contains(cb)) {
-        cbs.add(cb);
+      if (!cbs.contains(callback)) {
+        cbs.add(callback);
       }
       if (layoutListener == null) {
         ViewTreeObserver observer = view.getViewTreeObserver();
@@ -402,8 +402,8 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
      *
      * <p>See #2237.
      */
-    void removeCallback(@NonNull SizeReadyCallback cb) {
-      cbs.remove(cb);
+    void removeCallback(@NonNull SizeReadyCallback callback) {
+      cbs.remove(callback);
     }
 
     void clearCallbacksAndListener() {

--- a/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
@@ -58,6 +58,7 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
    * Constructor that defaults {@code waitForLayout} to {@code false}.
    */
   public ViewTarget(@NonNull T view) {
+    super();
     this.view = Preconditions.checkNotNull(view);
     sizeDeterminer = new SizeDeterminer(view);
   }

--- a/library/src/main/java/com/bumptech/glide/util/ByteBufferUtil.java
+++ b/library/src/main/java/com/bumptech/glide/util/ByteBufferUtil.java
@@ -140,9 +140,9 @@ public final class ByteBufferUtil {
       buffer = new byte[BUFFER_SIZE];
     }
 
-    int n;
-    while ((n = stream.read(buffer)) >= 0) {
-      outStream.write(buffer, 0, n);
+    int readByteCount;
+    while ((readByteCount = stream.read(buffer)) >= 0) {
+      outStream.write(buffer, 0, readByteCount);
     }
 
     BUFFER_REF.set(buffer);

--- a/library/src/main/java/com/bumptech/glide/util/ContentLengthInputStream.java
+++ b/library/src/main/java/com/bumptech/glide/util/ContentLengthInputStream.java
@@ -20,14 +20,14 @@ public final class ContentLengthInputStream extends FilterInputStream {
   private int readSoFar;
 
   @NonNull
-  public static InputStream obtain(@NonNull InputStream other,
+  public static InputStream obtain(@NonNull InputStream is,
       @Nullable String contentLengthHeader) {
-    return obtain(other, parseContentLength(contentLengthHeader));
+    return obtain(is, parseContentLength(contentLengthHeader));
   }
 
   @NonNull
-  public static InputStream obtain(@NonNull InputStream other, long contentLength) {
-    return new ContentLengthInputStream(other, contentLength);
+  public static InputStream obtain(@NonNull InputStream is, long contentLength) {
+    return new ContentLengthInputStream(is, contentLength);
   }
 
   private static int parseContentLength(@Nullable String contentLengthHeader) {
@@ -44,8 +44,8 @@ public final class ContentLengthInputStream extends FilterInputStream {
     return result;
   }
 
-  private ContentLengthInputStream(@NonNull InputStream in, long contentLength) {
-    super(in);
+  private ContentLengthInputStream(@NonNull InputStream is, long contentLength) {
+    super(is);
     this.contentLength = contentLength;
   }
 

--- a/library/src/main/java/com/bumptech/glide/util/ExceptionCatchingInputStream.java
+++ b/library/src/main/java/com/bumptech/glide/util/ExceptionCatchingInputStream.java
@@ -42,7 +42,8 @@ public class ExceptionCatchingInputStream extends InputStream {
   }
 
   ExceptionCatchingInputStream() {
-    // Do nothing.
+    super();
+    // Do nothing, only to hide constructor from public.
   }
 
   void setInputStream(@NonNull InputStream toWrap) {

--- a/library/src/main/java/com/bumptech/glide/util/MarkEnforcingInputStream.java
+++ b/library/src/main/java/com/bumptech/glide/util/MarkEnforcingInputStream.java
@@ -15,8 +15,8 @@ public class MarkEnforcingInputStream extends FilterInputStream {
 
   private int availableBytes = UNSET;
 
-  public MarkEnforcingInputStream(@NonNull InputStream in) {
-    super(in);
+  public MarkEnforcingInputStream(@NonNull InputStream is) {
+    super(is);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/util/Util.java
+++ b/library/src/main/java/com/bumptech/glide/util/Util.java
@@ -44,11 +44,10 @@ public final class Util {
   @SuppressWarnings("PMD.UseVarargs")
   @NonNull
   private static String bytesToHex(@NonNull byte[] bytes, @NonNull char[] hexChars) {
-    int v;
-    for (int j = 0; j < bytes.length; j++) {
-      v = bytes[j] & 0xFF;
-      hexChars[j * 2] = HEX_CHAR_ARRAY[v >>> 4];
-      hexChars[j * 2 + 1] = HEX_CHAR_ARRAY[v & 0x0F];
+    for (int i = 0; i < bytes.length; i++) {
+      final int value = bytes[i] & 0xFF;
+      hexChars[i * 2] = HEX_CHAR_ARRAY[value >>> 4];
+      hexChars[i * 2 + 1] = HEX_CHAR_ARRAY[value & 0x0F];
     }
     return new String(hexChars);
   }
@@ -198,10 +197,12 @@ public final class Util {
    *
    * @see java.util.Objects#equals
    */
+  @SuppressWarnings("PMD.ShortVariable")
   public static boolean bothNullOrEqual(@Nullable Object a, @Nullable Object b) {
     return a == null ? b == null : a.equals(b);
   }
 
+  @SuppressWarnings("PMD.ShortVariable")
   public static boolean bothModelsNullEquivalentOrEquals(@Nullable Object a, @Nullable Object b) {
     if (a == null) {
       return b == null;

--- a/library/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/src/test/java/com/bumptech/glide/GlideTest.java
@@ -808,8 +808,8 @@ public class GlideTest {
 
     @Override
     public Void answer(InvocationOnMock invocation) throws Throwable {
-      SizeReadyCallback cb = (SizeReadyCallback) invocation.getArguments()[0];
-      cb.onSizeReady(width, height);
+      SizeReadyCallback callback = (SizeReadyCallback) invocation.getArguments()[0];
+      callback.onSizeReady(width, height);
       return null;
     }
   }

--- a/library/src/test/java/com/bumptech/glide/ListPreloaderTest.java
+++ b/library/src/test/java/com/bumptech/glide/ListPreloaderTest.java
@@ -332,16 +332,16 @@ public class ListPreloaderTest {
 
   private <Resource> List<Integer> getTargetsSizes(
       RequestBuilder<Resource> requestBuilder, VerificationMode mode) {
-    ArgumentCaptor<Integer> integerArgumentCaptor = ArgumentCaptor.forClass(Integer.class);
+    ArgumentCaptor<Integer> intArgumentCaptor = ArgumentCaptor.forClass(int.class);
     ArgumentCaptor<Target<Resource>> targetArgumentCaptor =
         cast(ArgumentCaptor.forClass(Target.class));
-    SizeReadyCallback cb = mock(SizeReadyCallback.class);
+    SizeReadyCallback callback = mock(SizeReadyCallback.class);
     verify(requestBuilder, mode).into(targetArgumentCaptor.capture());
     for (Target<Resource> target : targetArgumentCaptor.getAllValues()) {
-      target.getSize(cb);
+      target.getSize(callback);
     }
-    verify(cb, mode).onSizeReady(integerArgumentCaptor.capture(), integerArgumentCaptor.capture());
-    return integerArgumentCaptor.getAllValues();
+    verify(callback, mode).onSizeReady(intArgumentCaptor.capture(), intArgumentCaptor.capture());
+    return intArgumentCaptor.getAllValues();
   }
 
   // It's safe to ignore the return value of containsAllIn.

--- a/library/src/test/java/com/bumptech/glide/RequestManagerTest.java
+++ b/library/src/test/java/com/bumptech/glide/RequestManagerTest.java
@@ -81,12 +81,12 @@ public class RequestManagerTest {
       }
 
       @Override
-      public void getSize(@NonNull SizeReadyCallback cb) {
+      public void getSize(@NonNull SizeReadyCallback callback) {
         // Empty.
       }
 
       @Override
-      public void removeCallback(@NonNull SizeReadyCallback cb) {
+      public void removeCallback(@NonNull SizeReadyCallback callback) {
         // Empty.
       }
     };

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
@@ -53,7 +53,7 @@ public class EngineJobTest {
     job.onResourceReady(harness.resource, harness.dataSource);
 
     ShadowLooper.runUiThreadTasks();
-    verify(harness.cb).onResourceReady(eq(harness.engineResource), eq(harness.dataSource));
+    verify(harness.callback).onResourceReady(eq(harness.engineResource), eq(harness.dataSource));
   }
 
   @Test
@@ -73,8 +73,8 @@ public class EngineJobTest {
     MultiCbHarness harness = new MultiCbHarness();
     harness.job.start(harness.decodeJob);
     harness.job.onResourceReady(harness.resource, harness.dataSource);
-    for (ResourceCallback cb : harness.cbs) {
-      verify(cb).onResourceReady(eq(harness.engineResource), eq(harness.dataSource));
+    for (ResourceCallback callback : harness.callbacks) {
+      verify(callback).onResourceReady(eq(harness.engineResource), eq(harness.dataSource));
     }
   }
 
@@ -84,8 +84,8 @@ public class EngineJobTest {
     harness.job.start(harness.decodeJob);
     GlideException exception = new GlideException("test");
     harness.job.onLoadFailed(exception);
-    for (ResourceCallback cb : harness.cbs) {
-      verify(cb).onLoadFailed(eq(exception));
+    for (ResourceCallback callback : harness.callbacks) {
+      verify(callback).onLoadFailed(eq(exception));
     }
   }
 
@@ -152,7 +152,7 @@ public class EngineJobTest {
     job.onResourceReady(harness.resource, harness.dataSource);
 
     ShadowLooper.runUiThreadTasks();
-    verify(harness.cb, never()).onResourceReady(anyResource(), isADataSource());
+    verify(harness.callback, never()).onResourceReady(anyResource(), isADataSource());
   }
 
   @Test
@@ -165,14 +165,14 @@ public class EngineJobTest {
     job.onLoadFailed(new GlideException("test"));
 
     ShadowLooper.runUiThreadTasks();
-    verify(harness.cb, never()).onLoadFailed(any(GlideException.class));
+    verify(harness.callback, never()).onLoadFailed(any(GlideException.class));
   }
 
   @Test
   public void testRemovingAllCallbacksCancelsRunner() {
     EngineJob<Object> job = harness.getJob();
     job.start(harness.decodeJob);
-    job.removeCallback(harness.cb);
+    job.removeCallback(harness.callback);
 
     assertTrue(job.isCancelled());
   }
@@ -182,7 +182,7 @@ public class EngineJobTest {
   public void removingSomeCallbacksDoesNotCancelRunner() {
     EngineJob<Object> job = harness.getJob();
     job.addCallback(mock(ResourceCallback.class));
-    job.removeCallback(harness.cb);
+    job.removeCallback(harness.callback);
 
     assertFalse(job.isCancelled());
   }
@@ -298,43 +298,43 @@ public class EngineJobTest {
   @Test
   public void testRemovingCallbackDuringOnResourceReadyIsIgnoredIfCallbackHasAlreadyBeenCalled() {
     final EngineJob<Object> job = harness.getJob();
-    final ResourceCallback cb = mock(ResourceCallback.class);
+    final ResourceCallback callback = mock(ResourceCallback.class);
 
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-        job.removeCallback(cb);
+        job.removeCallback(callback);
         return null;
       }
-    }).when(cb).onResourceReady(anyResource(), isADataSource());
+    }).when(callback).onResourceReady(anyResource(), isADataSource());
 
-    job.addCallback(cb);
+    job.addCallback(callback);
     job.start(harness.decodeJob);
     job.onResourceReady(harness.resource, harness.dataSource);
 
-    verify(cb, times(1)).onResourceReady(anyResource(), isADataSource());
+    verify(callback, times(1)).onResourceReady(anyResource(), isADataSource());
   }
 
   @Test
   public void testRemovingCallbackDuringOnExceptionIsIgnoredIfCallbackHasAlreadyBeenCalled() {
     harness = new EngineJobHarness();
     final EngineJob<Object> job = harness.getJob();
-    final ResourceCallback cb = mock(ResourceCallback.class);
+    final ResourceCallback callback = mock(ResourceCallback.class);
 
     doAnswer(new Answer<Void>() {
       @Override
       public Void answer(InvocationOnMock invocationOnMock) throws Throwable {
-        job.removeCallback(cb);
+        job.removeCallback(callback);
         return null;
       }
-    }).when(cb).onLoadFailed(any(GlideException.class));
+    }).when(callback).onLoadFailed(any(GlideException.class));
 
     GlideException exception = new GlideException("test");
-    job.addCallback(cb);
+    job.addCallback(callback);
     job.start(harness.decodeJob);
     job.onLoadFailed(exception);
 
-    verify(cb, times(1)).onLoadFailed(eq(exception));
+    verify(callback, times(1)).onLoadFailed(eq(exception));
   }
 
   @Test
@@ -349,7 +349,7 @@ public class EngineJobTest {
         job.removeCallback(notYetCalled);
         return null;
       }
-    }).when(harness.cb).onResourceReady(anyResource(), isADataSource());
+    }).when(harness.callback).onResourceReady(anyResource(), isADataSource());
 
     job.addCallback(notYetCalled);
     job.start(harness.decodeJob);
@@ -370,7 +370,7 @@ public class EngineJobTest {
         job.removeCallback(notYetCalled);
         return null;
       }
-    }).when(harness.cb).onResourceReady(anyResource(), isADataSource());
+    }).when(harness.callback).onResourceReady(anyResource(), isADataSource());
 
     job.addCallback(notYetCalled);
     job.start(harness.decodeJob);
@@ -465,7 +465,7 @@ public class EngineJobTest {
     final boolean useAnimationPool = false;
     final boolean onlyRetrieveFromCache = false;
     final int numCbs = 10;
-    final List<ResourceCallback> cbs = new ArrayList<>();
+    final List<ResourceCallback> callbacks = new ArrayList<>();
     final EngineJob.EngineResourceFactory factory = mock(EngineJob.EngineResourceFactory.class);
     final EngineJob<Object> job;
     final GlideExecutor diskCacheService = MockGlideExecutor.newMainThreadExecutor();
@@ -494,10 +494,10 @@ public class EngineJobTest {
           useAnimationPool,
           onlyRetrieveFromCache);
       for (int i = 0; i < numCbs; i++) {
-        cbs.add(mock(ResourceCallback.class));
+        callbacks.add(mock(ResourceCallback.class));
       }
-      for (ResourceCallback cb : cbs) {
-        job.addCallback(cb);
+      for (ResourceCallback callback : callbacks) {
+        job.addCallback(callback);
       }
     }
   }
@@ -507,7 +507,7 @@ public class EngineJobTest {
     final EngineJob.EngineResourceFactory factory = mock(EngineJob.EngineResourceFactory.class);
     final Key key = mock(Key.class);
     final Handler mainHandler = new Handler();
-    final ResourceCallback cb = mock(ResourceCallback.class);
+    final ResourceCallback callback = mock(ResourceCallback.class);
     final Resource<Object> resource = mockResource();
     final EngineResource<Object> engineResource = mock(EngineResource.class);
     final EngineJobListener listener = mock(EngineJobListener.class);
@@ -540,7 +540,7 @@ public class EngineJobTest {
           useUnlimitedSourceGeneratorPool,
           useAnimationPool,
           onlyRetrieveFromCache);
-      result.addCallback(cb);
+      result.addCallback(callback);
       return result;
     }
   }

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
@@ -628,7 +628,7 @@ public class EngineTest {
     ResourceCallback cb = mock(ResourceCallback.class);
     @SuppressWarnings("rawtypes")
     final EngineResource resource = mock(EngineResource.class);
-    final Jobs jobs = new Jobs();
+    final EngineJobs jobs = new EngineJobs();
     final ActiveResources activeResources =
         new ActiveResources(/*isActiveResourceRetentionAllowed=*/ true);
 

--- a/library/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
@@ -64,7 +64,7 @@ public class EngineTest {
   public void testCallbackIsAddedToNewEngineJobWithNoExistingLoad() {
     harness.doLoad();
 
-    verify(harness.job).addCallback(eq(harness.cb));
+    verify(harness.job).addCallback(eq(harness.callback));
   }
 
   @Test
@@ -77,7 +77,7 @@ public class EngineTest {
     Engine.LoadStatus loadStatus = harness.doLoad();
     loadStatus.cancel();
 
-    verify(harness.job).removeCallback(eq(harness.cb));
+    verify(harness.job).removeCallback(eq(harness.callback));
   }
 
   @Test
@@ -100,7 +100,7 @@ public class EngineTest {
     harness.doLoad();
 
     ResourceCallback newCallback = mock(ResourceCallback.class);
-    harness.cb = newCallback;
+    harness.callback = newCallback;
     harness.doLoad();
 
     verify(harness.job).addCallback(eq(newCallback));
@@ -120,7 +120,7 @@ public class EngineTest {
 
     harness.doLoad();
 
-    verify(harness.cb).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
   }
 
   @Test
@@ -154,7 +154,7 @@ public class EngineTest {
 
     harness.doLoad();
 
-    verify(harness.cb).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
     verify(harness.cache, never()).remove(any(Key.class));
   }
 
@@ -175,7 +175,7 @@ public class EngineTest {
 
     harness.doLoad();
 
-    verify(harness.cb).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
   }
 
   @Test
@@ -194,7 +194,7 @@ public class EngineTest {
 
     harness.doLoad();
 
-    verify(harness.cb).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(eq(harness.resource), eq(DataSource.MEMORY_CACHE));
   }
 
   @Test
@@ -211,11 +211,11 @@ public class EngineTest {
         assertEquals(expected, resource.get());
         return null;
       }
-    }).when(harness.cb).onResourceReady(anyResource(), isADataSource());
+    }).when(harness.callback).onResourceReady(anyResource(), isADataSource());
 
     harness.doLoad();
 
-    verify(harness.cb).onResourceReady(anyResource(), isADataSource());
+    verify(harness.callback).onResourceReady(anyResource(), isADataSource());
   }
 
   @Test
@@ -448,7 +448,7 @@ public class EngineTest {
     }).when(harness.job).start(any(DecodeJob.class));
     harness.doLoad();
     harness.doLoad();
-    verify(harness.cb).onResourceReady(any(Resource.class), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(any(Resource.class), eq(DataSource.MEMORY_CACHE));
   }
 
   @Test
@@ -465,7 +465,7 @@ public class EngineTest {
     harness.doLoad();
     harness.getEngine().onResourceReleased(harness.cacheKey, harness.resource);
     harness.doLoad();
-    verify(harness.cb).onResourceReady(any(Resource.class), eq(DataSource.MEMORY_CACHE));
+    verify(harness.callback).onResourceReady(any(Resource.class), eq(DataSource.MEMORY_CACHE));
   }
 
   @Test
@@ -625,7 +625,7 @@ public class EngineTest {
   private static class EngineTestHarness {
     final EngineKey cacheKey = mock(EngineKey.class);
     final EngineKeyFactory keyFactory = mock(EngineKeyFactory.class);
-    ResourceCallback cb = mock(ResourceCallback.class);
+    ResourceCallback callback = mock(ResourceCallback.class);
     @SuppressWarnings("rawtypes")
     final EngineResource resource = mock(EngineResource.class);
     final EngineJobs jobs = new EngineJobs();
@@ -687,7 +687,7 @@ public class EngineTest {
           useUnlimitedSourceGeneratorPool,
           /*useAnimationPool=*/ false,
           onlyRetrieveFromCache,
-          cb);
+          callback);
     }
 
     Engine getEngine() {

--- a/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
+++ b/library/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
@@ -60,7 +60,7 @@ public class GifDrawableTest {
   private Bitmap firstFrame;
   private int initialSdkVersion;
 
-  @Mock private Drawable.Callback cb;
+  @Mock private Drawable.Callback callback;
   @Mock private GifFrameLoader frameLoader;
   @Mock private Paint paint;
   @Mock private Transformation<Bitmap> transformation;
@@ -86,7 +86,7 @@ public class GifDrawableTest {
     when(frameLoader.getHeight()).thenReturn(frameHeight);
     when(frameLoader.getCurrentFrame()).thenReturn(firstFrame);
     when(frameLoader.getCurrentIndex()).thenReturn(0);
-    drawable.setCallback(cb);
+    drawable.setCallback(callback);
     initialSdkVersion = Build.VERSION.SDK_INT;
   }
 
@@ -155,7 +155,7 @@ public class GifDrawableTest {
     drawable.setVisible(true, false);
     drawable.start();
 
-    verify(cb).invalidateDrawable(eq(drawable));
+    verify(callback).invalidateDrawable(eq(drawable));
   }
 
   @Test
@@ -163,7 +163,7 @@ public class GifDrawableTest {
     drawable.setVisible(true, true);
     drawable.start();
 
-    verify(cb).invalidateDrawable(eq(drawable));
+    verify(callback).invalidateDrawable(eq(drawable));
   }
 
   @Test
@@ -193,7 +193,7 @@ public class GifDrawableTest {
     drawable.setIsRunning(true);
     drawable.onFrameReady();
 
-    verify(cb).invalidateDrawable(eq(drawable));
+    verify(callback).invalidateDrawable(eq(drawable));
   }
 
   @Test
@@ -442,7 +442,7 @@ public class GifDrawableTest {
     drawable.onFrameReady();
 
     // 4 onFrameReady(), 2 start()
-    verify(cb, times(4 + 2)).invalidateDrawable(eq(drawable));
+    verify(callback, times(4 + 2)).invalidateDrawable(eq(drawable));
     assertFalse("drawable should be stopped after loop is completed", drawable.isRunning());
   }
 
@@ -468,7 +468,7 @@ public class GifDrawableTest {
 
     int numStarts = 2;
     int expectedFrames = (initialLoopCount + newLoopCount) * frameCount + numStarts;
-    verify(cb, times(expectedFrames)).invalidateDrawable(eq(drawable));
+    verify(callback, times(expectedFrames)).invalidateDrawable(eq(drawable));
     assertFalse("drawable should be stopped after loop is completed", drawable.isRunning());
   }
 
@@ -603,7 +603,7 @@ public class GifDrawableTest {
 
   private void verifyRanLoops(int loopCount, int frameCount) {
     // 1 for invalidate in start().
-    verify(cb, times(1 + loopCount * frameCount)).invalidateDrawable(eq(drawable));
+    verify(callback, times(1 + loopCount * frameCount)).invalidateDrawable(eq(drawable));
   }
 
   private void runLoops(int loopCount, int frameCount) {

--- a/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
@@ -51,9 +51,9 @@ public class RequestFutureTargetTest {
 
   @Test
   public void testCallsSizeReadyCallbackOnGetSize() {
-    SizeReadyCallback cb = mock(SizeReadyCallback.class);
-    future.getSize(cb);
-    verify(cb).onSizeReady(eq(width), eq(height));
+    SizeReadyCallback callback = mock(SizeReadyCallback.class);
+    future.getSize(callback);
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
@@ -1059,11 +1059,9 @@ public class SingleRequestTest {
 
     @Override
     public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-      ResourceCallback cb =
-          (ResourceCallback) invocationOnMock.getArguments()[
-              invocationOnMock.getArguments().length
-                  - 1];
-      cb.onResourceReady(resource, DataSource.REMOTE);
+      Object[] arguments = invocationOnMock.getArguments();
+      ResourceCallback callback = (ResourceCallback) arguments[arguments.length - 1];
+      callback.onResourceReady(resource, DataSource.REMOTE);
       return null;
     }
   }
@@ -1080,8 +1078,8 @@ public class SingleRequestTest {
 
     @Override
     public Object answer(InvocationOnMock invocationOnMock) throws Throwable {
-      SizeReadyCallback cb = (SizeReadyCallback) invocationOnMock.getArguments()[0];
-      cb.onSizeReady(width, height);
+      SizeReadyCallback callback = (SizeReadyCallback) invocationOnMock.getArguments()[0];
+      callback.onSizeReady(width, height);
       return null;
     }
   }
@@ -1115,11 +1113,11 @@ public class SingleRequestTest {
 
 
     @Override
-    public void getSize(@NonNull SizeReadyCallback cb) {
+    public void getSize(@NonNull SizeReadyCallback callback) {
     }
 
     @Override
-    public void removeCallback(@NonNull SizeReadyCallback cb) {
+    public void removeCallback(@NonNull SizeReadyCallback callback) {
       // Do nothing.
     }
 

--- a/library/src/test/java/com/bumptech/glide/request/target/PreloadTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/PreloadTargetTest.java
@@ -30,10 +30,10 @@ public class PreloadTargetTest {
     int width = 1234;
     int height = 456;
     PreloadTarget<Object> target = PreloadTarget.obtain(requestManager, width, height);
-    SizeReadyCallback cb = mock(SizeReadyCallback.class);
-    target.getSize(cb);
+    SizeReadyCallback callback = mock(SizeReadyCallback.class);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(eq(width), eq(height));
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test

--- a/library/src/test/java/com/bumptech/glide/request/target/ViewTargetTest.java
+++ b/library/src/test/java/com/bumptech/glide/request/target/ViewTargetTest.java
@@ -57,7 +57,7 @@ public class ViewTargetTest {
   private ViewTarget<View, Object> target;
   private SizedShadowView shadowView;
   private PreDrawShadowViewTreeObserver shadowObserver;
-  @Mock private SizeReadyCallback cb;
+  @Mock private SizeReadyCallback callback;
   @Mock private Request request;
   private int sdkVersion;
   private AttachStateTarget attachStateTarget;
@@ -120,9 +120,9 @@ public class ViewTargetTest {
         .setHeight(dimens)
         .setIsLaidOut(true);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(eq(dimens), eq(dimens));
+    verify(callback).onSizeReady(eq(dimens), eq(dimens));
   }
 
   @Test
@@ -132,9 +132,9 @@ public class ViewTargetTest {
     view.setLayoutParams(layoutParams);
     shadowView.setIsLaidOut(true);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(eq(dimens), eq(dimens));
+    verify(callback).onSizeReady(eq(dimens), eq(dimens));
   }
 
   @Test
@@ -146,9 +146,9 @@ public class ViewTargetTest {
 
     setDisplayDimens(200, 300);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(300, 300);
+    verify(callback).onSizeReady(300, 300);
   }
 
   @Test
@@ -160,9 +160,9 @@ public class ViewTargetTest {
 
     setDisplayDimens(100, 200);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(200, height);
+    verify(callback).onSizeReady(200, height);
   }
 
   @Test
@@ -174,9 +174,9 @@ public class ViewTargetTest {
 
     setDisplayDimens(200, 100);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(width, 200);
+    verify(callback).onSizeReady(width, 200);
   }
 
   @Test
@@ -186,9 +186,9 @@ public class ViewTargetTest {
 
     setDisplayDimens(500, 600);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb, never()).onSizeReady(anyInt(), anyInt());
+    verify(callback, never()).onSizeReady(anyInt(), anyInt());
 
     int height = 32;
     shadowView
@@ -197,7 +197,7 @@ public class ViewTargetTest {
 
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(600, height);
+    verify(callback).onSizeReady(600, height);
   }
 
   @Test
@@ -207,9 +207,9 @@ public class ViewTargetTest {
 
     setDisplayDimens(300, 400);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb, never()).onSizeReady(anyInt(), anyInt());
+    verify(callback, never()).onSizeReady(anyInt(), anyInt());
 
 
     int width = 32;
@@ -218,7 +218,7 @@ public class ViewTargetTest {
         .setIsLaidOut(true);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(width, 400);
+    verify(callback).onSizeReady(width, 400);
   }
 
   @Test
@@ -226,9 +226,9 @@ public class ViewTargetTest {
     LayoutParams params = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
     view.setLayoutParams(params);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb, never()).onSizeReady(anyInt(), anyInt());
+    verify(callback, never()).onSizeReady(anyInt(), anyInt());
 
     int width = 32;
     int height = 45;
@@ -238,12 +238,12 @@ public class ViewTargetTest {
         .setIsLaidOut(true);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(eq(width), eq(height));
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test
   public void testSizeCallbackIsCalledPreDrawIfNoDimensAndNoLayoutParams() {
-    target.getSize(cb);
+    target.getSize(callback);
 
     int width = 12;
     int height = 32;
@@ -253,7 +253,7 @@ public class ViewTargetTest {
         .setIsLaidOut(true);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(eq(width), eq(height));
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test
@@ -272,21 +272,21 @@ public class ViewTargetTest {
     shadowObserver.fireOnPreDrawListeners();
 
     InOrder order = inOrder((Object[]) cbs);
-    for (SizeReadyCallback cb : cbs) {
-      order.verify(cb).onSizeReady(eq(width), eq(height));
+    for (SizeReadyCallback callback : cbs) {
+      order.verify(callback).onSizeReady(eq(width), eq(height));
     }
   }
 
   @Test
   public void testDoesNotNotifyCallbackTwiceIfAddedTwice() {
-    target.getSize(cb);
-    target.getSize(cb);
+    target.getSize(callback);
+    target.getSize(callback);
 
     view.setLayoutParams(new LayoutParams(100, 100));
     shadowView.setIsLaidOut(true);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb, times(1)).onSizeReady(anyInt(), anyInt());
+    verify(callback, times(1)).onSizeReady(anyInt(), anyInt());
   }
 
   @Test
@@ -321,16 +321,16 @@ public class ViewTargetTest {
 
   @Test
   public void testSizeCallbackIsNotCalledPreDrawIfNoDimensSetOnPreDraw() {
-    target.getSize(cb);
+    target.getSize(callback);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb, never()).onSizeReady(anyInt(), anyInt());
+    verify(callback, never()).onSizeReady(anyInt(), anyInt());
     assertThat(shadowObserver.getPreDrawListeners()).hasSize(1);
   }
 
   @Test
   public void testSizeCallbackIsCalledPreDrawIfNoDimensAndNoLayoutParamsButLayoutParamsSetLater() {
-    target.getSize(cb);
+    target.getSize(callback);
 
     int width = 689;
     int height = 354;
@@ -339,12 +339,12 @@ public class ViewTargetTest {
     shadowView.setIsLaidOut(true);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(eq(width), eq(height));
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test
   public void testCallbackIsNotCalledTwiceIfPreDrawFiresTwice() {
-    target.getSize(cb);
+    target.getSize(callback);
 
     LayoutParams layoutParams = new LayoutParams(1234, 4123);
     view.setLayoutParams(layoutParams);
@@ -352,7 +352,7 @@ public class ViewTargetTest {
     shadowObserver.fireOnPreDrawListeners();
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb, times(1)).onSizeReady(anyInt(), anyInt());
+    verify(callback, times(1)).onSizeReady(anyInt(), anyInt());
   }
 
   @Test
@@ -376,7 +376,7 @@ public class ViewTargetTest {
 
   @Test
   public void testDoesNotThrowOnPreDrawIfViewTreeObserverIsDead() {
-    target.getSize(cb);
+    target.getSize(callback);
 
     int width = 1;
     int height = 2;
@@ -386,7 +386,7 @@ public class ViewTargetTest {
     shadowObserver.setIsAlive(false);
     shadowObserver.fireOnPreDrawListeners();
 
-    verify(cb).onSizeReady(eq(width), eq(height));
+    verify(callback).onSizeReady(eq(width), eq(height));
   }
 
   @Test(expected = NullPointerException.class)
@@ -400,9 +400,9 @@ public class ViewTargetTest {
     view.setPadding(25, 25, 25, 25);
     shadowView.setIsLaidOut(true);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(50, 50);
+    verify(callback).onSizeReady(50, 50);
   }
 
   @Test
@@ -411,9 +411,9 @@ public class ViewTargetTest {
         .setWidth(100)
         .setHeight(100)
         .setIsLaidOut(false);
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(100, 100);
+    verify(callback).onSizeReady(100, 100);
   }
 
   @Test
@@ -423,9 +423,9 @@ public class ViewTargetTest {
         .setWidth(100)
         .setHeight(100)
         .setIsLaidOut(false);
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb, times(1)).onSizeReady(anyInt(), anyInt());
+    verify(callback, times(1)).onSizeReady(anyInt(), anyInt());
   }
 
   @Test
@@ -435,9 +435,9 @@ public class ViewTargetTest {
         .setWidth(100)
         .setHeight(100)
         .setIsLaidOut(false);
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(100, 100);
+    verify(callback).onSizeReady(100, 100);
   }
 
   @Test
@@ -448,9 +448,9 @@ public class ViewTargetTest {
         .setHeight(100)
         .requestLayout();
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb).onSizeReady(100, 100);
+    verify(callback).onSizeReady(100, 100);
   }
 
   @Test
@@ -462,9 +462,9 @@ public class ViewTargetTest {
 
     view.setPadding(50, 50, 50, 50);
 
-    target.getSize(cb);
+    target.getSize(callback);
 
-    verify(cb, never()).onSizeReady(anyInt(), anyInt());
+    verify(callback, never()).onSizeReady(anyInt(), anyInt());
   }
 
   private void setDisplayDimens(Integer width, Integer height) {


### PR DESCRIPTION
I went through a few of the suppressed/excluded PMD warnings.

Generic approach: After fixing the fixable... suppress only the most specific things, so future modifications cannot lurk in regressions to the same problem. (i.e. move generic `<exclude>` to `@SuppressWarnings`; and move `@SW` from class to method, or from method to local variable/statement).

Example where this really shows: `@SuppressWarnings("unused")` means that the method is probably not tested.

> `AvoidCatchingThrowable`/`AvoidCatchingGenericException`: It's clear that this is bad, but we have a number of cases where it makes sense and a blanket ban is irritating.

There were actually a few instances where a blanket Exception was used, but there were no checked exceptions thrown. Invoke generic approach.

---

> `AvoidCatchingGenericException`: This is redundant, also caught with AvoidCatchingNPEs.

Agree, suppressed NPEs, and enabled the rule. It is weird that Throwable is not a generic "exception", but NPEs are.
*I guess these two rules may need to be merged together in PMD and made properly parameterizable.*

---

> `AvoidUsingVolatile`: Used frequently in the singleton pattern.

Only half the usages are Singleton-ish. Those could be filtered with `.[@Private='true' and @Static='true']`.

---

> `ShortClassName`: This is not always true.
> `ShortMethodName`/`ShortVariable`: A good idea but we have tons of violations.

Suppressed common usages in config, some special ones in code, and fixed the rest so we can enable these rules. Some "global suppressions" could be resolved with a simple search and replace (all files, "match case", "whole words"); similar to `cb` &rarr; `callback`.

---

> `ExcessiveMethodLength`, `ExcessivePublicCount`, `ExcessiveClassLength`: TODO: explore these further

 * `Downsampler`: extracted some methods to shorten the methods and restrict scope of some calculations. Some of these methods are static so they can be moved out and tested individually.  
   See `TODO this comment is out of place, probably belongs to one of getImageSpecificSize branches`, I couldn't figure that out.
 * `RequestBuilder`: had a very long method, `buildThumbnailRequestRecursive` which I split into 3 and documented what's going on (also reordered the private method parameters to be consistent within class). Due to this the class length increased a bit and now it's a too long class. However I think it's possible to extract half of the methods out to a separate class as RequestBuilder is doing two things: gathering the data from the user of Glide AND calculating how to deal with that data.
 * `RequestOptions` is a really long class, not much we can do about it probably because of the myriad of options.

These refactors look ugly, but they're all "extract method"s really. Use IDEA's diff tool to see.

---

> `CouplingBetweenObjects`

`Glide`: split out a factory that creates the Registry, this splits the dependencies of Glide into half and allows for "better" code to create the registry. I split the `register`/`append` calls up along the `/**/` comments in the method. Strangely `ExcessiveMethodLength` appeared as I extracted the registry related stuff to a separate class: https://github.com/pmd/pmd/issues/825; this is why I "needed" to split, not sure if it's better I would probably be ok with leaving it a single method with locals (passing in the shared objects looked strange). Curious what you think about this split.

---

> `TooManyStaticImports`: Theoretically this might be reasonable but the number of imports probably varies from class to class and this doesn't seem worth the overhead to maintain

This particular violation is actually harder to read with static imports, hard to know if one is enum or int constant. Also there was mixed usage of static and non-static access to `ImageType`.
