### PR TITLE
Add Android X support to the annotation processor.

### DIFF
--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/GlideGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/GlideGenerator.java
@@ -79,6 +79,9 @@ final class GlideGenerator {
   private static final String VISIBLE_FOR_TESTING_QUALIFIED_NAME =
       "android.support.annotation.VisibleForTesting";
 
+  private static final String VISIBLE_FOR_TESTING_QUALIFIED_NAME_ANDROIDX =
+      "androidx.annotation.VisibleForTesting";
+
   private static final String SUPPRESS_LINT_PACKAGE_NAME =
       "android.annotation";
   private static final String SUPPRESS_LINT_CLASS_NAME =
@@ -174,11 +177,14 @@ final class GlideGenerator {
   }
 
   private Builder addReturnAnnotations(Builder builder, ExecutableElement methodToOverride) {
-    String visibleForTestingTypeQualifiedName =
-        processingEnv
-            .getElementUtils()
-            .getTypeElement(VISIBLE_FOR_TESTING_QUALIFIED_NAME)
-            .toString();
+    Elements elements = processingEnv.getElementUtils();
+    TypeElement visibleForTestingTypeElement = elements
+        .getTypeElement(VISIBLE_FOR_TESTING_QUALIFIED_NAME_ANDROIDX);
+    if (visibleForTestingTypeElement == null) {
+      // Fall back to looking for the Support library version.
+      visibleForTestingTypeElement = elements.getTypeElement(VISIBLE_FOR_TESTING_QUALIFIED_NAME);
+    }
+    String visibleForTestingTypeQualifiedName = visibleForTestingTypeElement.toString();
 
     for (AnnotationMirror mirror : methodToOverride.getAnnotationMirrors()) {
       builder.addAnnotation(AnnotationSpec.get(mirror));

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/ProcessorUtil.java
@@ -68,6 +68,12 @@ final class ProcessorUtil {
       ClassName.get("android.support.annotation", "NonNull");
   private static final ClassName JETBRAINS_NOTNULL_ANNOTATION =
       ClassName.get("org.jetbrains.annotations", "NotNull");
+  private static final ClassName ANDROIDX_NONNULL_ANNOTATION =
+      ClassName.get("androidx.annotation", "NonNull");
+  private static final ClassName CHECK_RESULT_ANNOTATION =
+      ClassName.get("android.support.annotation", "CheckResult");
+  private static final ClassName ANDROIDX_CHECK_RESULT_ANNOTATION =
+      ClassName.get("androidx.annotation", "CheckResult");
 
   private final ProcessingEnvironment processingEnv;
   private final TypeElement appGlideModuleType;
@@ -439,11 +445,26 @@ final class ProcessorUtil {
   }
 
   static ClassName nonNull() {
-    return NONNULL_ANNOTATION;
+    try {
+      Class.forName(ANDROIDX_NONNULL_ANNOTATION.reflectionName());
+      return ANDROIDX_NONNULL_ANNOTATION;
+    } catch (ClassNotFoundException e) {
+      return NONNULL_ANNOTATION;
+    }
+  }
+
+  static ClassName checkResult() {
+    try {
+      Class.forName(ANDROIDX_CHECK_RESULT_ANNOTATION.reflectionName());
+      return ANDROIDX_CHECK_RESULT_ANNOTATION;
+    } catch (ClassNotFoundException e) {
+      return CHECK_RESULT_ANNOTATION;
+    }
   }
 
   static List<ClassName> nonNulls() {
-    return Arrays.asList(NONNULL_ANNOTATION, JETBRAINS_NOTNULL_ANNOTATION);
+    return Arrays.asList(NONNULL_ANNOTATION, JETBRAINS_NOTNULL_ANNOTATION,
+        ANDROIDX_NONNULL_ANNOTATION);
   }
 
   List<ExecutableElement> findInstanceMethodsReturning(TypeElement clazz, TypeMirror returnType) {

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestBuilderGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestBuilderGenerator.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.annotation.compiler;
 
+import static com.bumptech.glide.annotation.compiler.ProcessorUtil.checkResult;
 import static com.bumptech.glide.annotation.compiler.ProcessorUtil.nonNull;
 
 import com.bumptech.glide.annotation.GlideExtension;
@@ -107,9 +108,8 @@ final class RequestBuilderGenerator {
   /** A set of method names to avoid overriding from RequestOptions. */
   private static final ImmutableSet<String> EXCLUDED_METHODS_FROM_BASE_REQUEST_OPTIONS =
       ImmutableSet.of("clone", "apply", "autoLock", "lock", "autoClone");
-  private static final ClassName CHECK_RESULT_CLASS_NAME =
-      ClassName.get("android.support.annotation", "CheckResult");
   private static final AnnotationSpec NON_NULL = AnnotationSpec.builder(nonNull()).build();
+  private static final AnnotationSpec CHECK_RESULT = AnnotationSpec.builder(checkResult()).build();
 
   private final ProcessingEnvironment processingEnv;
   private final ProcessorUtil processorUtil;
@@ -448,7 +448,7 @@ final class RequestBuilderGenerator {
         = ParameterizedTypeName.get(generatedRequestBuilderClassName, ClassName.get(File.class));
     return MethodSpec.methodBuilder("getDownloadOnlyRequest")
         .addAnnotation(Override.class)
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(CHECK_RESULT)
         .addAnnotation(NON_NULL)
         .returns(generatedRequestBuilderOfFile)
         .addModifiers(Modifier.PROTECTED)

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestManagerGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestManagerGenerator.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.annotation.compiler;
 
+import static com.bumptech.glide.annotation.compiler.ProcessorUtil.checkResult;
 import static com.bumptech.glide.annotation.compiler.ProcessorUtil.nonNull;
 
 import com.bumptech.glide.annotation.GlideExtension;
@@ -61,8 +62,6 @@ final class RequestManagerGenerator {
       "com.bumptech.glide.manager.Lifecycle";
   private static final String REQUEST_MANAGER_TREE_NODE_QUALIFIED_NAME =
       "com.bumptech.glide.manager.RequestManagerTreeNode";
-  private static final ClassName CHECK_RESULT_CLASS_NAME =
-      ClassName.get("android.support.annotation", "CheckResult");
   private static final ClassName CONTEXT_CLASS_NAME =
       ClassName.get("android.content", "Context");
 
@@ -164,7 +163,7 @@ final class RequestManagerGenerator {
     return MethodSpec.methodBuilder("as")
         .addModifiers(Modifier.PUBLIC)
         .addAnnotation(Override.class)
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addAnnotation(nonNull())
         .addTypeVariable(TypeVariableName.get("ResourceType"))
         .returns(requestBuilderOfResourceType)
@@ -289,7 +288,7 @@ final class RequestManagerGenerator {
         .returns(parameterizedTypeName)
         .addJavadoc(processorUtil.generateSeeMethodJavadoc(extensionMethod))
         .addAnnotation(nonNull())
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addStatement(
             "$T requestBuilder = this.as($T.class)", parameterizedTypeName, returnTypeClassName)
         .addStatement("$T.$N(requestBuilder)",
@@ -311,7 +310,7 @@ final class RequestManagerGenerator {
         .returns(parameterizedTypeName)
         .addJavadoc(processorUtil.generateSeeMethodJavadoc(extensionMethod))
         .addAnnotation(nonNull())
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addStatement(
             "return ($T) $T.$N(this.as($T.class))",
             parameterizedTypeName,

--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsGenerator.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.annotation.compiler;
 
 import static com.bumptech.glide.annotation.GlideOption.OVERRIDE_EXTEND;
+import static com.bumptech.glide.annotation.compiler.ProcessorUtil.checkResult;
 import static com.bumptech.glide.annotation.compiler.ProcessorUtil.nonNull;
 
 import com.bumptech.glide.annotation.GlideExtension;
@@ -76,8 +77,6 @@ final class RequestOptionsGenerator {
   private static final String REQUEST_OPTIONS_SIMPLE_NAME = "RequestOptions";
   static final String REQUEST_OPTIONS_QUALIFIED_NAME =
       REQUEST_OPTIONS_PACKAGE_NAME + "." + REQUEST_OPTIONS_SIMPLE_NAME;
-  private static final ClassName CHECK_RESULT_CLASS_NAME =
-      ClassName.get("android.support.annotation", "CheckResult");
 
   private final ProcessingEnvironment processingEnvironment;
   private final ClassName requestOptionsName;
@@ -301,7 +300,7 @@ final class RequestOptionsGenerator {
     builder.addStatement(code.toString(), args.toArray(new Object[0]));
 
     builder
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addAnnotation(nonNull());
 
     List<MethodAndStaticVar> result = new ArrayList<>();
@@ -375,7 +374,7 @@ final class RequestOptionsGenerator {
     builder.addStatement(code.toString(), args.toArray(new Object[0]));
 
     builder.addStatement("return this")
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addAnnotation(nonNull());
 
     List<MethodAndStaticVar> result = new ArrayList<>();
@@ -483,7 +482,7 @@ final class RequestOptionsGenerator {
     }
 
     methodSpecBuilder
-        .addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build())
+        .addAnnotation(checkResult())
         .addAnnotation(nonNull());
 
     return new MethodAndStaticVar(methodSpecBuilder.build(), requiredStaticField);
@@ -569,7 +568,7 @@ final class RequestOptionsGenerator {
           TypeVariableName.get(typeParameterElement.getSimpleName().toString()));
     }
 
-    methodSpecBuilder.addAnnotation(AnnotationSpec.builder(CHECK_RESULT_CLASS_NAME).build());
+    methodSpecBuilder.addAnnotation(checkResult());
 
     return new MethodAndStaticVar(methodSpecBuilder.build(), requiredStaticField);
   }


### PR DESCRIPTION
## Description
Add support for generating code with the Android X annotations, if they are present in the classpath. If they aren't available, use the default Support library annotations.

## Motivation and Context
Currently, Glide cannot be used with Android X enabled. This fixes #3126.