### PR TITLE
Fix don't start preload on open RecyclerView (without user intract)

### DIFF
--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -33,7 +33,7 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
 
   private int lastEnd;
   private int lastStart;
-  private int lastFirstVisible;
+  private int lastFirstVisible = -1;
   private int totalItemCount;
 
   private boolean isIncreasing = true;


### PR DESCRIPTION
I see that ListPreloader don't start preload until the user don't start scroll. I think my commit fix it.