### PR TITLE
Improve comments and consistency of sampling in DownsampleStrategies.

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
@@ -87,6 +87,17 @@ public class DownsamplerEmulatorTest {
                 .with(formats(JPEG, WEBP).expect(13, 100), formats(PNG).expect(12, 100)),
             below(VERSION_CODES.N)
                 .with(formats(JPEG).expect(13, 100), formats(PNG, WEBP).expect(12, 100)))
+        .givenImageWithDimensionsOf(
+            801,
+            100,
+            below(KITKAT)
+                .with(
+                    // JPEG is correct because CENTER_INSIDE wants to give a subsequent
+                    // transformation an image that is greater in size than the requested size. On
+                    // Api > VERSION_CODES.KITKAT, CENTER_INSIDE can do the transformation itself.
+                    // On < VERSION_CODES.KITKAT, it has to assume a subsequent transformation will
+                    // be called.
+                    formats(JPEG).expect(50, 6), formats(PNG, WEBP).expect(50, 6)))
         .givenImageWithDimensionsOf(87, 78, onAllApisAndAllFormatsExpect(87, 78))
         // This set of examples demonstrate that webp uses round on N+ and floor < N.
         .setTargetDimensions(13, 13)
@@ -145,7 +156,6 @@ public class DownsamplerEmulatorTest {
             3024,
             4032,
             atAndAbove(KITKAT).with(allFormats().expect(1977, 2636)),
-            // TODO(b/134182995): This shouldn't be preserving quality.
             below(KITKAT).with(allFormats().expect(3024, 4032)))
         .setTargetDimensions(100, 100)
         .givenSquareImageWithDimensionOf(100, onAllApisAndAllFormatsExpect(100, 100))
@@ -164,7 +174,7 @@ public class DownsamplerEmulatorTest {
             800,
             100,
             atAndAbove(KITKAT).with(allFormats().expect(100, 13)),
-            below(KITKAT).with(allFormats().expect(200, 25)))
+            below(KITKAT).with(formats(JPEG).expect(100, 13), formats(PNG, WEBP).expect(100, 12)))
         .givenImageWithDimensionsOf(
             801,
             100,
@@ -184,7 +194,7 @@ public class DownsamplerEmulatorTest {
             100,
             800,
             atAndAbove(KITKAT).with(allFormats().expect(13, 100)),
-            below(KITKAT).with(allFormats().expect(25, 200)))
+            below(KITKAT).with(formats(JPEG).expect(13, 100), formats(PNG, WEBP).expect(12, 100)))
         .givenImageWithDimensionsOf(87, 78, onAllApisAndAllFormatsExpect(87, 78))
         .setTargetDimensions(897, 897)
         .givenImageWithDimensionsOf(
@@ -278,7 +288,6 @@ public class DownsamplerEmulatorTest {
             3024,
             4032,
             atAndAbove(KITKAT).with(allFormats().expect(1977, 2636)),
-            // TODO(b/134182995): This shouldn't be preserving quality.
             below(KITKAT).with(allFormats().expect(3024, 4032)))
         .setTargetDimensions(100, 100)
         .givenSquareImageWithDimensionOf(100, onAllApisAndAllFormatsExpect(100, 100))
@@ -298,7 +307,7 @@ public class DownsamplerEmulatorTest {
             800,
             100,
             atAndAbove(KITKAT).with(allFormats().expect(100, 13)),
-            below(KITKAT).with(allFormats().expect(200, 25)))
+            below(KITKAT).with(formats(JPEG).expect(100, 13), formats(PNG, WEBP).expect(100, 12)))
         .givenImageWithDimensionsOf(
             801,
             100,
@@ -318,7 +327,7 @@ public class DownsamplerEmulatorTest {
             100,
             800,
             atAndAbove(KITKAT).with(allFormats().expect(13, 100)),
-            below(KITKAT).with(allFormats().expect(25, 200)))
+            below(KITKAT).with(formats(JPEG).expect(13, 100), formats(PNG, WEBP).expect(12, 100)))
         .givenImageWithDimensionsOf(
             87,
             78,

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -430,6 +430,9 @@ public final class Downsampler {
     int widthScaleFactor = orientedSourceWidth / outWidth;
     int heightScaleFactor = orientedSourceHeight / outHeight;
 
+    // TODO: This isn't really right for both CenterOutside and CenterInside. Consider allowing
+    // DownsampleStrategy to pick, or trying to do something more sophisticated like picking the
+    // scale factor that leads to an exact match.
     int scaleFactor =
         rounding == SampleSizeRounding.MEMORY
             ? Math.max(widthScaleFactor, heightScaleFactor)

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
@@ -8,7 +8,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = 21)
 public class DownsampleStrategyTest {
 
   @Test


### PR DESCRIPTION
FitCenter, CenterInside, and CenterOutside now all reliably prefer 
quality on versions < KitKat where we can only do power of two 
downsampling.

I’ve also fixed a bug in FitCenter and CenterInside where we would 
downsample to 2x the requested size in some cases where there was
an exact power of 2 match in one dimension but not the other. The logic
to fix the bug isn’t perfect, but it keeps this change small and avoids
making any API changes.