### PR TITLE
Don't throw exception about closed RecyclableBufferedInputStream when it is not closed

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStream.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStream.java
@@ -89,8 +89,11 @@ public class RecyclableBufferedInputStream extends FilterInputStream {
   public synchronized int available() throws IOException {
     // in could be invalidated by close().
     InputStream localIn = in;
-    if (buf == null || localIn == null) {
+    if (localIn == null) {
       throw streamClosed();
+    }
+    if (buf == null) {
+      return 0;
     }
     return count - pos + localIn.available();
   }

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStreamTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStreamTest.java
@@ -252,6 +252,12 @@ public class RecyclableBufferedInputStreamTest {
     stream.close();
     stream.available();
   }
+    
+  @Test
+  public void testAvailableReturnsZeroIfStreamIsReleased() throws IOException {
+    stream.release();
+    assertEquals(0, stream.available());
+  }
 
   @Test(expected = IOException.class)
   public void testReadThrowsIfStreamIsClosed() throws IOException {


### PR DESCRIPTION
Potential fix for #2808

## Motivation and Context
1. Exception message is invalid because stream is not closed.
2. https://github.com/koral--/android-gif-drawable/issues/503