### PR TITLE
Evict oldest half of cache on TRIM_MEMORY_RUNNING_CRITICAL

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
@@ -142,6 +142,8 @@ public final class LruArrayPool implements ArrayPool {
       clearMemory();
     } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
       evictToSize(maxSize / 2);
+    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+      evictToSize(maxSize / 2);
     }
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPool.java
@@ -140,9 +140,8 @@ public final class LruArrayPool implements ArrayPool {
   public synchronized void trimMemory(int level) {
     if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
       clearMemory();
-    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-      evictToSize(maxSize / 2);
-    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+        || level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
       evictToSize(maxSize / 2);
     }
   }

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
@@ -219,9 +219,8 @@ public class LruBitmapPool implements BitmapPool {
     }
     if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
       clearMemory();
-    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-      trimToSize(getMaxSize() / 2);
-    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+        || level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
       trimToSize(getMaxSize() / 2);
     }
   }

--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPool.java
@@ -220,7 +220,9 @@ public class LruBitmapPool implements BitmapPool {
     if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
       clearMemory();
     } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-      trimToSize(maxSize / 2);
+      trimToSize(getMaxSize() / 2);
+    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+      trimToSize(getMaxSize() / 2);
     }
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
@@ -47,11 +47,15 @@ public class LruResourceCache extends LruCache<Key, Resource<?>> implements Memo
   @Override
   public void trimMemory(int level) {
     if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND) {
-      // Nearing middle of list of cached background apps
+      // Entering list of cached background apps
       // Evict our entire bitmap cache
       clearMemory();
     } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-      // Entering list of cached background apps
+      // The app's UI is no longer visible
+      // Evict oldest half of our bitmap cache
+      trimToSize(getMaxSize() / 2);
+    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+      // App is in the foreground but system is running critically low on memory
       // Evict oldest half of our bitmap cache
       trimToSize(getMaxSize() / 2);
     }

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/LruResourceCache.java
@@ -50,12 +50,10 @@ public class LruResourceCache extends LruCache<Key, Resource<?>> implements Memo
       // Entering list of cached background apps
       // Evict our entire bitmap cache
       clearMemory();
-    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN) {
-      // The app's UI is no longer visible
-      // Evict oldest half of our bitmap cache
-      trimToSize(getMaxSize() / 2);
-    } else if (level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
-      // App is in the foreground but system is running critically low on memory
+    } else if (level >= android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN
+        || level == android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL) {
+      // The app's UI is no longer visible, or app is in the foreground but system is running
+      // critically low on memory
       // Evict oldest half of our bitmap cache
       trimToSize(getMaxSize() / 2);
     }

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.load.engine.bitmap_recycle;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
+import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -72,6 +73,11 @@ public class LruArrayPoolTest {
   @Test
   public void testTrimMemoryUiHiddenOrLessRemovesHalfOfArrays() {
     testTrimMemory(MAX_SIZE, TRIM_MEMORY_UI_HIDDEN, MAX_SIZE / 2);
+  }
+
+  @Test
+  public void testTrimMemoryRunningCriticalRemovesHalfOfBitmaps() {
+    testTrimMemory(MAX_SIZE, TRIM_MEMORY_RUNNING_CRITICAL, MAX_SIZE / 2);
   }
 
   @Test

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPoolTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruBitmapPoolTest.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.load.engine.bitmap_recycle;
 
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
+import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -100,6 +101,11 @@ public class LruBitmapPoolTest {
   @Test
   public void testTrimMemoryUiHiddenOrLessRemovesHalfOfBitmaps() {
     testTrimMemory(MAX_SIZE, TRIM_MEMORY_UI_HIDDEN, MAX_SIZE / 2);
+  }
+
+  @Test
+  public void testTrimMemoryRunningCriticalRemovesHalfOfBitmaps() {
+    testTrimMemory(MAX_SIZE, TRIM_MEMORY_RUNNING_CRITICAL, MAX_SIZE / 2);
   }
 
   @Test

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/cache/LruResourceCacheTest.java
@@ -106,6 +106,16 @@ public class LruResourceCacheTest {
   }
 
   @Test
+  public void testTrimMemoryRunningCritical() {
+    TrimClearMemoryCacheHarness harness = new TrimClearMemoryCacheHarness();
+
+    harness.resourceCache.trimMemory(ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL);
+
+    verify(harness.listener).onResourceRemoved(harness.first);
+    verify(harness.listener, never()).onResourceRemoved(harness.second);
+  }
+
+  @Test
   public void testResourceRemovedListenerIsNotifiedWhenResourceIsRemoved() {
     LruResourceCache resourceCache = new LruResourceCache(100);
     Resource<?> resource = mockResource();


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

Trim half of resource cache allocations when receiving [TRIM_MEMORY_RUNNING_CRITICAL](https://developer.android.com/reference/android/content/ComponentCallbacks2.html#TRIM_MEMORY_RUNNING_CRITICAL) in `trimMemory()`

See #2810 

Also, while in the code I updated some outdated comments, and replaced `maxSize` with `getMaxSize()` in `LruBitmapPool`

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

Glide is excellent at trimming memory when backgrounded, but fails to do anything when `trimMemory()` is received while foregrounded. This fixes that, which may save an app from slowing down or encountering an OOM while foregrounded, especially if the foreground context isn't the one using the images.

@sjudd had some good points about this strategy in #2810, which is why I've elected to be pretty conservative by only evicting half the cache when TRIM_MEMORY_RUNNING_CRITICAL is encountered. I also think this makes sense because the next stage after CRITICAL is [TRIM_MEMORY_COMPLETE](https://developer.android.com/reference/android/content/ComponentCallbacks2.html#TRIM_MEMORY_COMPLETE), which Glide already handles by evicting the entire cache. Thus, this follows the same pattern as the backgrounded behavior: Half of the cache is evicted first, then one level up the whole cache is evicted.

If anybody thinks the strategy should be more or less aggressive I'd be happy to discuss, but hopefully that explains my rationale. I also think that if the community finds this effective, we could always make it more aggressive in a future update.

Thank you for considering my contribution!

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->