### PR TITLE
Add Gif loop end listener

### DIFF
--- a/library/build.gradle
+++ b/library/build.gradle
@@ -13,6 +13,7 @@ dependencies {
     api project(':third_party:disklrucache')
     api project(':annotation')
     api "com.android.support:support-fragment:${ANDROID_SUPPORT_VERSION}"
+    api "com.android.support:animated-vector-drawable:${ANDROID_SUPPORT_VERSION}"
     compileOnly "com.android.support:appcompat-v7:${ANDROID_SUPPORT_VERSION}"
 
     if (project.plugins.hasPlugin('net.ltgt.errorprone')) {

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -14,6 +14,7 @@ import android.graphics.drawable.Animatable;
 import android.graphics.drawable.Drawable;
 import android.support.annotation.NonNull;
 import android.support.annotation.VisibleForTesting;
+import android.support.graphics.drawable.Animatable2Compat;
 import android.view.Gravity;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.gifdecoder.GifDecoder;
@@ -21,12 +22,14 @@ import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.util.Preconditions;
 import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
 
 /**
  * An animated {@link android.graphics.drawable.Drawable} that plays the frames of an animated GIF.
  */
 public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallback,
-    Animatable {
+    Animatable, Animatable2Compat {
   /**
    * A constant indicating that an animated drawable should loop continuously.
    */
@@ -75,6 +78,11 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
   private boolean applyGravity;
   private Paint paint;
   private Rect destRect;
+
+  /**
+   * Callbacks to notify loop completion of a gif, where the loop count is explicitly specified.
+   */
+  private List<AnimationCallback> animationCallbacks;
 
   /**
    * Constructor for GifDrawable.
@@ -351,7 +359,16 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
     }
 
     if (maxLoopCount != LOOP_FOREVER && loopCount >= maxLoopCount) {
+      notifyAnimationEndToListeners();
       stop();
+    }
+  }
+
+  private void notifyAnimationEndToListeners() {
+    if (animationCallbacks != null) {
+      for (int i = 0, size = animationCallbacks.size(); i < size; i++) {
+        animationCallbacks.get(i).onAnimationEnd(this);
+      }
     }
   }
 
@@ -387,6 +404,42 @@ public class GifDrawable extends Drawable implements GifFrameLoader.FrameCallbac
           (intrinsicCount == TOTAL_ITERATION_COUNT_FOREVER) ? LOOP_FOREVER : intrinsicCount;
     } else {
       maxLoopCount = loopCount;
+    }
+  }
+
+  /**
+   * Register callback to listen to GifDrawable animation end event after specific loop count
+   * set by {@link GifDrawable#setLoopCount(int)}.
+   *
+   * Note: This will only be called if the Gif stop because it reaches the loop count. Unregister
+   * this in onLoadCleared to avoid potential memory leak.
+   * @see GifDrawable#unregisterAnimationCallback(AnimationCallback).
+   *
+   * @param animationCallback Animation callback {@link Animatable2Compat.AnimationCallback}.
+   */
+  @Override
+  public void registerAnimationCallback(@NonNull AnimationCallback animationCallback) {
+    if (animationCallback == null) {
+      return;
+    }
+    if (animationCallbacks == null) {
+      animationCallbacks = new ArrayList<>();
+    }
+    animationCallbacks.add(animationCallback);
+  }
+
+  @Override
+  public boolean unregisterAnimationCallback(@NonNull AnimationCallback animationCallback) {
+    if (animationCallbacks == null || animationCallback == null) {
+      return false;
+    }
+    return animationCallbacks.remove(animationCallback);
+  }
+
+  @Override
+  public void clearAnimationCallbacks() {
+    if (animationCallbacks != null) {
+      animationCallbacks.clear();
     }
   }
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
This PR adds a listener to the `GifDrawable` to listen to gif loop end, when it's explicitly specified by the user.

Possibly solves #1872 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
I worked on a feature for showing and stopping a gif after certain loop count. The spec was,
* Show Gif in a RecyclerView
* Render it as a static picture (first frame of the Gif), but with an UI indicator that the picture is a gif
* When the user taps on the gif, hide the UI indicator and start playing it
* After 3 times of looping, stop the Gif and show the UI indicator again on top of the static first frame again.

To implement the above spec, (showing and hiding some UI stuff based on the Gif start/stop) I need to know when the Gif finishes looping 3 times. As glide doesn't expose decoder from GifDrawable and we cannot use anything other than GifDrawable in Request listener for gifs, I had to add a callback that can notify client when certain amount of looping finishes. This solution solves my issue and I wanted to share it with the community.
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->

Please, let me know if it can be done in better way or any more work I need to do.