### PR TITLE
Disable BuildConfig generation

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -174,5 +174,11 @@ subprojects { project ->
                 }
             }
         }
+
+        if (project.plugins.hasPlugin('com.android.library')) {
+            android.libraryVariants.all {
+                it.generateBuildConfigProvider.configure { enabled = false }
+            }
+        }
     }
 }

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -70,7 +70,7 @@ static def getAndroidLibraryVariants(projects, variantName) {
 def getSourceFilesForVariantJar(variantName) {
     getAndroidLibraryVariantsForJar(variantName).collect { variant -> 
         variant.getJavaCompileProvider().get().source.findAll { 
-            return !it.getName().equals("R.java") && !it.getName().equals("BuildConfig.java")
+            return !it.getName().equals("R.java")
         }
     }
 }
@@ -123,7 +123,6 @@ project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"
                     "${getAndroidSdkDirectory()}/docs/reference")
         }
 
-        exclude '**/BuildConfig.java'
         exclude '**/R.java'
     }
 
@@ -145,7 +144,6 @@ jar {
             }
     )
     exclude "**/R.class"
-    exclude "**/BuildConfig.class"
     exclude "**/R\$*.class"
     exclude "android/**"
 }

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -181,7 +181,6 @@ afterEvaluate { project ->
                         "${getAndroidSdkDirectory}/docs/reference")
             }
 
-            exclude '**/BuildConfig.java'
             exclude '**/R.java'
         }
 
@@ -205,7 +204,6 @@ afterEvaluate { project ->
         task androidLibraryJar(type: Jar, dependsOn: compileDebugJavaWithJavac /* == variant.javaCompile */) {
             from compileDebugJavaWithJavac.destinationDir
             exclude '**/R.class'
-            exclude '**/BuildConfig.class'
             exclude '**/R$*.class'
             baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
         }


### PR DESCRIPTION
Some BuildConfigs were not properly excluded, e.g. glide@aar and gifdecoder@aar had `BuildConfig.class` in them. 