### PR TITLE
Fix best guess related APT compiler crash with underscore in package name

### DIFF
--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/AppModuleGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/AppModuleGenerator.java
@@ -250,13 +250,12 @@ final class AppModuleGenerator {
         "Discovered AppGlideModule from annotation: " + appGlideModule);
     // Excluded GlideModule classes from the manifest are logged in Glide's singleton.
     for (String glideModule : libraryGlideModuleClassNames) {
-      ClassName moduleClassName = ClassName.bestGuess(glideModule);
       if (excludedGlideModuleClassNames.contains(glideModule)) {
         constructorBuilder.addStatement("$T.d($S, $S)", androidLogName, GLIDE_LOG_TAG,
-            "AppGlideModule excludes LibraryGlideModule from annotation: " + moduleClassName);
+            "AppGlideModule excludes LibraryGlideModule from annotation: " + glideModule);
       } else {
         constructorBuilder.addStatement("$T.d($S, $S)", androidLogName, GLIDE_LOG_TAG,
-            "Discovered LibraryGlideModule from annotation: " + moduleClassName);
+            "Discovered LibraryGlideModule from annotation: " + glideModule);
       }
     }
     constructorBuilder.endControlFlow();

--- a/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithLibraryInPackageTest.java
+++ b/annotation/compiler/test/src/test/java/com/bumptech/glide/annotation/compiler/AppGlideModuleWithLibraryInPackageTest.java
@@ -1,0 +1,101 @@
+package com.bumptech.glide.annotation.compiler;
+
+import static com.bumptech.glide.annotation.compiler.test.Util.appResource;
+import static com.bumptech.glide.annotation.compiler.test.Util.asUnixChars;
+import static com.bumptech.glide.annotation.compiler.test.Util.glide;
+import static com.bumptech.glide.annotation.compiler.test.Util.subpackage;
+import static com.google.testing.compile.CompilationSubject.assertThat;
+import static com.google.testing.compile.Compiler.javac;
+
+import com.bumptech.glide.annotation.compiler.test.ReferencedResource;
+import com.bumptech.glide.annotation.compiler.test.RegenerateResourcesRule;
+import com.bumptech.glide.annotation.compiler.test.Util;
+import com.google.testing.compile.Compilation;
+import java.io.IOException;
+import javax.tools.JavaFileObject;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/**
+ * Tests AppGlideModules that use the @Excludes annotation
+ * with a single excluded Module class in a strangely named subpackage.
+ */
+@RunWith(JUnit4.class)
+public class AppGlideModuleWithLibraryInPackageTest {
+  @Rule public final RegenerateResourcesRule regenerateResourcesRule =
+      new RegenerateResourcesRule(getClass());
+  private Compilation compilation;
+
+  @Before
+  public void setUp() {
+    compilation =
+        javac()
+            .withProcessors(new GlideAnnotationProcessor())
+            .compile(
+                forResource("AppModuleWithLibraryInPackage.java"),
+                forResource("LibraryModuleInPackage.java"));
+    assertThat(compilation).succeededWithoutWarnings();
+  }
+
+  @Test
+  @ReferencedResource
+  public void compilation_generatesExpectedGlideOptionsClass() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(subpackage("GlideOptions"))
+        .contentsAsUtf8String()
+        .isEqualTo(asUnixChars(appResource("GlideOptions.java").getCharContent(true)));
+  }
+
+  @Test
+  @ReferencedResource
+  public void compilation_generatesExpectedGlideRequestClass() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(subpackage("GlideRequest"))
+        .contentsAsUtf8String()
+        .isEqualTo(asUnixChars(appResource("GlideRequest.java").getCharContent(true)));
+  }
+
+  @Test
+  @ReferencedResource
+  public void compilation_generatesExpectedGlideRequestsClass() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(subpackage("GlideRequests"))
+        .contentsAsUtf8String()
+        .isEqualTo(asUnixChars(appResource("GlideRequests.java").getCharContent(true)));
+  }
+
+  @Test
+  @ReferencedResource
+  public void compilationGeneratesExpectedGlideAppClass() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(subpackage("GlideApp"))
+        .contentsAsUtf8String()
+        .isEqualTo(asUnixChars(appResource("GlideApp.java").getCharContent(true)));
+  }
+
+  @Test
+  public void compilation_generatesExpectedGeneratedAppGlideModuleImpl() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(glide("GeneratedAppGlideModuleImpl"))
+        .contentsAsUtf8String()
+        .isEqualTo(
+            asUnixChars(forResource("GeneratedAppGlideModuleImpl.java").getCharContent(true)));
+  }
+
+  @Test
+  @ReferencedResource
+  public void compilation_generatesExpectedGeneratedRequestManagerFactory() throws IOException {
+    assertThat(compilation)
+        .generatedSourceFile(glide("GeneratedRequestManagerFactory"))
+        .contentsAsUtf8String()
+        .isEqualTo(
+            asUnixChars(appResource("GeneratedRequestManagerFactory.java").getCharContent(true)));
+  }
+
+  private JavaFileObject forResource(String name) {
+    return Util.forResource(getClass().getSimpleName(), name);
+  }
+}

--- a/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/AppModuleWithLibraryInPackage.java
+++ b/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/AppModuleWithLibraryInPackage.java
@@ -1,0 +1,10 @@
+package com.bumptech.glide.test;
+
+import com.bumptech.glide.annotation.Excludes;
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.module.AppGlideModule;
+import com.bumptech.glide.test._package.LibraryModuleInPackage;
+
+@GlideModule
+@Excludes(LibraryModuleInPackage.class)
+public final class AppModuleWithLibraryInPackage extends AppGlideModule {}

