### PR TITLE
Improved @NonNull annotation check for Kotlin

### DIFF
--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/GlideExtensionValidator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/GlideExtensionValidator.java
@@ -1,11 +1,13 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.compiler.ProcessorUtil.nonNull;
+import static com.bumptech.glide.annotation.compiler.ProcessorUtil.nonNulls;
 
 import com.bumptech.glide.annotation.GlideOption;
 import com.bumptech.glide.annotation.GlideType;
 import com.google.common.base.Function;
 import com.google.common.collect.FluentIterable;
+import com.squareup.javapoet.ClassName;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Set;
@@ -273,7 +275,14 @@ final class GlideExtensionValidator {
               }
             })
             .toSet();
-    if (!annotationNames.contains(nonNull().reflectionName())) {
+    boolean noNonNull = true;
+    for (ClassName nonNull : nonNulls()) {
+      if (annotationNames.contains(nonNull.reflectionName())) {
+        noNonNull = false;
+        break;
+      }
+    }
+    if (noNonNull) {
       processingEnvironment.getMessager().printMessage(
           Kind.WARNING,
           getQualifiedMethodName(executableElement)

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
@@ -24,6 +24,7 @@ import java.lang.annotation.Annotation;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
@@ -65,6 +66,8 @@ final class ProcessorUtil {
       GlideAnnotationProcessor.class.getPackage().getName();
   private static final ClassName NONNULL_ANNOTATION =
       ClassName.get("android.support.annotation", "NonNull");
+  private static final ClassName JETBRAINS_NOTNULL_ANNOTATION =
+      ClassName.get("org.jetbrains.annotations", "NotNull");
 
   private final ProcessingEnvironment processingEnv;
   private final TypeElement appGlideModuleType;
@@ -336,6 +339,10 @@ final class ProcessorUtil {
 
   static ClassName nonNull() {
     return NONNULL_ANNOTATION;
+  }
+
+  static List<ClassName> nonNulls() {
+    return Arrays.asList(NONNULL_ANNOTATION, JETBRAINS_NOTNULL_ANNOTATION);
   }
 
   List<ExecutableElement> findInstanceMethodsReturning(TypeElement clazz, TypeMirror returnType) {


### PR DESCRIPTION
## Description
Improved @NonNull annotation check for Kotlin.

## Motivation and Context
When writing Glide extensions in Kotlin, I got complains from annotation processor:
````
ExtensionName#methodName(com.bumptech.glide.RequestBuilder<DrawableType>) is missing the android.support.annotation.NonNull annotation, please add it to ensure that your extension methods are always returning non-null values
````
Kotlin annotates NonNull/Nullable to every return type/parameter. After inspecting bytecode from its source, I found Kotlin uses `org.jetbrains.annotations.NotNull` for @NonNull annotation instead.

Adding support @NonNull annotation in Kotlin is unnecessary. This commit adds JetBrains NonNull annotation check.