### PR TITLE
Implemented Disk LRU Cache with entity expiration capabilities

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/CacheDirectoryGetter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/CacheDirectoryGetter.java
@@ -1,0 +1,10 @@
+package com.bumptech.glide.load.engine.cache;
+
+import java.io.File;
+
+/**
+ * Interface called out of UI thread to get the cache folder.
+ */
+public interface CacheDirectoryGetter {
+  File getCacheDirectory();
+}

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheFactory.java
@@ -7,31 +7,34 @@ import java.io.File;
  * disk cache directory.
  *
  * <p>If you need to make I/O access before returning the cache directory use the {@link
- * DiskLruCacheFactory#DiskLruCacheFactory(CacheDirectoryGetter, long)} constructor variant.
+ * ExpirableDiskLruCacheFactory#ExpirableDiskLruCacheFactory(CacheDirectoryGetter, long, long)}
+ * constructor variant.
  */
 // Public API.
 @SuppressWarnings("unused")
-public class DiskLruCacheFactory implements DiskCache.Factory {
+public class ExpirableDiskLruCacheFactory implements DiskCache.Factory {
   private final long diskCacheSize;
+  private final long expirationMillis;
   private final CacheDirectoryGetter cacheDirectoryGetter;
 
-  public DiskLruCacheFactory(final String diskCacheFolder, long diskCacheSize) {
+  public ExpirableDiskLruCacheFactory(final String diskCacheFolder, long diskCacheSize,
+                                      long expirationMillis) {
     this(new CacheDirectoryGetter() {
       @Override
       public File getCacheDirectory() {
         return new File(diskCacheFolder);
       }
-    }, diskCacheSize);
+    }, diskCacheSize, expirationMillis);
   }
 
-  public DiskLruCacheFactory(final String diskCacheFolder, final String diskCacheName,
-                             long diskCacheSize) {
+  public ExpirableDiskLruCacheFactory(final String diskCacheFolder, final String diskCacheName,
+                                      long diskCacheSize, long expirationMillis) {
     this(new CacheDirectoryGetter() {
       @Override
       public File getCacheDirectory() {
         return new File(diskCacheFolder, diskCacheName);
       }
-    }, diskCacheSize);
+    }, diskCacheSize, expirationMillis);
   }
 
   /**
@@ -40,11 +43,14 @@ public class DiskLruCacheFactory implements DiskCache.Factory {
    *
    * @param cacheDirectoryGetter Interface called out of UI thread to get the cache folder.
    * @param diskCacheSize        Desired max bytes size for the LRU disk cache.
+   * @param expirationMillis     The expiration time in milliseconds
    */
   // Public API.
   @SuppressWarnings("WeakerAccess")
-  public DiskLruCacheFactory(CacheDirectoryGetter cacheDirectoryGetter, long diskCacheSize) {
+  public ExpirableDiskLruCacheFactory(CacheDirectoryGetter cacheDirectoryGetter,
+                                      long diskCacheSize, long expirationMillis) {
     this.diskCacheSize = diskCacheSize;
+    this.expirationMillis = expirationMillis;
     this.cacheDirectoryGetter = cacheDirectoryGetter;
   }
 
@@ -60,6 +66,6 @@ public class DiskLruCacheFactory implements DiskCache.Factory {
       return null;
     }
 
-    return DiskLruCacheWrapper.create(cacheDir, diskCacheSize);
+    return ExpirableDiskLruCacheWrapper.create(cacheDir, diskCacheSize, expirationMillis);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheWrapper.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheWrapper.java
@@ -1,0 +1,51 @@
+package com.bumptech.glide.load.engine.cache;
+
+import android.support.annotation.Nullable;
+import com.bumptech.glide.load.Key;
+import java.io.File;
+
+/**
+ * The expirable DiskCache implementation. When entity is accessed, file last modified date is used
+ * to check if it's not expired. If entity is expired it is removed and null is returned instead.
+ * <p>
+ * There must be no more than one active instance for a given directory at a time.
+ *
+ * @see #get(java.io.File, long)
+ */
+public class ExpirableDiskLruCacheWrapper extends DiskLruCacheWrapper {
+
+  private final long expirationMillis;
+
+  @SuppressWarnings({"WeakerAccess", "deprecation"})
+  protected ExpirableDiskLruCacheWrapper(File directory, long maxSize, long expirationMillis) {
+    super(directory, maxSize);
+    this.expirationMillis = expirationMillis;
+  }
+
+  /**
+   * Create a new DiskCache in the given directory with a specified max size and expiration
+   * time.
+   *
+   * @param directory        The directory for the disk cache
+   * @param maxSize          The max size for the disk cache
+   * @param expirationMillis The expiration time in milliseconds
+   * @return The new disk cache with the given arguments
+   */
+  public static DiskCache create(File directory, long maxSize, long expirationMillis) {
+    return new ExpirableDiskLruCacheWrapper(directory, maxSize, expirationMillis);
+  }
+
+  @Override
+  public File get(Key key) {
+    File file = super.get(key);
+    if (hasExpired(file)) {
+      delete(key);
+      file = null;
+    }
+    return file;
+  }
+
+  private boolean hasExpired(@Nullable File file) {
+    return file != null && System.currentTimeMillis() > file.lastModified() + expirationMillis;
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalCacheDirectoryGetter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalCacheDirectoryGetter.java
@@ -1,0 +1,59 @@
+package com.bumptech.glide.load.engine.cache;
+
+import android.content.Context;
+import android.support.annotation.Nullable;
+import java.io.File;
+
+/**
+ * Creates an {@link ExternalCacheDirectoryGetter} which returns external
+ * disk cache directory, which falls back to the internal disk cache if no external storage is
+ * available. If ever fell back to the internal disk cache, will use that one from that moment on.
+ *
+ * <p><b>Images can be read by everyone when using external disk cache.</b>
+ */
+// Public API.
+@SuppressWarnings("WeakerAccess")
+public class ExternalCacheDirectoryGetter implements CacheDirectoryGetter {
+
+  private final Context context;
+  private final String diskCacheName;
+
+  public ExternalCacheDirectoryGetter(final Context context, final String diskCacheName) {
+    this.context = context;
+    this.diskCacheName = diskCacheName;
+  }
+
+  @Nullable
+  private File getInternalCacheDirectory() {
+    File cacheDirectory = context.getCacheDir();
+    if (cacheDirectory == null) {
+      return null;
+    }
+    if (diskCacheName != null) {
+      return new File(cacheDirectory, diskCacheName);
+    }
+    return cacheDirectory;
+  }
+
+  @Override
+  public File getCacheDirectory() {
+    File internalCacheDirectory = getInternalCacheDirectory();
+
+    // Already used internal cache, so keep using that one,
+    // thus avoiding using both external and internal with transient errors.
+    if ((null != internalCacheDirectory) && internalCacheDirectory.exists()) {
+      return internalCacheDirectory;
+    }
+
+    File cacheDirectory = context.getExternalCacheDir();
+
+    // Shared storage is not available.
+    if ((cacheDirectory == null) || (!cacheDirectory.canWrite())) {
+      return internalCacheDirectory;
+    }
+    if (diskCacheName != null) {
+      return new File(cacheDirectory, diskCacheName);
+    }
+    return cacheDirectory;
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalExpirableCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalExpirableCacheDiskCacheFactory.java
@@ -1,0 +1,31 @@
+package com.bumptech.glide.load.engine.cache;
+
+import android.content.Context;
+
+/**
+ * Creates an {@link com.bumptech.glide.disklrucache.DiskLruCache} based disk cache in the external
+ * disk cache directory, which falls back to the internal disk cache if no external storage is
+ * available. If ever fell back to the internal disk cache, will use that one from that moment on.
+ *
+ * <p><b>Images can be read by everyone when using external disk cache.</b>
+ */
+// Public API.
+@SuppressWarnings({"unused", "WeakerAccess"})
+public final class ExternalExpirableCacheDiskCacheFactory extends ExpirableDiskLruCacheFactory {
+
+  public ExternalExpirableCacheDiskCacheFactory(Context context, long expirationMillis) {
+    this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR,
+        DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE, expirationMillis);
+  }
+
+  public ExternalExpirableCacheDiskCacheFactory(Context context, long diskCacheSize,
+                                                long expirationMillis) {
+    this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR, diskCacheSize, expirationMillis);
+  }
+
+  public ExternalExpirableCacheDiskCacheFactory(final Context context, final String diskCacheName,
+                                                final long diskCacheSize, long expirationMillis) {
+    super(new ExternalCacheDirectoryGetter(context, diskCacheName),
+        diskCacheSize, expirationMillis);
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/ExternalPreferredCacheDiskCacheFactory.java
@@ -1,8 +1,6 @@
 package com.bumptech.glide.load.engine.cache;
 
 import android.content.Context;
-import android.support.annotation.Nullable;
-import java.io.File;
 
 /**
  * Creates an {@link com.bumptech.glide.disklrucache.DiskLruCache} based disk cache in the external
@@ -26,40 +24,6 @@ public final class ExternalPreferredCacheDiskCacheFactory extends DiskLruCacheFa
 
   public ExternalPreferredCacheDiskCacheFactory(final Context context, final String diskCacheName,
                                                 final long diskCacheSize) {
-    super(new CacheDirectoryGetter() {
-      @Nullable
-      private File getInternalCacheDirectory() {
-        File cacheDirectory = context.getCacheDir();
-        if (cacheDirectory == null) {
-          return null;
-        }
-        if (diskCacheName != null) {
-          return new File(cacheDirectory, diskCacheName);
-        }
-        return cacheDirectory;
-      }
-
-      @Override
-      public File getCacheDirectory() {
-        File internalCacheDirectory = getInternalCacheDirectory();
-
-        // Already used internal cache, so keep using that one,
-        // thus avoiding using both external and internal with transient errors.
-        if ((null != internalCacheDirectory) && internalCacheDirectory.exists()) {
-          return internalCacheDirectory;
-        }
-
-        File cacheDirectory = context.getExternalCacheDir();
-
-        // Shared storage is not available.
-        if ((cacheDirectory == null) || (!cacheDirectory.canWrite())) {
-          return internalCacheDirectory;
-        }
-        if (diskCacheName != null) {
-          return new File(cacheDirectory, diskCacheName);
-        }
-        return cacheDirectory;
-      }
-    }, diskCacheSize);
+    super(new ExternalCacheDirectoryGetter(context, diskCacheName), diskCacheSize);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDirectoryGetter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDirectoryGetter.java
@@ -1,0 +1,33 @@
+package com.bumptech.glide.load.engine.cache;
+
+import android.content.Context;
+import java.io.File;
+
+/**
+ * Creates an {@link com.bumptech.glide.disklrucache.DiskLruCache} based disk cache in the internal
+ * disk cache directory.
+ */
+// Public API.
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class InternalCacheDirectoryGetter implements CacheDirectoryGetter {
+
+    private final Context context;
+    private final String diskCacheName;
+
+    InternalCacheDirectoryGetter(Context context, String diskCacheName) {
+        this.context = context;
+        this.diskCacheName = diskCacheName;
+    }
+
+    @Override
+    public File getCacheDirectory() {
+        File cacheDirectory = context.getCacheDir();
+        if (cacheDirectory == null) {
+            return null;
+        }
+        if (diskCacheName != null) {
+            return new File(cacheDirectory, diskCacheName);
+        }
+        return cacheDirectory;
+    }
+}

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalCacheDiskCacheFactory.java
@@ -1,7 +1,6 @@
 package com.bumptech.glide.load.engine.cache;
 
 import android.content.Context;
-import java.io.File;
 
 /**
  * Creates an {@link com.bumptech.glide.disklrucache.DiskLruCache} based disk cache in the internal
@@ -22,18 +21,6 @@ public final class InternalCacheDiskCacheFactory extends DiskLruCacheFactory {
 
   public InternalCacheDiskCacheFactory(final Context context, final String diskCacheName,
                                        long diskCacheSize) {
-    super(new CacheDirectoryGetter() {
-      @Override
-      public File getCacheDirectory() {
-        File cacheDirectory = context.getCacheDir();
-        if (cacheDirectory == null) {
-          return null;
-        }
-        if (diskCacheName != null) {
-          return new File(cacheDirectory, diskCacheName);
-        }
-        return cacheDirectory;
-      }
-    }, diskCacheSize);
+    super(new InternalCacheDirectoryGetter(context, diskCacheName), diskCacheSize);
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalExpirableCacheDiskCacheFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/cache/InternalExpirableCacheDiskCacheFactory.java
@@ -1,0 +1,28 @@
+package com.bumptech.glide.load.engine.cache;
+
+import android.content.Context;
+
+/**
+ * Creates an {@link com.bumptech.glide.disklrucache.DiskLruCache} based disk cache in the internal
+ * disk cache directory.
+ */
+// Public API.
+@SuppressWarnings({"WeakerAccess", "unused"})
+public class InternalExpirableCacheDiskCacheFactory extends ExpirableDiskLruCacheFactory {
+
+  public InternalExpirableCacheDiskCacheFactory(Context context, long expirationMillis) {
+    this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR,
+        DiskCache.Factory.DEFAULT_DISK_CACHE_SIZE, expirationMillis);
+  }
+
+  public InternalExpirableCacheDiskCacheFactory(Context context, long diskCacheSize,
+                                                long expirationMillis) {
+    this(context, DiskCache.Factory.DEFAULT_DISK_CACHE_DIR, diskCacheSize, expirationMillis);
+  }
+
+  public InternalExpirableCacheDiskCacheFactory(final Context context, final String diskCacheName,
+                                                long diskCacheSize, long expirationMillis) {
+    super(new InternalCacheDirectoryGetter(context, diskCacheName),
+        diskCacheSize, expirationMillis);
+  }
+}

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheWrapperTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/cache/ExpirableDiskLruCacheWrapperTest.java
@@ -1,0 +1,192 @@
+package com.bumptech.glide.load.engine.cache;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.fail;
+import static org.junit.Assume.assumeTrue;
+import static org.mockito.Mockito.mock;
+
+import android.os.SystemClock;
+import android.support.annotation.NonNull;
+import com.bumptech.glide.load.Key;
+import com.bumptech.glide.signature.ObjectKey;
+import com.bumptech.glide.tests.Util;
+import java.io.File;
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(manifest = Config.NONE, sdk = 18)
+public class ExpirableDiskLruCacheWrapperTest {
+
+  private DiskCache cache;
+  private byte[] data;
+  private ObjectKey key;
+  private File dir;
+  private long expirationMillis;
+
+  @Before
+  public void setUp() {
+    expirationMillis = TimeUnit.SECONDS.toMillis(10);
+    dir = RuntimeEnvironment.application.getCacheDir();
+    cache = ExpirableDiskLruCacheWrapper.create(dir, 10 * 1024 * 1024, expirationMillis);
+    key = new ObjectKey("test" + Math.random());
+    data = new byte[]{1, 2, 3, 4, 5, 6};
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      cache.clear();
+    } finally {
+      deleteRecursive(dir);
+    }
+  }
+
+  private static void deleteRecursive(File file) {
+    if (file.isDirectory()) {
+      File[] files = file.listFiles();
+      if (files != null) {
+        for (File f : files) {
+          deleteRecursive(f);
+        }
+      }
+    }
+    // GC before delete() to release files on Windows (https://stackoverflow.com/a/4213208/253468)
+    System.gc();
+    if (!file.delete() && file.exists()) {
+      throw new RuntimeException("Failed to delete: " + file);
+    }
+  }
+
+  @Test
+  public void testCanInsertAndGet() throws IOException {
+    cache.put(key, new DiskCache.Writer() {
+      @Override
+      public boolean write(@NonNull File file) {
+        try {
+          Util.writeFile(file, data);
+        } catch (IOException e) {
+          fail(e.toString());
+        }
+        return true;
+      }
+    });
+
+    byte[] received = Util.readFile(cache.get(key), data.length);
+
+    assertArrayEquals(data, received);
+  }
+
+  @Test
+  public void testExpiredReturnNull() {
+    long expirationMillis = 100;
+    cache = ExpirableDiskLruCacheWrapper.create(dir, 1024 * 1024, expirationMillis);
+    cache.put(key, new DiskCache.Writer() {
+      @Override
+      public boolean write(@NonNull File file) {
+        try {
+          Util.writeFile(file, data);
+        } catch (IOException e) {
+          fail(e.toString());
+        }
+        return true;
+      }
+    });
+
+    // wait until value has expired
+    SystemClock.sleep(expirationMillis * 2);
+
+    File file = cache.get(key);
+
+    assertNull(file);
+  }
+
+  @Test
+  public void testDoesNotCommitIfWriterReturnsFalse() {
+    cache.put(key, new DiskCache.Writer() {
+      @Override
+      public boolean write(@NonNull File file) {
+        return false;
+      }
+    });
+
+    assertNull(cache.get(key));
+  }
+
+  @Test
+  public void testDoesNotCommitIfWriterWritesButReturnsFalse() {
+    cache.put(key, new DiskCache.Writer() {
+      @Override
+      public boolean write(@NonNull File file) {
+        try {
+          Util.writeFile(file, data);
+        } catch (IOException e) {
+          fail(e.toString());
+        }
+        return false;
+      }
+    });
+
+    assertNull(cache.get(key));
+  }
+
+  @Test
+  public void testEditIsAbortedIfWriterThrows() throws IOException {
+    try {
+      cache.put(key, new DiskCache.Writer() {
+        @Override
+        public boolean write(@NonNull File file) {
+          throw new RuntimeException("test");
+        }
+      });
+    } catch (RuntimeException e) {
+      // Expected.
+    }
+
+    cache.put(key, new DiskCache.Writer() {
+      @Override
+      public boolean write(@NonNull File file) {
+        try {
+          Util.writeFile(file, data);
+        } catch (IOException e) {
+          fail(e.toString());
+        }
+        return true;
+      }
+    });
+
+    byte[] received = Util.readFile(cache.get(key), data.length);
+
+    assertArrayEquals(data, received);
+  }
+
+  // Tests #2465.
+  @Test
+  public void clearDiskCache_afterOpeningDiskCache_andDeleteDirectoryOutsideGlide_doesNotThrow() {
+    assumeTrue("A file handle is likely open, so cannot delete dir", !Util.isWindows());
+    DiskCache cache = ExpirableDiskLruCacheWrapper.create(dir, 1024 * 1024, expirationMillis);
+    cache.get(mock(Key.class));
+    deleteRecursive(dir);
+    cache.clear();
+  }
+
+  // Tests #2465.
+  @Test
+  public void get_afterDeleteDirectoryOutsideGlideAndClose_doesNotThrow() {
+    assumeTrue("A file handle is likely open, so cannot delete dir", !Util.isWindows());
+    DiskCache cache = ExpirableDiskLruCacheWrapper.create(dir, 1024 * 1024, expirationMillis);
+    cache.get(mock(Key.class));
+    deleteRecursive(dir);
+    cache.clear();
+
+    cache.get(mock(Key.class));
+  }
+}


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Implementation for [Proposal: Expirable LRU Disk Cache #3418](https://github.com/bumptech/glide/issues/3418).

Basically created `ExpirableDiskLruCacheWrapper` and some factories. `ExpirableDiskLruCacheWrapper` extends `DiskLruCacheWrapper` and overwrites `get` method which removes entity if it has expired.

Moved somme common code into `InternalCacheDirectoryGetter` and `ExternalCacheDirectoryGetter`.

Usage from client prospective:

```java
@GlideModule
public class YourAppGlideModule extends AppGlideModule {
  @Override
  public void applyOptions(Context context, GlideBuilder builder) {
    long expirationMillis = TimeUnit.DAYS.toMillis(30);
    builder.setDiskCache(new ExternalExpirableCacheDiskCacheFactory(context, expiration));
  }
}
```

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
With upcoming [GDPR](https://en.wikipedia.org/wiki/General_Data_Protection_Regulation) it would be nice to have some disk cache expiration policy. E.g. I want to cache image for 30 days.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->