### PR TITLE
replace 'GlideExecutor' to 'ExecutorService'

### DIFF
--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
 
 /**
  * A builder class for setting default structural classes for Glide to use.
@@ -42,8 +43,8 @@ public final class GlideBuilder {
   private BitmapPool bitmapPool;
   private ArrayPool arrayPool;
   private MemoryCache memoryCache;
-  private GlideExecutor sourceExecutor;
-  private GlideExecutor diskCacheExecutor;
+  private ExecutorService sourceExecutor;
+  private ExecutorService diskCacheExecutor;
   private DiskCache.Factory diskCacheFactory;
   private MemorySizeCalculator memorySizeCalculator;
   private ConnectivityMonitorFactory connectivityMonitorFactory;
@@ -51,7 +52,7 @@ public final class GlideBuilder {
   private RequestOptions defaultRequestOptions = new RequestOptions();
   @Nullable
   private RequestManagerFactory requestManagerFactory;
-  private GlideExecutor animationExecutor;
+  private ExecutorService animationExecutor;
   private boolean isActiveResourceRetentionAllowed;
   @Nullable
   private List<RequestListener<Object>> defaultRequestListeners;
@@ -115,7 +116,7 @@ public final class GlideBuilder {
   }
 
   /**
-   * Sets the {@link GlideExecutor} to use when retrieving
+   * Sets the {@link ExecutorService} to use when retrieving
    * {@link com.bumptech.glide.load.engine.Resource}s that are not already in the cache.
    *
    * <p>The thread count defaults to the number of cores available on the device, with a maximum of
@@ -126,18 +127,16 @@ public final class GlideBuilder {
    *
    * @param service The ExecutorService to use.
    * @return This builder.
-   * @see #setDiskCacheExecutor(GlideExecutor)
-   * @see GlideExecutor
-   *
-   * @deprecated Use {@link #setSourceExecutor(GlideExecutor)}
+   * @see #setDiskCacheExecutor(ExecutorService)
+   * @deprecated Use {@link #setSourceExecutor(ExecutorService)}
    */
   @Deprecated
