### PR TITLE
Make ProGuard rules consumable

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -37,6 +37,7 @@ android {
         minSdkVersion MIN_SDK_VERSION as int
         targetSdkVersion TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
+        consumerProguardFiles 'proguard-rules.txt'
     }
 
     compileOptions {


### PR DESCRIPTION
Make `proguard-rules.txt` consumable so you do not need to add the Proguard rules manually.
With `consumerProguardFiles` the rules will be merged automatically.