### PR TITLE
CustomTarget javadoc is incorrect

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/CustomTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/CustomTarget.java
@@ -61,8 +61,9 @@ public abstract class CustomTarget<T> implements Target<T> {
    * as the requested size (unless overridden by
    * {@link com.bumptech.glide.request.RequestOptions#override(int)} in the request).
    *
-   * @param width The requested width (>= 0, or == Target.SIZE_ORIGINAL).
-   * @param height The requested height (>= 0, or == Target.SIZE_ORIGINAL).
+   * @param width The requested width (> 0, or == Target.SIZE_ORIGINAL).
+   * @param height The requested height (> 0, or == Target.SIZE_ORIGINAL).
+   * @throws IllegalArgumentException if width/height doesn't meet (> 0, or == Target.SIZE_ORIGINAL)
    */
   public CustomTarget(int width, int height) {
      if (!Util.isValidDimensions(width, height)) {


### PR DESCRIPTION
`isValidDimensions` implementation enforces that width and height must be `> 0` or `== Target.SIZE_ORIGINAL`

Issue: https://github.com/bumptech/glide/issues/3582
