### PR TITLE
fix: replace "GlideApp" with "Glide"

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ Simple use cases with Glide's [generated API][21] will look something like this:
   ...
   ImageView imageView = (ImageView) findViewById(R.id.my_image_view);
 
-  GlideApp.with(this).load("http://goo.gl/gEgYUd").into(imageView);
+  Glide.with(this).load("http://goo.gl/gEgYUd").into(imageView);
 }
 
 // For a simple image list:
@@ -98,7 +98,7 @@ Simple use cases with Glide's [generated API][21] will look something like this:
 
   String url = myUrls.get(position);
 
-  GlideApp
+  Glide
     .with(myFragment)
     .load(url)
     .centerCrop()


### PR DESCRIPTION
## Description

This tiny PR fixes the readme example of using Glide. It looks like previous versions used the "GlideApp" instance, whereby the current version uses "Glide" and works fine on my end. 