### PR TITLE
Support loading resources from dynamic modules

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/ResourceDrawableDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/ResourceDrawableDecoder.java
@@ -47,7 +47,7 @@ public class ResourceDrawableDecoder implements ResourceDecoder<Uri, Drawable> {
       @NonNull Options options) {
     @DrawableRes int resId = loadResourceIdFromUri(source);
     String packageName = source.getAuthority();
-    Context targetContext = packageName.equals(context.getPackageName())
+    Context targetContext = packageName.contains(context.getPackageName())
         ? context : getContextForPackage(source, packageName);
     // We can't get a theme from another application.
     Drawable drawable = DrawableDecoderCompat.getDrawable(context, targetContext, resId);

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/ResourceDrawableDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/ResourceDrawableDecoder.java
@@ -47,14 +47,14 @@ public class ResourceDrawableDecoder implements ResourceDecoder<Uri, Drawable> {
       @NonNull Options options) {
     @DrawableRes int resId = loadResourceIdFromUri(source);
     String packageName = source.getAuthority();
-    Context targetContext = getContextForPackage(source, packageName);
+    Context targetContext = findContextForPackage(source, packageName);
     // We can't get a theme from another application.
     Drawable drawable = DrawableDecoderCompat.getDrawable(context, targetContext, resId);
     return NonOwnedDrawableResource.newInstance(drawable);
   }
 
   @NonNull
-  private Context getContextForPackage(Uri source, String packageName) {
+  private Context findContextForPackage(Uri source, String packageName) {
     // Fast path
     if (packageName.equals(context.getPackageName())) {
       return context;


### PR DESCRIPTION
### Background

Dynamic modules use split APKs to distribute resources with the module instead of the base APK. This means that, for example, the runtime package may be `com.supercilex.robotscouter` while the resource is located in `com.supercilex.robotscouter.teams`.

These differences cause problems when Glide tries to load the resource because Glide will try to create a context from the `com.supercilex.robotscouter.teams` package which doesn't really exist.

### Proposal

If resources are a subset of the context's package, use said context. Otherwise, try to create a new context.

@sjudd Can you think of a better solution? This is the best one I've come up with so far, but it seems hacky.