### PR TITLE
Fix a wrong process

### DIFF
--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -178,7 +178,7 @@ public class RequestManagerRetriever implements Handler.Callback {
     // prefer to just fall back to the Activity directly.
     if (activity instanceof FragmentActivity) {
       Fragment fragment = findSupportFragment(view, (FragmentActivity) activity);
-      return fragment != null ? get(fragment) : get(activity);
+      return fragment != null ? get(fragment) : get((FragmentActivity)activity);
     }
 
     // Standard Fragments.


### PR DESCRIPTION
It has been determined that `activity` belongs to `FragmentActivity` , so  should use the `get()` method of `FragmentActivity`