### PR TITLE
Updated BaseRequestOptions.transform api (update for issue #2875)

### DIFF
--- a/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsOverrideGenerator.java
+++ b/annotation/compiler/src/main/java/com/bumptech/glide/annotation/compiler/RequestOptionsOverrideGenerator.java
@@ -86,7 +86,8 @@ final class RequestOptionsOverrideGenerator {
             .add(");\n")
             .build());
 
-    if (methodToOverride.getSimpleName().toString().equals("transforms")) {
+    if (methodToOverride.getSimpleName().toString().contains("transform")
+        && methodToOverride.isVarArgs()) {
       result
           .addModifiers(Modifier.FINAL)
           .addAnnotation(SafeVarargs.class)

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -556,6 +557,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/EmptyAppGlideModuleTest/GlideRequest.java
@@ -385,8 +385,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -559,6 +560,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/MemoizeStaticMethod/GlideRequest.java
@@ -385,8 +385,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -550,6 +551,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtend/GlideRequest.java
@@ -376,8 +376,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -540,6 +541,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideExtendMultipleArguments/GlideRequest.java
@@ -376,8 +376,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -550,6 +551,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/OverrideReplace/GlideRequest.java
@@ -376,8 +376,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -557,6 +558,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/SkipStaticMethod/GlideRequest.java
@@ -385,8 +385,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -557,6 +558,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionOptionsTest/StaticMethodName/GlideRequest.java
@@ -385,8 +385,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -557,6 +558,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithOptionTest/GlideRequest.java
@@ -385,8 +385,22 @@ public class GlideRequest<TranscodeType> extends RequestBuilder<TranscodeType> i
   }
 
   /**
+   * @see GlideOptions#transform(Transformation<Bitmap>[])
+   */
+  @NonNull
+  @CheckResult
+  @SuppressWarnings({
+      "unchecked",
+      "varargs"
+  })
+  public GlideRequest<TranscodeType> transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideRequest<TranscodeType>) super.transform(transformations);
+  }
+
+  /**
    * @see GlideOptions#transforms(Transformation<Bitmap>[])
    */
+  @Deprecated
   @NonNull
   @CheckResult
   @SuppressWarnings({

--- a/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideOptions.java
+++ b/annotation/compiler/test/src/test/resources/GlideExtensionWithTypeTest/GlideOptions.java
@@ -20,6 +20,7 @@ import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.RequestOptions;
 import java.lang.Class;
 import java.lang.Cloneable;
+import java.lang.Deprecated;
 import java.lang.Override;
 import java.lang.SafeVarargs;
 import java.lang.SuppressWarnings;
@@ -557,6 +558,16 @@ public final class GlideOptions extends RequestOptions implements Cloneable {
   @Override
   @SafeVarargs
   @SuppressWarnings("varargs")
+  @NonNull
+  @CheckResult
+  public final GlideOptions transform(@NonNull Transformation<Bitmap>... transformations) {
+    return (GlideOptions) super.transform(transformations);
+  }
+
+  @Override
+  @SafeVarargs
+  @SuppressWarnings("varargs")
+  @Deprecated
   @NonNull
   @CheckResult
   public final GlideOptions transforms(@NonNull Transformation<Bitmap>... transformations) {

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -464,7 +464,7 @@ public final class TransformationUtils {
    *
    * <p>This method does <em>NOT</em> resize the given {@link Bitmap}, it only rounds it's corners.
    * To both resize and round the corners of an image, consider
-   * {@link com.bumptech.glide.request.RequestOptions#transforms(Transformation[])} and/or
+   * {@link com.bumptech.glide.request.RequestOptions#transform(Transformation[])} and/or
    * {@link com.bumptech.glide.load.MultiTransformation}.
    *
    * @param inBitmap the source bitmap to use as a basis for the created bitmap.

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -929,6 +929,36 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
   @SuppressWarnings({"unchecked", "varargs", "CheckResult"})
   @NonNull
   @CheckResult
+  public T transform(@NonNull Transformation<Bitmap>... transformations) {
+    if (transformations.length > 1) {
+      return transform(new MultiTransformation<>(transformations), /*isRequired=*/ true);
+    } else if (transformations.length == 1) {
+      return transform(transformations[0]);
+    } else {
+      return selfOrThrowIfLocked();
+    }
+  }
+
+  /**
+   * Applies the given {@link Transformation}s in the given order for
+   * {@link Bitmap Bitmaps} to the default types ({@link Bitmap},
+   * {@link android.graphics.drawable.BitmapDrawable}, and
+   * {@link com.bumptech.glide.load.resource.gif.GifDrawable})
+   * and throws an exception if asked to transform an unknown type.
+   *
+   * <p>This will override previous calls to {@link #dontTransform()}.
+   *
+   *
+   * @deprecated Deprecated due to api update, use {@link #transform(Transformation[])} instead
+   * @param transformations One or more {@link Transformation}s for {@link Bitmap}s.
+   * @see #optionalTransform(Transformation)
+   * @see #optionalTransform(Class, Transformation)
+   */
+  // Guaranteed to modify the current object by the isAutoCloneEnabledCheck.
+  @SuppressWarnings({"unchecked", "varargs", "CheckResult"})
+  @NonNull
+  @CheckResult
+  @Deprecated
   public T transforms(@NonNull Transformation<Bitmap>... transformations) {
     return transform(new MultiTransformation<>(transformations), /*isRequired=*/ true);
   }

--- a/library/test/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
@@ -255,7 +255,7 @@ public class RequestOptionsTest {
   @Test
   @SuppressWarnings({"unchecked", "varargs"})
   public void testApplyMultiTransform() {
-    options.transforms(new CircleCrop(), new CenterCrop());
+    options.transform(new CircleCrop(), new CenterCrop());
     assertThat(options.isTransformationRequired()).isTrue();
     assertThat(options.getTransformations()).containsKey(Bitmap.class);
     assertThat(options.getTransformations().get(Bitmap.class))


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Added varargs overload method for BaseRequestOptions.transform.
Deprecated BaseRequestOptions.transforms

## Motivation and Context
This is fix for issue #2875, where user requested a little simplification to api.


<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

While building locally, I kept failing build because of lint check in volley. It insists on having volley latest version (1.1.0, while there is 1.0.0 in project), so I am not sure if CI will be successfull too.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->