### PR TITLE
solved the problem of file descriptor leaked

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/model/StreamEncoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/StreamEncoder.java
@@ -43,6 +43,7 @@ public class StreamEncoder implements Encoder<InputStream> {
     } finally {
       if (os != null) {
         try {
+          data.close();
           os.close();
         } catch (IOException e) {
           // Do nothing.


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
cause this problem at our app.
       // Short Msg: java.lang.RuntimeException
// Long Msg: java.lang.RuntimeException: Could not read input channel file descriptors from parcel.
// Build Time: 1480739752000
// java.lang.RuntimeException: Could not read input channel file descriptors from parcel.
// 	at android.view.InputChannel.nativeReadFromParcel(Native Method)
// 	at android.view.InputChannel.readFromParcel(InputChannel.java:148)
// 	at android.view.InputChannel$1.createFromParcel(InputChannel.java:39)
// 	at android.view.InputChannel$1.createFromParcel(InputChannel.java:36)
// 	at com.android.internal.view.InputBindResult.<init>(InputBindResult.java:68)
// 	at com.android.internal.view.InputBindResult$1.createFromParcel(InputBindResult.java:112)
// 	at com.android.internal.view.InputBindResult$1.createFromParcel(InputBindResult.java:109)
// 	at com.android.internal.view.IInputMethodManager$Stub$Proxy.startInput(IInputMethodManager.java:631)
// 	at android.view.inputmethod.InputMethodManager.startInputInner(InputMethodManager.java:1326)
// 	at android.view.inputmethod.InputMethodManager.checkFocus(InputMethodManager.java:1466)
// 	at android.view.ViewRootImpl$ViewRootHandler.handleMessage(ViewRootImpl.java:3610)
// 	at android.os.Handler.dispatchMessage(Handler.java:102)
// 	at android.os.Looper.loop(Looper.java:179)
// 	at android.app.ActivityThread.main(ActivityThread.java:5672)
// 	at java.lang.reflect.Method.invoke(Native Method)
// 	at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run(ZygoteInit.java:786)
// 	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:676)
// 

<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->