### PR TITLE
Add support for incremental annotation processing

### DIFF
--- a/annotation/compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
+++ b/annotation/compiler/src/main/resources/META-INF/gradle/incremental.annotation.processors
@@ -1,0 +1,1 @@
+com.bumptech.glide.annotation.compiler.GlideAnnotationProcessor,aggregating

--- a/annotation/src/main/java/com/bumptech/glide/annotation/GlideExtension.java
+++ b/annotation/src/main/java/com/bumptech/glide/annotation/GlideExtension.java
@@ -11,5 +11,5 @@ import java.lang.annotation.Target;
  * @see GlideOption
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface GlideExtension { }

--- a/annotation/src/main/java/com/bumptech/glide/annotation/GlideModule.java
+++ b/annotation/src/main/java/com/bumptech/glide/annotation/GlideModule.java
@@ -12,7 +12,7 @@ import java.lang.annotation.Target;
  * <p>Replaces <meta-data /> tags in AndroidManifest.xml.
  */
 @Target(ElementType.TYPE)
-@Retention(RetentionPolicy.SOURCE)
+@Retention(RetentionPolicy.CLASS)
 public @interface GlideModule {
   /**
    * Returns the name of the class that will be used as a replacement for


### PR DESCRIPTION
I've had to change the retention of `GlideModule` and `GlideExtension` to `CLASS` because [aggregating](https://docs.gradle.org/current/userguide/java_plugin.html#compilejava) annotation processors support only `CLASS` and `RUNTIME` retention.

Resolves #2983 
cc @stephanenicolas 