### PR TITLE
Improve load RequestManager clear performance

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/CustomViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/CustomViewTarget.java
@@ -21,7 +21,9 @@ import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.Synthetic;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 /**
  * A base {@link Target} for loading resources ({@link android.graphics.Bitmap}, {@link Drawable}
@@ -300,7 +302,8 @@ public abstract class CustomViewTarget<T extends View, Z> implements Target<Z> {
     @Nullable
     static Integer maxDisplayLength;
     private final View view;
-    private final List<SizeReadyCallback> cbs = new ArrayList<>();
+    private final Set<SizeReadyCallback> cbs =
+        Collections.newSetFromMap(new IdentityHashMap<SizeReadyCallback, Boolean>());
     @Synthetic boolean waitForLayout;
 
     @Nullable private SizeDeterminerLayoutListener layoutListener;

--- a/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/ViewTarget.java
@@ -19,7 +19,9 @@ import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.Synthetic;
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
+import java.util.IdentityHashMap;
+import java.util.Set;
 
 /**
  * A base {@link Target} for loading {@link android.graphics.Bitmap}s into {@link View}s that
@@ -334,7 +336,8 @@ public abstract class ViewTarget<T extends View, Z> extends BaseTarget<Z> {
     @Nullable
     static Integer maxDisplayLength;
     private final View view;
-    private final List<SizeReadyCallback> cbs = new ArrayList<>();
+    private final Set<SizeReadyCallback> cbs =
+        Collections.newSetFromMap(new IdentityHashMap<SizeReadyCallback, Boolean>());
     @Synthetic boolean waitForLayout;
 
     @Nullable private SizeDeterminerLayoutListener layoutListener;


### PR DESCRIPTION
This PR is mostly just a hunch. 😕 Basically, I noticed that way too much time is spent removing items in my flame chart. My guess is that using a hashmap will yield better performance but I'm not sure how to benchmark this.

![image](https://user-images.githubusercontent.com/9490724/50552126-86791300-0c41-11e9-83e9-782fd4296de2.png)
