### PR TITLE
Fixed slow GIF animations

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
@@ -215,7 +215,7 @@ public final class GlideExecutor implements ExecutorService {
   }
 
   /**
-   * Returns a new cached thread pool that defaults to either one or two threads depending on the
+   * Returns a new fixed thread pool that defaults to either one or two threads depending on the
    * number of available cores to use when loading frames of animations.
    */
   public static GlideExecutor newAnimationExecutor() {
@@ -231,7 +231,7 @@ public final class GlideExecutor implements ExecutorService {
   }
 
   /**
-   * Returns a new cached thread pool with the given thread count and {@link
+   * Returns a new fixed thread pool with the given thread count and {@link
    * UncaughtThrowableStrategy} to use when loading frames of animations.
    */
   // Public API.
@@ -240,9 +240,9 @@ public final class GlideExecutor implements ExecutorService {
       int threadCount, UncaughtThrowableStrategy uncaughtThrowableStrategy) {
     return new GlideExecutor(
         new ThreadPoolExecutor(
-            0 /* corePoolSize */,
             threadCount,
-            KEEP_ALIVE_TIME_MS,
+            threadCount,
+            0,
             TimeUnit.MILLISECONDS,
             new PriorityBlockingQueue<Runnable>(),
             new DefaultThreadFactory(ANIMATION_EXECUTOR_NAME, uncaughtThrowableStrategy, true)));


### PR DESCRIPTION
## Description
Fixed slow GIF animations by using fixed thread pool.
See [comment](https://github.com/bumptech/glide/issues/3575#issuecomment-517302060) for description.
Issue #3575