-  public GlideBuilder setResizeExecutor(@Nullable GlideExecutor service) {
+  public GlideBuilder setResizeExecutor(@Nullable ExecutorService service) {
     return setSourceExecutor(service);
   }
 
   /**
-   * Sets the {@link GlideExecutor} to use when retrieving
+   * Sets the {@link ExecutorService} to use when retrieving
    * {@link com.bumptech.glide.load.engine.Resource}s that are not already in the cache.
    *
    * <p>The thread count defaults to the number of cores available on the device, with a maximum of
@@ -148,19 +147,18 @@ public final class GlideBuilder {
    *
    * @param service The ExecutorService to use.
    * @return This builder.
-   * @see #setDiskCacheExecutor(GlideExecutor)
-   * @see GlideExecutor
+   * @see #setDiskCacheExecutor(ExecutorService)
    */
   // Public API.
   @SuppressWarnings("WeakerAccess")
   @NonNull
-  public GlideBuilder setSourceExecutor(@Nullable GlideExecutor service) {
+  public GlideBuilder setSourceExecutor(@Nullable ExecutorService service) {
     this.sourceExecutor = service;
     return this;
   }
 
   /**
-   * Sets the {@link GlideExecutor} to use when retrieving
+   * Sets the {@link ExecutorService} to use when retrieving
    * {@link com.bumptech.glide.load.engine.Resource}s that are currently in Glide's disk caches.
    *
    * <p>Defaults to a single thread which is usually the best combination of memory usage,
@@ -169,15 +167,14 @@ public final class GlideBuilder {
    * <p>Use the {@link GlideExecutor#newDiskCacheExecutor()} if you'd like to specify options
    * for the disk cache executor.
    *
-   * @param service The {@link GlideExecutor} to use.
+   * @param service The ExecutorService to use.
    * @return This builder.
-   * @see #setSourceExecutor(GlideExecutor)
-   * @see GlideExecutor
+   * @see #setSourceExecutor(ExecutorService)
    */
   // Public API.
   @SuppressWarnings("WeakerAccess")
   @NonNull
-  public GlideBuilder setDiskCacheExecutor(@Nullable GlideExecutor service) {
+  public GlideBuilder setDiskCacheExecutor(@Nullable ExecutorService service) {
     this.diskCacheExecutor = service;
     return this;
   }
@@ -191,13 +188,13 @@ public final class GlideBuilder {
    * <p>Use the {@link GlideExecutor#newAnimationExecutor()} methods  if you'd like to specify
    * options for the animation executor.
    *
-   * @param service The {@link GlideExecutor} to use.
+   * @param service The ExecutorService to use.
    * @return This builder.
    */
   // Public API.
   @SuppressWarnings("WeakerAccess")
   @NonNull
-  public GlideBuilder setAnimationExecutor(@Nullable GlideExecutor service) {
+  public GlideBuilder setAnimationExecutor(@Nullable ExecutorService service) {
     this.animationExecutor = service;
     return this;
   }
@@ -247,10 +244,9 @@ public final class GlideBuilder {
    * Sets the {@link MemorySizeCalculator} to use to calculate maximum sizes for default
    * {@link MemoryCache MemoryCaches} and/or default {@link BitmapPool BitmapPools}.
    *
-   * @see #setMemorySizeCalculator(MemorySizeCalculator)
-   *
    * @param builder The builder to use (will not be modified).
    * @return This builder.
+   * @see #setMemorySizeCalculator(MemorySizeCalculator)
    */
   // Public API.
   @SuppressWarnings("unused")

--- a/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
@@ -14,7 +14,6 @@ import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.cache.DiskCache;
 import com.bumptech.glide.load.engine.cache.DiskCacheAdapter;
 import com.bumptech.glide.load.engine.cache.MemoryCache;
-import com.bumptech.glide.load.engine.executor.GlideExecutor;
 import com.bumptech.glide.request.ResourceCallback;
 import com.bumptech.glide.util.Executors;
 import com.bumptech.glide.util.LogTime;
@@ -23,6 +22,7 @@ import com.bumptech.glide.util.Synthetic;
 import com.bumptech.glide.util.pool.FactoryPools;
 import java.util.Map;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 
 /**
  * Responsible for starting loads and managing active and cached resources.
@@ -45,10 +45,10 @@ public class Engine implements EngineJobListener,
   public Engine(
       MemoryCache memoryCache,
       DiskCache.Factory diskCacheFactory,
-      GlideExecutor diskCacheExecutor,
-      GlideExecutor sourceExecutor,
-      GlideExecutor sourceUnlimitedExecutor,
-      GlideExecutor animationExecutor,
+      ExecutorService diskCacheExecutor,
+      ExecutorService sourceExecutor,
+      ExecutorService sourceUnlimitedExecutor,
+      ExecutorService animationExecutor,
       boolean isActiveResourceRetentionAllowed) {
     this(
         memoryCache,
@@ -69,10 +69,10 @@ public class Engine implements EngineJobListener,
   @VisibleForTesting
   Engine(MemoryCache cache,
       DiskCache.Factory diskCacheFactory,
-      GlideExecutor diskCacheExecutor,
-      GlideExecutor sourceExecutor,
-      GlideExecutor sourceUnlimitedExecutor,
-      GlideExecutor animationExecutor,
+      ExecutorService diskCacheExecutor,
+      ExecutorService sourceExecutor,
+      ExecutorService sourceUnlimitedExecutor,
+      ExecutorService animationExecutor,
       Jobs jobs,
       EngineKeyFactory keyFactory,
       ActiveResources activeResources,
@@ -452,10 +452,10 @@ public class Engine implements EngineJobListener,
 
   @VisibleForTesting
   static class EngineJobFactory {
-    @Synthetic final GlideExecutor diskCacheExecutor;
-    @Synthetic final GlideExecutor sourceExecutor;
-    @Synthetic final GlideExecutor sourceUnlimitedExecutor;
-    @Synthetic final GlideExecutor animationExecutor;
+    @Synthetic final ExecutorService diskCacheExecutor;
+    @Synthetic final ExecutorService sourceExecutor;
+    @Synthetic final ExecutorService sourceUnlimitedExecutor;
+    @Synthetic final ExecutorService animationExecutor;
     @Synthetic final EngineJobListener listener;
     @Synthetic final Pools.Pool<EngineJob<?>> pool =
         FactoryPools.threadSafe(
@@ -474,10 +474,10 @@ public class Engine implements EngineJobListener,
             });
 
     EngineJobFactory(
-        GlideExecutor diskCacheExecutor,
-        GlideExecutor sourceExecutor,
-        GlideExecutor sourceUnlimitedExecutor,
-        GlideExecutor animationExecutor,
+        ExecutorService diskCacheExecutor,
+        ExecutorService sourceExecutor,
+        ExecutorService sourceUnlimitedExecutor,
+        ExecutorService animationExecutor,
         EngineJobListener listener) {
       this.diskCacheExecutor = diskCacheExecutor;
       this.sourceExecutor = sourceExecutor;

--- a/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/EngineJob.java
@@ -5,7 +5,6 @@ import android.support.annotation.VisibleForTesting;
 import android.support.v4.util.Pools;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.Key;
-import com.bumptech.glide.load.engine.executor.GlideExecutor;
 import com.bumptech.glide.request.ResourceCallback;
 import com.bumptech.glide.util.Executors;
 import com.bumptech.glide.util.Preconditions;
@@ -16,6 +15,7 @@ import java.util.ArrayList;
 import java.util.Iterator;
 import java.util.List;
 import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 
 /**
@@ -34,10 +34,10 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
   private final Pools.Pool<EngineJob<?>> pool;
   private final EngineResourceFactory engineResourceFactory;
   private final EngineJobListener listener;
-  private final GlideExecutor diskCacheExecutor;
-  private final GlideExecutor sourceExecutor;
-  private final GlideExecutor sourceUnlimitedExecutor;
-  private final GlideExecutor animationExecutor;
+  private final ExecutorService diskCacheExecutor;
+  private final ExecutorService sourceExecutor;
+  private final ExecutorService sourceUnlimitedExecutor;
+  private final ExecutorService animationExecutor;
   private final AtomicInteger pendingCallbacks = new AtomicInteger();
 
   private Key key;
@@ -69,10 +69,10 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
   private volatile boolean isCancelled;
 
   EngineJob(
-      GlideExecutor diskCacheExecutor,
-      GlideExecutor sourceExecutor,
-      GlideExecutor sourceUnlimitedExecutor,
-      GlideExecutor animationExecutor,
+      ExecutorService diskCacheExecutor,
+      ExecutorService sourceExecutor,
+      ExecutorService sourceUnlimitedExecutor,
+      ExecutorService animationExecutor,
       EngineJobListener listener,
       Pools.Pool<EngineJob<?>> pool) {
     this(
@@ -87,10 +87,10 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
 
   @VisibleForTesting
   EngineJob(
-      GlideExecutor diskCacheExecutor,
-      GlideExecutor sourceExecutor,
-      GlideExecutor sourceUnlimitedExecutor,
-      GlideExecutor animationExecutor,
+      ExecutorService diskCacheExecutor,
+      ExecutorService sourceExecutor,
+      ExecutorService sourceUnlimitedExecutor,
+      ExecutorService animationExecutor,
       EngineJobListener listener,
       Pools.Pool<EngineJob<?>> pool,
       EngineResourceFactory engineResourceFactory) {
@@ -120,7 +120,7 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
 
   public synchronized void start(DecodeJob<R> decodeJob) {
     this.decodeJob = decodeJob;
-    GlideExecutor executor = decodeJob.willDecodeFromCache()
+    ExecutorService executor = decodeJob.willDecodeFromCache()
         ? diskCacheExecutor
         : getActiveSourceExecutor();
     executor.execute(decodeJob);
@@ -184,7 +184,7 @@ class EngineJob<R> implements DecodeJob.Callback<R>,
     return onlyRetrieveFromCache;
   }
 
-  private GlideExecutor getActiveSourceExecutor() {
+  private ExecutorService getActiveSourceExecutor() {
     return useUnlimitedSourceGeneratorPool
         ? sourceUnlimitedExecutor : (useAnimationPool ? animationExecutor : sourceExecutor);
   }


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
#3474 

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
In general, libraries should allow developers to customize `ExecutorService`, and [v3](https://github.com/bumptech/glide/blob/3.0/library/src/main/java/com/bumptech/glide/GlideBuilder.java#L29) does

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->