### PR TITLE
Give generated code meaningful parameter names

### DIFF
--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
@@ -256,15 +256,15 @@ final class ProcessorUtil {
     processingEnv.getMessager().printMessage(Diagnostic.Kind.WARNING, toLog);
   }
 
-  static CodeBlock generateCastingSuperCall(TypeName toReturn, ExecutableElement method) {
+  static CodeBlock generateCastingSuperCall(TypeName toReturn, MethodSpec method) {
     return CodeBlock.builder()
-        .add("return ($T) super.$N(", toReturn, method.getSimpleName())
+        .add("return ($T) super.$N(", toReturn, method.name)
         .add(
-            FluentIterable.from(method.getParameters())
-                .transform(new Function<VariableElement, String>() {
+            FluentIterable.from(method.parameters)
+                .transform(new Function<ParameterSpec, String>() {
                   @Override
-                  public String apply(VariableElement input) {
-                    return input.getSimpleName().toString();
+                  public String apply(ParameterSpec input) {
+                    return input.name;
                   }
                 })
                 .join(Joiner.on(",")))
@@ -317,16 +317,115 @@ final class ProcessorUtil {
     for (VariableElement parameter : parameters) {
       result.add(getParameter(parameter));
     }
-    return result;
+    return dedupedParameters(result);
   }
 
-  private static ParameterSpec getParameter(VariableElement method) {
-    TypeName type = TypeName.get(method.asType());
-    String name = method.getSimpleName().toString();
-    return ParameterSpec.builder(type, name)
-        .addModifiers(method.getModifiers())
-        .addAnnotations(getAnnotations(method))
+  private static List<ParameterSpec> dedupedParameters(List<ParameterSpec> parameters) {
+    boolean hasDupes = false;
+    Set<String> names = new HashSet<>();
+    for (ParameterSpec parameter : parameters) {
+      String name = parameter.name;
+      if (names.contains(name)) {
+        hasDupes = true;
+      } else {
+        names.add(name);
+      }
+    }
+
+    if (hasDupes) {
+      List<ParameterSpec> copy = parameters;
+      parameters = new ArrayList<>();
+      for (int i = 0; i < copy.size(); i++) {
+        ParameterSpec parameter = copy.get(i);
+        parameters.add(ParameterSpec.builder(parameter.type, parameter.name + i)
+            .addModifiers(parameter.modifiers)
+            .addAnnotations(parameter.annotations)
+            .build());
+      }
+    }
+
+    return parameters;
+  }
+
+  private static ParameterSpec getParameter(VariableElement parameter) {
+    TypeName type = TypeName.get(parameter.asType());
+    return ParameterSpec.builder(type, computeParameterName(parameter, type))
+        .addModifiers(parameter.getModifiers())
+        .addAnnotations(getAnnotations(parameter))
         .build();
+  }
+
+  private static String computeParameterName(VariableElement parameter, TypeName type) {
+    String rawClassName = type.withoutAnnotations().toString();
+
+    String name;
+
+    if (type.isPrimitive() || type.isBoxedPrimitive()) {
+      name = getSmartPrimitiveParameterName(parameter);
+    } else {
+      if (rawClassName.contains("<") && rawClassName.contains(">")) {
+        String[] preGenericSplit = rawClassName.split("<");
+        String preGeneric = preGenericSplit[0];
+        String[] postGenericSplit = rawClassName.split(">");
+        String postGeneric = postGenericSplit[postGenericSplit.length - 1];
+        if (postGenericSplit.length > 1) {
+          rawClassName = preGeneric + postGeneric;
+        } else {
+          rawClassName = preGeneric;
+        }
+      }
+
+      String[] qualifiers = rawClassName.split("\\.");
+      rawClassName = qualifiers[qualifiers.length - 1];
+
+      rawClassName = applySmartParameterNameReplacements(rawClassName);
+
+      boolean allCaps = true;
+      for (char c : rawClassName.toCharArray()) {
+        if (Character.isLowerCase(c)) {
+          allCaps = false;
+          break;
+        }
+      }
+      if (allCaps) {
+        name = rawClassName.toLowerCase();
+      } else {
+        int indexOfLastWordStart = 0;
+        char[] chars = rawClassName.toCharArray();
+        for (int i = 0, charArrayLength = chars.length; i < charArrayLength; i++) {
+          char c = chars[i];
+          if (Character.isUpperCase(c)) {
+            indexOfLastWordStart = i;
+          }
+        }
+        rawClassName = rawClassName.substring(indexOfLastWordStart, rawClassName.length());
+
+        name = Character.toLowerCase(rawClassName.charAt(0))
+            + rawClassName.substring(1, rawClassName.length());
+      }
+    }
+
+    return name;
+  }
+
+  private static String getSmartPrimitiveParameterName(VariableElement parameter) {
+    for (AnnotationMirror annotation : parameter.getAnnotationMirrors()) {
+      String annotationName = annotation.getAnnotationType().toString().toUpperCase();
+      if (annotationName.endsWith("RES")) { // Catch annotations like StringRes
+        return "id";
+      } else if (annotationName.endsWith("RANGE")) { // Catch annotations like IntRange
+        return "value";
+      }
+    }
+
+    return parameter.getSimpleName().toString();
+  }
+
+  private static String applySmartParameterNameReplacements(String name) {
+    name = name.replace("[]", "s");
+    name = name.replace(Class.class.getSimpleName(), "clazz");
+    name = name.replace(Object.class.getSimpleName(), "o");
+    return name;
   }
 
   private static List<AnnotationSpec> getAnnotations(VariableElement element) {

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
@@ -411,9 +411,11 @@ final class ProcessorUtil {
   private static String getSmartPrimitiveParameterName(VariableElement parameter) {
     for (AnnotationMirror annotation : parameter.getAnnotationMirrors()) {
       String annotationName = annotation.getAnnotationType().toString().toUpperCase();
-      if (annotationName.endsWith("RES")) { // Catch annotations like StringRes
+      if (annotationName.endsWith("RES")) {
+        // Catch annotations like StringRes
         return "id";
-      } else if (annotationName.endsWith("RANGE")) { // Catch annotations like IntRange
+      } else if (annotationName.endsWith("RANGE")) {
+        // Catch annotations like IntRange
         return "value";
       }
     }

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestBuilderGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestBuilderGenerator.java
@@ -33,7 +33,6 @@ import javax.lang.model.element.AnnotationMirror;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
-import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.DeclaredType;
 import javax.lang.model.type.TypeMirror;
 
@@ -214,20 +213,20 @@ final class RequestBuilderGenerator {
         ParameterizedTypeName.get(generatedRequestBuilderClassName, ClassName.get(typeArgument));
 
     MethodSpec.Builder builder = ProcessorUtil.overriding(methodToOverride)
-        .returns(generatedRequestBuilderOfType)
-        .addCode(CodeBlock.builder()
-            .add("return ($T) super.$N(",
-                generatedRequestBuilderOfType, methodToOverride.getSimpleName())
-            .add(FluentIterable.from(methodToOverride.getParameters())
-                .transform(new Function<VariableElement, String>() {
-                  @Override
-                  public String apply(VariableElement input) {
-                    return input.getSimpleName().toString();
-                  }
-                })
-                .join(Joiner.on(", ")))
-            .add(");\n")
-            .build());
+        .returns(generatedRequestBuilderOfType);
+    builder.addCode(CodeBlock.builder()
+        .add("return ($T) super.$N(",
+            generatedRequestBuilderOfType, methodToOverride.getSimpleName())
+        .add(FluentIterable.from(builder.build().parameters)
+            .transform(new Function<ParameterSpec, String>() {
+              @Override
+              public String apply(ParameterSpec input) {
+                return input.name;
+              }
+            })
+            .join(Joiner.on(", ")))
+        .add(");\n")
+        .build());
 
     for (AnnotationMirror mirror : methodToOverride.getAnnotationMirrors()) {
       builder = builder.addAnnotation(AnnotationSpec.get(mirror));

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestManagerGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestManagerGenerator.java
@@ -12,6 +12,7 @@ import com.google.common.collect.Lists;
 import com.squareup.javapoet.AnnotationSpec;
 import com.squareup.javapoet.ClassName;
 import com.squareup.javapoet.MethodSpec;
+import com.squareup.javapoet.MethodSpec.Builder;
 import com.squareup.javapoet.ParameterSpec;
 import com.squareup.javapoet.ParameterizedTypeName;
 import com.squareup.javapoet.TypeSpec;
@@ -192,10 +193,12 @@ final class RequestManagerGenerator {
       String generatedPackageName, ExecutableElement method) {
     ClassName generatedRequestManagerName =
         ClassName.get(generatedPackageName, GENERATED_REQUEST_MANAGER_SIMPLE_NAME);
-    return ProcessorUtil.overriding(method)
+    Builder returns = ProcessorUtil.overriding(method)
         .addAnnotation(nonNull())
-        .returns(generatedRequestManagerName)
-        .addCode(ProcessorUtil.generateCastingSuperCall(generatedRequestManagerName, method))
+        .returns(generatedRequestManagerName);
+    return returns
+        .addCode(ProcessorUtil.generateCastingSuperCall(
+            generatedRequestManagerName, returns.build()))
         .build();
   }
 
@@ -240,10 +243,9 @@ final class RequestManagerGenerator {
         ParameterizedTypeName.get(generatedRequestBuilderClassName, ClassName.get(typeArgument));
 
     MethodSpec.Builder builder = ProcessorUtil.overriding(methodToOverride)
-        .returns(generatedRequestBuilderOfType)
-        .addCode(
-            ProcessorUtil.generateCastingSuperCall(
-                generatedRequestBuilderOfType, methodToOverride));
+        .returns(generatedRequestBuilderOfType);
+    builder.addCode(
+        ProcessorUtil.generateCastingSuperCall(generatedRequestBuilderOfType, builder.build()));
 
     for (AnnotationMirror mirror : methodToOverride.getAnnotationMirrors()) {
       builder.addAnnotation(AnnotationSpec.get(mirror));

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsGenerator.java
@@ -30,7 +30,6 @@ import java.util.Set;
 import javax.annotation.Nullable;
 import javax.annotation.processing.ProcessingEnvironment;
 import javax.lang.model.element.AnnotationMirror;
-import javax.lang.model.element.Element;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Modifier;
 import javax.lang.model.element.TypeElement;
@@ -197,19 +196,19 @@ final class RequestOptionsGenerator {
   private MethodSpec generateRequestOptionOverride(ExecutableElement methodToOverride) {
     MethodSpec.Builder result = ProcessorUtil.overriding(methodToOverride)
         .returns(glideOptionsName)
-        .addModifiers(Modifier.FINAL)
-        .addCode(CodeBlock.builder()
-            .add("return ($T) super.$N(", glideOptionsName, methodToOverride.getSimpleName())
-            .add(FluentIterable.from(methodToOverride.getParameters())
-                .transform(new Function<VariableElement, String>() {
-                  @Override
-                  public String apply(VariableElement input) {
-                    return input.getSimpleName().toString();
-                  }
-                })
-                .join(Joiner.on(", ")))
-            .add(");\n")
-            .build());
+        .addModifiers(Modifier.FINAL);
+    result.addCode(CodeBlock.builder()
+        .add("return ($T) super.$N(", glideOptionsName, methodToOverride.getSimpleName())
+        .add(FluentIterable.from(result.build().parameters)
+            .transform(new Function<ParameterSpec, String>() {
+              @Override
+              public String apply(ParameterSpec input) {
+                return input.name;
+              }
+            })
+            .join(Joiner.on(", ")))
+        .add(");\n")
+        .build());
 
     if (methodToOverride.getSimpleName().toString().equals("transforms")) {
       result
@@ -254,24 +253,25 @@ final class RequestOptionsGenerator {
         .returns(glideOptionsName);
 
     // The 0th element is expected to be a RequestOptions object.
-    List<? extends VariableElement> parameters =
+    List<? extends VariableElement> paramElements =
         element.getParameters().subList(1, element.getParameters().size());
-    builder.addParameters(ProcessorUtil.getParameters(parameters));
+    List<ParameterSpec> parameters = ProcessorUtil.getParameters(paramElements);
+    builder.addParameters(parameters);
 
     String extensionRequestOptionsArgument;
     if (overrideType == OVERRIDE_EXTEND) {
       builder
           .addJavadoc(
-              processorUtil.generateSeeMethodJavadoc(requestOptionsName, methodName, parameters))
+              processorUtil.generateSeeMethodJavadoc(requestOptionsName, methodName, paramElements))
           .addAnnotation(Override.class);
 
       List<Object> methodArgs = new ArrayList<>();
       methodArgs.add(element.getSimpleName().toString());
       StringBuilder methodLiterals = new StringBuilder();
       if (!parameters.isEmpty()) {
-        for (VariableElement variable : parameters) {
+        for (ParameterSpec parameter : parameters) {
           methodLiterals.append("$L, ");
-          methodArgs.add(variable.getSimpleName().toString());
+          methodArgs.add(parameter.name);
         }
         methodLiterals = new StringBuilder(
             methodLiterals.substring(0, methodLiterals.length() - 2));
@@ -291,9 +291,9 @@ final class RequestOptionsGenerator {
     args.add(element.getSimpleName().toString());
     args.add(extensionRequestOptionsArgument);
     if (!parameters.isEmpty()) {
-      for (VariableElement variable : parameters) {
+      for (ParameterSpec parameter : parameters) {
         code.append("$L, ");
-        args.add(variable.getSimpleName().toString());
+        args.add(parameter.name);
       }
     }
     code = new StringBuilder(code.substring(0, code.length() - 2));
@@ -326,9 +326,10 @@ final class RequestOptionsGenerator {
         .returns(glideOptionsName);
 
     // The 0th element is expected to be a RequestOptions object.
-    List<? extends VariableElement> parameters =
+    List<? extends VariableElement> paramElements =
         element.getParameters().subList(1, element.getParameters().size());
-    builder.addParameters(ProcessorUtil.getParameters(parameters));
+    List<ParameterSpec> parameters = ProcessorUtil.getParameters(paramElements);
+    builder.addParameters(parameters);
 
     // Generates the String and list of arguments to pass in when calling this method or super.
     // IE centerCrop(context) creates methodLiterals="%L" and methodArgs=[centerCrop, context].
@@ -336,9 +337,9 @@ final class RequestOptionsGenerator {
     methodArgs.add(element.getSimpleName().toString());
     StringBuilder methodLiterals = new StringBuilder();
     if (!parameters.isEmpty()) {
-      for (VariableElement variable : parameters) {
+      for (ParameterSpec parameter : parameters) {
         methodLiterals.append("$L, ");
-        methodArgs.add(variable.getSimpleName().toString());
+        methodArgs.add(parameter.name);
       }
       methodLiterals = new StringBuilder(methodLiterals.substring(0, methodLiterals.length() - 2));
     }
@@ -353,7 +354,7 @@ final class RequestOptionsGenerator {
       String callSuper = "super.$L(" + methodLiterals + ")";
       builder.addStatement(callSuper, methodArgs.toArray(new Object[0]))
           .addJavadoc(processorUtil.generateSeeMethodJavadoc(
-              requestOptionsName, methodName, parameters))
+              requestOptionsName, methodName, paramElements))
           .addAnnotation(Override.class);
     }
 
@@ -364,9 +365,9 @@ final class RequestOptionsGenerator {
     args.add(element.getSimpleName().toString());
     args.add("this");
     if (!parameters.isEmpty()) {
-      for (VariableElement variable : parameters) {
+      for (ParameterSpec parameter : parameters) {
         code.append("$L, ");
-        args.add(variable.getSimpleName().toString());
+        args.add(parameter.name);
       }
     }
     code = new StringBuilder(code.substring(0, code.length() - 2));
@@ -446,9 +447,8 @@ final class RequestOptionsGenerator {
             .addJavadoc(processorUtil.generateSeeMethodJavadoc(staticMethod))
             .returns(glideOptionsName);
 
-    List<? extends VariableElement> parameters = staticMethod.getParameters();
     StringBuilder createNewOptionAndCall = createNewOptionAndCall(memoize, methodSpecBuilder,
-        parameters, "new $T().$N(", ProcessorUtil.getParameters(staticMethod));
+        "new $T().$N(", ProcessorUtil.getParameters(staticMethod));
 
     FieldSpec requiredStaticField = null;
     if (memoize) {
@@ -535,7 +535,7 @@ final class RequestOptionsGenerator {
     parameters = parameters.subList(1, parameters.size());
 
     StringBuilder createNewOptionAndCall = createNewOptionAndCall(memoize, methodSpecBuilder,
-        parameters, "new $T().$L(", ProcessorUtil.getParameters(parameters));
+        "new $T().$L(", ProcessorUtil.getParameters(parameters));
 
     FieldSpec requiredStaticField = null;
     if (memoize) {
@@ -576,12 +576,12 @@ final class RequestOptionsGenerator {
 
   private StringBuilder createNewOptionAndCall(boolean memoize,
       MethodSpec.Builder methodSpecBuilder,
-      List<? extends VariableElement> parameters, String start, List<ParameterSpec> specs) {
+      String start, List<ParameterSpec> specs) {
     StringBuilder createNewOptionAndCall = new StringBuilder(start);
-    if (!parameters.isEmpty()) {
+    if (!specs.isEmpty()) {
       methodSpecBuilder.addParameters(specs);
-      for (VariableElement parameter : parameters) {
-        createNewOptionAndCall.append(parameter.getSimpleName().toString());
+      for (ParameterSpec parameter : specs) {
+        createNewOptionAndCall.append(parameter.name);
         // use the Application Context to avoid memory leaks.
         if (memoize && isAndroidContext(parameter)) {
           createNewOptionAndCall.append(".getApplicationContext()");
@@ -595,9 +595,8 @@ final class RequestOptionsGenerator {
     return createNewOptionAndCall;
   }
 
-  private boolean isAndroidContext(VariableElement variableElement) {
-    Element element = processingEnvironment.getTypeUtils().asElement(variableElement.asType());
-    return element.toString().equals("android.content.Context");
+  private boolean isAndroidContext(ParameterSpec parameter) {
+    return parameter.type.toString().equals("android.content.Context");
   }
 
   @Nullable

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideApp.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideApp.java
@@ -32,24 +32,24 @@ public final class GlideApp {
    * @see Glide#getPhotoCacheDir(Context)
    */
   @Nullable
-  public static File getPhotoCacheDir(@NonNull Context arg0) {
-    return Glide.getPhotoCacheDir(arg0);
+  public static File getPhotoCacheDir(@NonNull Context context) {
+    return Glide.getPhotoCacheDir(context);
   }
 
   /**
    * @see Glide#getPhotoCacheDir(Context, String)
    */
   @Nullable
-  public static File getPhotoCacheDir(@NonNull Context arg0, @NonNull String arg1) {
-    return Glide.getPhotoCacheDir(arg0, arg1);
+  public static File getPhotoCacheDir(@NonNull Context context, @NonNull String string) {
+    return Glide.getPhotoCacheDir(context, string);
   }
 
   /**
    * @see Glide#get(Context)
    */
   @NonNull
-  public static Glide get(@NonNull Context arg0) {
-    return Glide.get(arg0);
+  public static Glide get(@NonNull Context context) {
+    return Glide.get(context);
   }
 
   /**
@@ -67,8 +67,8 @@ public final class GlideApp {
    */
   @VisibleForTesting
   @SuppressLint("VisibleForTests")
-  public static void init(@NonNull Context arg0, @NonNull GlideBuilder arg1) {
-    Glide.init(arg0, arg1);
+  public static void init(@NonNull Context context, @NonNull GlideBuilder builder) {
+    Glide.init(context, builder);
   }
 
   /**
@@ -84,32 +84,32 @@ public final class GlideApp {
    * @see Glide#with(Context)
    */
   @NonNull
-  public static GlideRequests with(@NonNull Context arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull Context context) {
+    return (GlideRequests) Glide.with(context);
   }
 
   /**
    * @see Glide#with(Activity)
    */
   @NonNull
-  public static GlideRequests with(@NonNull Activity arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull Activity activity) {
+    return (GlideRequests) Glide.with(activity);
   }
 
   /**
    * @see Glide#with(FragmentActivity)
    */
   @NonNull
-  public static GlideRequests with(@NonNull FragmentActivity arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull FragmentActivity activity) {
+    return (GlideRequests) Glide.with(activity);
   }
 
   /**
    * @see Glide#with(Fragment)
    */
   @NonNull
-  public static GlideRequests with(@NonNull Fragment arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull Fragment fragment) {
+    return (GlideRequests) Glide.with(fragment);
   }
 
   /**
@@ -117,15 +117,15 @@ public final class GlideApp {
    */
   @Deprecated
   @NonNull
-  public static GlideRequests with(@NonNull android.app.Fragment arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull android.app.Fragment fragment) {
+    return (GlideRequests) Glide.with(fragment);
   }
 
   /**
    * @see Glide#with(View)
    */
   @NonNull
-  public static GlideRequests with(@NonNull View arg0) {
-    return (GlideRequests) Glide.with(arg0);
+  public static GlideRequests with(@NonNull View view) {
+    return (GlideRequests) Glide.with(view);
   }
 }

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideOptions.java
@@ -47,8 +47,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -56,8 +56,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -65,8 +65,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -74,8 +74,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -83,8 +83,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -92,8 +92,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -101,8 +101,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -119,9 +119,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -129,8 +129,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -138,8 +138,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -199,8 +199,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -221,8 +221,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -230,8 +230,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -239,8 +239,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -248,8 +248,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -257,8 +257,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -266,8 +266,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -275,8 +275,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -284,8 +284,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -304,8 +304,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -332,64 +332,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -416,8 +416,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -429,43 +429,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -478,15 +478,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -548,8 +548,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -557,30 +557,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -600,8 +601,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequests.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequests.java
@@ -5,8 +5,10 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.CheckResult;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -45,14 +47,14 @@ public class GlideRequests extends RequestManager {
 
   @Override
   @NonNull
-  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.applyDefaultRequestOptions(arg0);
+  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.applyDefaultRequestOptions(options);
   }
 
   @Override
   @NonNull
-  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.setDefaultRequestOptions(arg0);
+  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.setDefaultRequestOptions(options);
   }
 
   @Override
@@ -79,64 +81,64 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<Drawable>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Drawable arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Drawable drawable) {
+    return (GlideRequest<Drawable>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable String arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable String string) {
+    return (GlideRequest<Drawable>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Uri arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Uri uri) {
+    return (GlideRequest<Drawable>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable File arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable File file) {
+    return (GlideRequest<Drawable>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Integer arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<Drawable>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable URL arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable URL url) {
+    return (GlideRequest<Drawable>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable byte[] arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable byte[] bytes) {
+    return (GlideRequest<Drawable>) super.load(bytes);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Object arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Object o) {
+    return (GlideRequest<Drawable>) super.load(o);
   }
 
   @Override
@@ -149,8 +151,8 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<File> download(@Nullable Object arg0) {
-    return (GlideRequest<File>) super.download(arg0);
+  public GlideRequest<File> download(@Nullable Object o) {
+    return (GlideRequest<File>) super.download(o);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
@@ -50,8 +50,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -59,8 +59,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -68,8 +68,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -77,8 +77,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -86,8 +86,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -95,8 +95,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -104,8 +104,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -122,9 +122,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -132,8 +132,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -141,8 +141,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -202,8 +202,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -224,8 +224,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -233,8 +233,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -242,8 +242,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -251,8 +251,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -260,8 +260,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -269,8 +269,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -278,8 +278,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -287,8 +287,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -307,8 +307,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -335,64 +335,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -419,8 +419,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -432,43 +432,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -481,15 +481,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -551,8 +551,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -560,30 +560,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -603,8 +604,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -542,8 +542,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -551,30 +551,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -594,8 +595,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -536,11 +536,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -554,11 +554,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -582,12 +582,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -597,12 +597,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,8 +120,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -129,8 +129,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -190,8 +190,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -212,8 +212,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -221,8 +221,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -230,8 +230,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -239,8 +239,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -248,8 +248,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -257,8 +257,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -266,8 +266,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -275,8 +275,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -295,8 +295,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -323,64 +323,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -400,8 +400,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -413,43 +413,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -462,15 +462,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -532,8 +532,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -541,30 +541,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -584,8 +585,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -284,11 +284,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -396,11 +396,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -536,11 +536,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -554,11 +554,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -582,12 +582,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -597,12 +597,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -542,8 +542,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -551,30 +551,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -594,8 +595,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -536,11 +536,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -554,11 +554,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -582,12 +582,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -597,12 +597,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideRequests.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideRequests.java
@@ -5,8 +5,10 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.CheckResult;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -55,14 +57,14 @@ public class GlideRequests extends RequestManager {
 
   @Override
   @NonNull
-  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.applyDefaultRequestOptions(arg0);
+  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.applyDefaultRequestOptions(options);
   }
 
   @Override
   @NonNull
-  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.setDefaultRequestOptions(arg0);
+  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.setDefaultRequestOptions(options);
   }
 
   @Override
@@ -89,64 +91,64 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<Drawable>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Drawable arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Drawable drawable) {
+    return (GlideRequest<Drawable>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable String arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable String string) {
+    return (GlideRequest<Drawable>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Uri arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Uri uri) {
+    return (GlideRequest<Drawable>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable File arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable File file) {
+    return (GlideRequest<Drawable>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Integer arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<Drawable>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable URL arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable URL url) {
+    return (GlideRequest<Drawable>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable byte[] arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable byte[] bytes) {
+    return (GlideRequest<Drawable>) super.load(bytes);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Object arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Object o) {
+    return (GlideRequest<Drawable>) super.load(o);
   }
 
   @Override
@@ -159,8 +161,8 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<File> download(@Nullable Object arg0) {
-    return (GlideRequest<File>) super.download(arg0);
+  public GlideRequest<File> download(@Nullable Object o) {
+    return (GlideRequest<File>) super.download(o);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
@@ -50,8 +50,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -59,8 +59,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -68,8 +68,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -77,8 +77,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -86,8 +86,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -95,8 +95,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -104,8 +104,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -122,9 +122,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -132,8 +132,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -141,8 +141,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -202,8 +202,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -224,8 +224,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -233,8 +233,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -242,8 +242,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -251,8 +251,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -260,8 +260,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -269,8 +269,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -278,8 +278,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -287,8 +287,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -307,8 +307,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -335,64 +335,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -419,8 +419,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -432,43 +432,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -481,15 +481,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -551,8 +551,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -560,30 +560,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -603,8 +604,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -542,8 +542,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -551,30 +551,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -594,8 +595,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -536,11 +536,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -554,11 +554,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -582,12 +582,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -597,12 +597,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -542,8 +542,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -551,30 +551,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -594,8 +595,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -536,11 +536,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -554,11 +554,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -582,12 +582,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -597,12 +597,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -652,35 +652,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -688,8 +688,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -702,64 +702,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithOptionTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithOptionTest/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithOptionTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithOptionTest/GlideRequest.java
@@ -74,11 +74,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
+  public GlideRequest<TranscodeType> sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).sizeMultiplier(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).sizeMultiplier(value);
     }
     return this;
   }
@@ -130,11 +130,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
+  public GlideRequest<TranscodeType> diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).diskCacheStrategy(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).diskCacheStrategy(strategy);
     }
     return this;
   }
@@ -144,11 +144,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> priority(@NonNull Priority arg0) {
+  public GlideRequest<TranscodeType> priority(@NonNull Priority priority) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).priority(priority);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).priority(priority);
     }
     return this;
   }
@@ -158,11 +158,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> placeholder(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(drawable);
     }
     return this;
   }
@@ -172,11 +172,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> placeholder(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> placeholder(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).placeholder(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).placeholder(id);
     }
     return this;
   }
@@ -186,11 +186,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> fallback(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(drawable);
     }
     return this;
   }
@@ -200,11 +200,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> fallback(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> fallback(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).fallback(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).fallback(id);
     }
     return this;
   }
@@ -214,11 +214,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@Nullable Drawable arg0) {
+  public GlideRequest<TranscodeType> error(@Nullable Drawable drawable) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(drawable);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(drawable);
     }
     return this;
   }
@@ -228,11 +228,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> error(@DrawableRes int arg0) {
+  public GlideRequest<TranscodeType> error(@DrawableRes int id) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).error(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).error(id);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).error(id);
     }
     return this;
   }
@@ -242,11 +242,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme arg0) {
+  public GlideRequest<TranscodeType> theme(@Nullable Resources.Theme theme) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).theme(theme);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).theme(theme);
     }
     return this;
   }
@@ -298,11 +298,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> signature(@NonNull Key arg0) {
+  public GlideRequest<TranscodeType> signature(@NonNull Key key) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).signature(key);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).signature(key);
     }
     return this;
   }
@@ -312,11 +312,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> arg0, @NonNull T arg1) {
+  public <T> GlideRequest<TranscodeType> set(@NonNull Option<T> option, @NonNull T t) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).set(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).set(option, t);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).set(option, t);
     }
     return this;
   }
@@ -326,11 +326,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> decode(@NonNull Class<?> arg0) {
+  public GlideRequest<TranscodeType> decode(@NonNull Class<?> clazz) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).decode(clazz);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).decode(clazz);
     }
     return this;
   }
@@ -340,11 +340,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
+  public GlideRequest<TranscodeType> encodeFormat(@NonNull Bitmap.CompressFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeFormat(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeFormat(format);
     }
     return this;
   }
@@ -354,11 +354,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
+  public GlideRequest<TranscodeType> encodeQuality(@IntRange(from = 0, to = 100) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).encodeQuality(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).encodeQuality(value);
     }
     return this;
   }
@@ -368,11 +368,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long arg0) {
+  public GlideRequest<TranscodeType> frame(@IntRange(from = 0) long value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).frame(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).frame(value);
     }
     return this;
   }
@@ -382,11 +382,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat arg0) {
+  public GlideRequest<TranscodeType> format(@NonNull DecodeFormat format) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).format(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).format(format);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).format(format);
     }
     return this;
   }
@@ -410,11 +410,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy arg0) {
+  public GlideRequest<TranscodeType> downsample(@NonNull DownsampleStrategy strategy) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).downsample(strategy);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).downsample(strategy);
     }
     return this;
   }
@@ -424,11 +424,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int arg0) {
+  public GlideRequest<TranscodeType> timeout(@IntRange(from = 0) int value) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).timeout(value);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).timeout(value);
     }
     return this;
   }
@@ -550,11 +550,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(transformation);
     }
     return this;
   }
