### PR TITLE
Add nullability annotations to LazyHeaders.Builder functions

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/LazyHeaders.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.load.model;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import java.util.ArrayList;
@@ -132,7 +133,7 @@ public final class LazyHeaders implements Headers {
      *
      * @see #addHeader(String, LazyHeaderFactory)
      */
-    public Builder addHeader(String key, String value) {
+    public Builder addHeader(@NonNull String key, @NonNull String value) {
       return addHeader(key, new StringHeaderFactory(value));
     }
 
@@ -146,7 +147,7 @@ public final class LazyHeaders implements Headers {
      * <p> This class does not prevent you from adding the same value to a given key multiple
      * times </p>
      */
-    public Builder addHeader(String key, LazyHeaderFactory factory) {
+    public Builder addHeader(@NonNull String key, @NonNull LazyHeaderFactory factory) {
       if (isUserAgentDefault && USER_AGENT_HEADER.equalsIgnoreCase(key)) {
         return setHeader(key, factory);
       }
@@ -166,7 +167,7 @@ public final class LazyHeaders implements Headers {
      * (i.e. an OAuth token). </p>
      */
     @SuppressWarnings({"UnusedReturnValue", "WeakerAccess"}) // Public API
-    public Builder setHeader(String key, String value) {
+    public Builder setHeader(@NonNull String key, @Nullable String value) {
       return setHeader(key, value == null ? null : new StringHeaderFactory(value));
     }
 
@@ -176,7 +177,7 @@ public final class LazyHeaders implements Headers {
      *
      * <p> If the given value is {@code null}, the header at the given key will be removed. </p>
      */
-    public Builder setHeader(String key, LazyHeaderFactory factory) {
+    public Builder setHeader(@NonNull String key, @Nullable LazyHeaderFactory factory) {
       copyIfNecessary();
       if (factory == null) {
         headers.remove(key);
@@ -255,9 +256,10 @@ public final class LazyHeaders implements Headers {
 
   static final class StringHeaderFactory implements LazyHeaderFactory {
 
+    @NonNull
     private final String value;
 
-    StringHeaderFactory(String value) {
+    StringHeaderFactory(@NonNull String value) {
       this.value = value;
     }
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
Add `@NonNull` and `@Nullable` annotations to `LazyHeaders.Builder` and `StringHeaderFactory`. When there is a possibility of null, a warning is displayed on the IDE and bug entry can be prevented.
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
`StringHeaderFactory` doesn't allow null `value` and `LazyHeaders.Builder.addHeader(String key, String value)` also doesn't allow null `value`. However, the user can not know this spec unless they actually read the code.


<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->