--- a/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/GeneratedAppGlideModuleImpl.java
+++ b/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/GeneratedAppGlideModuleImpl.java
@@ -1,0 +1,54 @@
+package com.bumptech.glide;
+
+import android.content.Context;
+import android.support.annotation.NonNull;
+import android.util.Log;
+import com.bumptech.glide.test.AppModuleWithLibraryInPackage;
+import java.lang.Class;
+import java.lang.Override;
+import java.lang.SuppressWarnings;
+import java.util.HashSet;
+import java.util.Set;
+
+@SuppressWarnings("deprecation")
+final class GeneratedAppGlideModuleImpl extends GeneratedAppGlideModule {
+  private final AppModuleWithLibraryInPackage appGlideModule;
+
+  GeneratedAppGlideModuleImpl() {
+    appGlideModule = new AppModuleWithLibraryInPackage();
+    if (Log.isLoggable("Glide", Log.DEBUG)) {
+      Log.d("Glide", "Discovered AppGlideModule from annotation: com.bumptech.glide.test.AppModuleWithLibraryInPackage");
+      Log.d("Glide", "AppGlideModule excludes LibraryGlideModule from annotation: com.bumptech.glide.test._package.LibraryModuleInPackage");
+    }
+  }
+
+  @Override
+  public void applyOptions(@NonNull Context context, @NonNull GlideBuilder builder) {
+    appGlideModule.applyOptions(context, builder);
+  }
+
+  @Override
+  public void registerComponents(@NonNull Context context, @NonNull Glide glide,
+      @NonNull Registry registry) {
+    appGlideModule.registerComponents(context, glide, registry);
+  }
+
+  @Override
+  public boolean isManifestParsingEnabled() {
+    return appGlideModule.isManifestParsingEnabled();
+  }
+
+  @Override
+  @NonNull
+  public Set<Class<?>> getExcludedModuleClasses() {
+    Set<Class<?>> excludedClasses = new HashSet<Class<?>>();
+    excludedClasses.add(com.bumptech.glide.test._package.LibraryModuleInPackage.class);
+    return excludedClasses;
+  }
+
+  @Override
+  @NonNull
+  GeneratedRequestManagerFactory getRequestManagerFactory() {
+    return new GeneratedRequestManagerFactory();
+  }
+}

--- a/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/LibraryModuleInPackage.java
+++ b/annotation/compiler/test/src/test/resources/AppGlideModuleWithLibraryInPackageTest/LibraryModuleInPackage.java
@@ -1,0 +1,8 @@
+// _ in the name is important otherwise everything would work
+package com.bumptech.glide.test._package;
+
+import com.bumptech.glide.annotation.GlideModule;
+import com.bumptech.glide.module.LibraryGlideModule;
+
+@GlideModule
+public final class LibraryModuleInPackage extends LibraryGlideModule {}


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Fixes this crash during compilation:
```
org.gradle.api.tasks.TaskExecutionException: Execution failed for task ':compileGlide4DebugJavaWithJavac'.
	at org.gradle.api.internal.tasks.execution.ExecuteActionsTaskExecuter.executeActions(ExecuteActionsTaskExecuter.java:100)
	...
Caused by: java.lang.RuntimeException: java.lang.IllegalArgumentException: couldn't make a guess for com.bumptech.glide.supportapp.github._1133_stetho_integration.GlideModule
	at com.sun.tools.javac.main.Main.compile(Main.java:553)
	...
	at org.gradle.api.tasks.compile.JavaCompile.compile(JavaCompile.java:130)
	at com.android.build.gradle.tasks.factory.AndroidJavaCompile.compile(AndroidJavaCompile.java:95)
    ...
	... 28 more
Caused by: java.lang.IllegalArgumentException: couldn't make a guess for com.bumptech.glide.supportapp.github._1133_stetho_integration.GlideModule
	at com.bumptech.glide.repackaged.com.squareup.javapoet.Util.checkArgument(Util.java:64)
	at com.bumptech.glide.repackaged.com.squareup.javapoet.ClassName.bestGuess(ClassName.java:186)
	at com.bumptech.glide.annotation.compiler.AppModuleGenerator.generateConstructor(AppModuleGenerator.java:253)
	at com.bumptech.glide.annotation.compiler.AppModuleGenerator.generate(AppModuleGenerator.java:101)
	at com.bumptech.glide.annotation.compiler.AppModuleProcessor.maybeWriteAppModule(AppModuleProcessor.java:109)
	at com.bumptech.glide.annotation.compiler.GlideAnnotationProcessor.process(GlideAnnotationProcessor.java:131)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.callProcessor(JavacProcessingEnvironment.java:794)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.discoverAndRunProcs(JavacProcessingEnvironment.java:705)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.access$1800(JavacProcessingEnvironment.java:91)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment$Round.run(JavacProcessingEnvironment.java:1035)
	at com.sun.tools.javac.processing.JavacProcessingEnvironment.doProcessing(JavacProcessingEnvironment.java:1176)
	at com.sun.tools.javac.main.JavaCompiler.processAnnotations(JavaCompiler.java:1170)
	at com.sun.tools.javac.main.JavaCompiler.compile(JavaCompiler.java:856)
	at com.sun.tools.javac.main.Main.compile(Main.java:523)
	... 53 more
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
The problem is that the APT compiler is failing because of a log line, Glide shouldn't impose any limitations on the names used in modules as long as they're standard Java.
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->