@@ -568,11 +568,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
       "unchecked",
       "varargs"
   })
-  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... arg0) {
+  public GlideRequest<TranscodeType> transforms(@NonNull Transformation<Bitmap>... transformations) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transforms(transformations);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transforms(transformations);
     }
     return this;
   }
@@ -582,11 +582,11 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> arg0) {
+  public GlideRequest<TranscodeType> optionalTransform(@NonNull Transformation<Bitmap> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(transformation);
     }
     return this;
   }
@@ -596,12 +596,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).optionalTransform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).optionalTransform(clazz, transformation);
     }
     return this;
   }
@@ -611,12 +611,12 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
    */
   @NonNull
   @CheckResult
-  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
+  public <T> GlideRequest<TranscodeType> transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
     if (getMutableOptions() instanceof GlideOptions) {
-      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(arg0, arg1);
+      this.requestOptions = ((GlideOptions) getMutableOptions()).transform(clazz, transformation);
     } else {
-      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(arg0, arg1);
+      this.requestOptions = new GlideOptions().apply(this.requestOptions).transform(clazz, transformation);
     }
     return this;
   }
@@ -666,35 +666,35 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions arg0) {
-    return (GlideRequest<TranscodeType>) super.apply(arg0);
+  public GlideRequest<TranscodeType> apply(@NonNull RequestOptions options) {
+    return (GlideRequest<TranscodeType>) super.apply(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.transition(arg0);
+  public GlideRequest<TranscodeType> transition(@NonNull TransitionOptions<?, ? super TranscodeType> options) {
+    return (GlideRequest<TranscodeType>) super.transition(options);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.listener(arg0);
+  public GlideRequest<TranscodeType> listener(@Nullable RequestListener<TranscodeType> listener) {
+    return (GlideRequest<TranscodeType>) super.listener(listener);
   }
 
   @Override
   @NonNull
-  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.error(arg0);
+  public GlideRequest<TranscodeType> error(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.error(builder);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType> builder) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builder);
   }
 
   @Override
@@ -702,8 +702,8 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @CheckResult
   @SafeVarargs
   @SuppressWarnings("varargs")
-  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... arg0) {
-    return (GlideRequest<TranscodeType>) super.thumbnail(arg0);
+  public final GlideRequest<TranscodeType> thumbnail(@Nullable RequestBuilder<TranscodeType>... builders) {
+    return (GlideRequest<TranscodeType>) super.thumbnail(builders);
   }
 
   @Override
@@ -716,64 +716,64 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Object arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Object o) {
+    return (GlideRequest<TranscodeType>) super.load(o);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<TranscodeType>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Drawable arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Drawable drawable) {
+    return (GlideRequest<TranscodeType>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable String arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable String string) {
+    return (GlideRequest<TranscodeType>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable Uri arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable Uri uri) {
+    return (GlideRequest<TranscodeType>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable File arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable File file) {
+    return (GlideRequest<TranscodeType>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<TranscodeType>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable URL arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable URL url) {
+    return (GlideRequest<TranscodeType>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<TranscodeType> load(@Nullable byte[] arg0) {
-    return (GlideRequest<TranscodeType>) super.load(arg0);
+  public GlideRequest<TranscodeType> load(@Nullable byte[] bytes) {
+    return (GlideRequest<TranscodeType>) super.load(bytes);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithTypeTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithTypeTest/GlideOptions.java
@@ -48,8 +48,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return new GlideOptions().sizeMultiplier(arg0);
+  public static GlideOptions sizeMultiplierOf(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return new GlideOptions().sizeMultiplier(value);
   }
 
   /**
@@ -57,8 +57,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy arg0) {
-    return new GlideOptions().diskCacheStrategy(arg0);
+  public static GlideOptions diskCacheStrategyOf(@NonNull DiskCacheStrategy strategy) {
+    return new GlideOptions().diskCacheStrategy(strategy);
   }
 
   /**
@@ -66,8 +66,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions priorityOf(@NonNull Priority arg0) {
-    return new GlideOptions().priority(arg0);
+  public static GlideOptions priorityOf(@NonNull Priority priority) {
+    return new GlideOptions().priority(priority);
   }
 
   /**
@@ -75,8 +75,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@Nullable Drawable arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@Nullable Drawable drawable) {
+    return new GlideOptions().placeholder(drawable);
   }
 
   /**
@@ -84,8 +84,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions placeholderOf(@DrawableRes int arg0) {
-    return new GlideOptions().placeholder(arg0);
+  public static GlideOptions placeholderOf(@DrawableRes int id) {
+    return new GlideOptions().placeholder(id);
   }
 
   /**
@@ -93,8 +93,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@Nullable Drawable arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@Nullable Drawable drawable) {
+    return new GlideOptions().error(drawable);
   }
 
   /**
@@ -102,8 +102,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions errorOf(@DrawableRes int arg0) {
-    return new GlideOptions().error(arg0);
+  public static GlideOptions errorOf(@DrawableRes int id) {
+    return new GlideOptions().error(id);
   }
 
   /**
@@ -120,9 +120,9 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0,
-      @IntRange(from = 0) int arg1) {
-    return new GlideOptions().override(arg0, arg1);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value0,
+      @IntRange(from = 0) int value1) {
+    return new GlideOptions().override(value0, value1);
   }
 
   /**
@@ -130,8 +130,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions overrideOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().override(arg0);
+  public static GlideOptions overrideOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().override(value);
   }
 
   /**
@@ -139,8 +139,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions signatureOf(@NonNull Key arg0) {
-    return new GlideOptions().signature(arg0);
+  public static GlideOptions signatureOf(@NonNull Key key) {
+    return new GlideOptions().signature(key);
   }
 
   /**
@@ -200,8 +200,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> arg0) {
-    return new GlideOptions().transform(arg0);
+  public static GlideOptions bitmapTransform(@NonNull Transformation<Bitmap> transformation) {
+    return new GlideOptions().transform(transformation);
   }
 
   /**
@@ -222,8 +222,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static <T> GlideOptions option(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return new GlideOptions().set(arg0, arg1);
+  public static <T> GlideOptions option(@NonNull Option<T> option, @NonNull T t) {
+    return new GlideOptions().set(option, t);
   }
 
   /**
@@ -231,8 +231,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions decodeTypeOf(@NonNull Class<?> arg0) {
-    return new GlideOptions().decode(arg0);
+  public static GlideOptions decodeTypeOf(@NonNull Class<?> clazz) {
+    return new GlideOptions().decode(clazz);
   }
 
   /**
@@ -240,8 +240,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions formatOf(@NonNull DecodeFormat arg0) {
-    return new GlideOptions().format(arg0);
+  public static GlideOptions formatOf(@NonNull DecodeFormat format) {
+    return new GlideOptions().format(format);
   }
 
   /**
@@ -249,8 +249,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions frameOf(@IntRange(from = 0) long arg0) {
-    return new GlideOptions().frame(arg0);
+  public static GlideOptions frameOf(@IntRange(from = 0) long value) {
+    return new GlideOptions().frame(value);
   }
 
   /**
@@ -258,8 +258,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy arg0) {
-    return new GlideOptions().downsample(arg0);
+  public static GlideOptions downsampleOf(@NonNull DownsampleStrategy strategy) {
+    return new GlideOptions().downsample(strategy);
   }
 
   /**
@@ -267,8 +267,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions timeoutOf(@IntRange(from = 0) int arg0) {
-    return new GlideOptions().timeout(arg0);
+  public static GlideOptions timeoutOf(@IntRange(from = 0) int value) {
+    return new GlideOptions().timeout(value);
   }
 
   /**
@@ -276,8 +276,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int arg0) {
-    return new GlideOptions().encodeQuality(arg0);
+  public static GlideOptions encodeQualityOf(@IntRange(from = 0, to = 100) int value) {
+    return new GlideOptions().encodeQuality(value);
   }
 
   /**
@@ -285,8 +285,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
    */
   @CheckResult
   @NonNull
-  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat arg0) {
-    return new GlideOptions().encodeFormat(arg0);
+  public static GlideOptions encodeFormatOf(@NonNull Bitmap.CompressFormat format) {
+    return new GlideOptions().encodeFormat(format);
   }
 
   /**
@@ -305,8 +305,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float arg0) {
-    return (GlideOptions) super.sizeMultiplier(arg0);
+  public final GlideOptions sizeMultiplier(@FloatRange(from = 0.0, to = 1.0) float value) {
+    return (GlideOptions) super.sizeMultiplier(value);
   }
 
   @Override
@@ -333,64 +333,64 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy arg0) {
-    return (GlideOptions) super.diskCacheStrategy(arg0);
+  public final GlideOptions diskCacheStrategy(@NonNull DiskCacheStrategy strategy) {
+    return (GlideOptions) super.diskCacheStrategy(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions priority(@NonNull Priority arg0) {
-    return (GlideOptions) super.priority(arg0);
+  public final GlideOptions priority(@NonNull Priority priority) {
+    return (GlideOptions) super.priority(priority);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@Nullable Drawable arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@Nullable Drawable drawable) {
+    return (GlideOptions) super.placeholder(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions placeholder(@DrawableRes int arg0) {
-    return (GlideOptions) super.placeholder(arg0);
+  public final GlideOptions placeholder(@DrawableRes int id) {
+    return (GlideOptions) super.placeholder(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@Nullable Drawable arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@Nullable Drawable drawable) {
+    return (GlideOptions) super.fallback(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions fallback(@DrawableRes int arg0) {
-    return (GlideOptions) super.fallback(arg0);
+  public final GlideOptions fallback(@DrawableRes int id) {
+    return (GlideOptions) super.fallback(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@Nullable Drawable arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@Nullable Drawable drawable) {
+    return (GlideOptions) super.error(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions error(@DrawableRes int arg0) {
-    return (GlideOptions) super.error(arg0);
+  public final GlideOptions error(@DrawableRes int id) {
+    return (GlideOptions) super.error(id);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions theme(@Nullable Resources.Theme arg0) {
-    return (GlideOptions) super.theme(arg0);
+  public final GlideOptions theme(@Nullable Resources.Theme theme) {
+    return (GlideOptions) super.theme(theme);
   }
 
   @Override
@@ -417,8 +417,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions signature(@NonNull Key arg0) {
-    return (GlideOptions) super.signature(arg0);
+  public final GlideOptions signature(@NonNull Key key) {
+    return (GlideOptions) super.signature(key);
   }
 
   @Override
@@ -430,43 +430,43 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions set(@NonNull Option<T> arg0, @NonNull T arg1) {
-    return (GlideOptions) super.set(arg0, arg1);
+  public final <T> GlideOptions set(@NonNull Option<T> option, @NonNull T t) {
+    return (GlideOptions) super.set(option, t);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions decode(@NonNull Class<?> arg0) {
-    return (GlideOptions) super.decode(arg0);
+  public final GlideOptions decode(@NonNull Class<?> clazz) {
+    return (GlideOptions) super.decode(clazz);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat arg0) {
-    return (GlideOptions) super.encodeFormat(arg0);
+  public final GlideOptions encodeFormat(@NonNull Bitmap.CompressFormat format) {
+    return (GlideOptions) super.encodeFormat(format);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int arg0) {
-    return (GlideOptions) super.encodeQuality(arg0);
+  public final GlideOptions encodeQuality(@IntRange(from = 0, to = 100) int value) {
+    return (GlideOptions) super.encodeQuality(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions frame(@IntRange(from = 0) long arg0) {
-    return (GlideOptions) super.frame(arg0);
+  public final GlideOptions frame(@IntRange(from = 0) long value) {
+    return (GlideOptions) super.frame(value);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions format(@NonNull DecodeFormat arg0) {
-    return (GlideOptions) super.format(arg0);
+  public final GlideOptions format(@NonNull DecodeFormat format) {
+    return (GlideOptions) super.format(format);
   }
 
   @Override
@@ -479,15 +479,15 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions downsample(@NonNull DownsampleStrategy arg0) {
-    return (GlideOptions) super.downsample(arg0);
+  public final GlideOptions downsample(@NonNull DownsampleStrategy strategy) {
+    return (GlideOptions) super.downsample(strategy);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions timeout(@IntRange(from = 0) int arg0) {
-    return (GlideOptions) super.timeout(arg0);
+  public final GlideOptions timeout(@IntRange(from = 0) int value) {
+    return (GlideOptions) super.timeout(value);
   }
 
   @Override
@@ -549,8 +549,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions transform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.transform(arg0);
+  public final GlideOptions transform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.transform(transformation);
   }
 
   @Override
@@ -558,30 +558,31 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @SuppressWarnings("varargs")
   @NonNull
   @CheckResult
-  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... arg0) {
-    return (GlideOptions) super.transforms(arg0);
+  public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transforms(transformations);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> arg0) {
-    return (GlideOptions) super.optionalTransform(arg0);
+  public final GlideOptions optionalTransform(@NonNull Transformation<Bitmap> transformation) {
+    return (GlideOptions) super.optionalTransform(transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions optionalTransform(@NonNull Class<T> arg0,
-      @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.optionalTransform(arg0, arg1);
+  public final <T> GlideOptions optionalTransform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.optionalTransform(clazz, transformation);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public final <T> GlideOptions transform(@NonNull Class<T> arg0, @NonNull Transformation<T> arg1) {
-    return (GlideOptions) super.transform(arg0, arg1);
+  public final <T> GlideOptions transform(@NonNull Class<T> clazz,
+      @NonNull Transformation<T> transformation) {
+    return (GlideOptions) super.transform(clazz, transformation);
   }
 
   @Override
@@ -601,8 +602,8 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @NonNull
   @CheckResult
-  public final GlideOptions apply(@NonNull RequestOptions arg0) {
-    return (GlideOptions) super.apply(arg0);
+  public final GlideOptions apply(@NonNull RequestOptions options) {
+    return (GlideOptions) super.apply(options);
   }
 
   @Override

--- a/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithTypeTest/GlideRequests.java
+++ b/annotation/compiler/test/src/test/resources/LegacyGlideExtensionWithTypeTest/GlideRequests.java
@@ -5,8 +5,10 @@ import android.graphics.Bitmap;
 import android.graphics.drawable.Drawable;
 import android.net.Uri;
 import android.support.annotation.CheckResult;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -57,14 +59,14 @@ public class GlideRequests extends RequestManager {
 
   @Override
   @NonNull
-  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.applyDefaultRequestOptions(arg0);
+  public GlideRequests applyDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.applyDefaultRequestOptions(options);
   }
 
   @Override
   @NonNull
-  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions arg0) {
-    return (GlideRequests) super.setDefaultRequestOptions(arg0);
+  public GlideRequests setDefaultRequestOptions(@NonNull RequestOptions options) {
+    return (GlideRequests) super.setDefaultRequestOptions(options);
   }
 
   @Override
@@ -91,64 +93,64 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Bitmap arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Bitmap bitmap) {
+    return (GlideRequest<Drawable>) super.load(bitmap);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Drawable arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Drawable drawable) {
+    return (GlideRequest<Drawable>) super.load(drawable);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable String arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable String string) {
+    return (GlideRequest<Drawable>) super.load(string);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Uri arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Uri uri) {
+    return (GlideRequest<Drawable>) super.load(uri);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable File arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable File file) {
+    return (GlideRequest<Drawable>) super.load(file);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Integer arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@RawRes @DrawableRes @Nullable Integer id) {
+    return (GlideRequest<Drawable>) super.load(id);
   }
 
   @Override
   @Deprecated
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable URL arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable URL url) {
+    return (GlideRequest<Drawable>) super.load(url);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable byte[] arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable byte[] bytes) {
+    return (GlideRequest<Drawable>) super.load(bytes);
   }
 
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<Drawable> load(@Nullable Object arg0) {
-    return (GlideRequest<Drawable>) super.load(arg0);
+  public GlideRequest<Drawable> load(@Nullable Object o) {
+    return (GlideRequest<Drawable>) super.load(o);
   }
 
   @Override
@@ -161,8 +163,8 @@ public class GlideRequests extends RequestManager {
   @Override
   @NonNull
   @CheckResult
-  public GlideRequest<File> download(@Nullable Object arg0) {
-    return (GlideRequest<File>) super.download(arg0);
+  public GlideRequest<File> download(@Nullable Object o) {
+    return (GlideRequest<File>) super.download(o);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/RequestManager.java
+++ b/library/src/main/java/com/bumptech/glide/RequestManager.java
@@ -11,8 +11,10 @@ import android.net.Uri;
 import android.os.Handler;
 import android.os.Looper;
 import android.support.annotation.CheckResult;
+import android.support.annotation.DrawableRes;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
+import android.support.annotation.RawRes;
 import android.view.View;
 import com.bumptech.glide.load.engine.DiskCacheStrategy;
 import com.bumptech.glide.load.resource.gif.GifDrawable;
@@ -424,7 +426,7 @@ public class RequestManager implements LifecycleListener,
   @NonNull
   @CheckResult
   @Override
-  public RequestBuilder<Drawable> load(@Nullable Integer resourceId) {
+  public RequestBuilder<Drawable> load(@RawRes @DrawableRes @Nullable Integer resourceId) {
     return asDrawable().load(resourceId);
   }
 


### PR DESCRIPTION
The currently generated method parameters are meaningless `arg0`, `arg1` kind of stuff which makes for an unpleasant development experience. This PR makes the params as pretty as possible given the limitation that we don't know what the actual parameter names are.

Now I'm not gonna lie, the code to do this is kind of ugly, but I think the end result is well worth it.