### PR TITLE
Support for StaggeredGridLayoutManager in RecyclerView preloading

### DIFF
--- a/integration/recyclerview/src/main/java/com/bumptech/glide/integration/recyclerview/RecyclerToListViewScrollListener.java
+++ b/integration/recyclerview/src/main/java/com/bumptech/glide/integration/recyclerview/RecyclerToListViewScrollListener.java
@@ -81,16 +81,14 @@ public final class RecyclerToListViewScrollListener extends RecyclerView.OnScrol
   static class StaggeredGridLayoutHelper {
     private static int[] itemPositionsHolder;
 
-    static int findFirstVisibleItemPosition(
-        StaggeredGridLayoutManager staggeredGridLayoutManager) {
+    static int findFirstVisibleItemPosition(StaggeredGridLayoutManager staggeredGridLayoutManager) {
       if (itemPositionsHolder == null) {
         itemPositionsHolder = new int[staggeredGridLayoutManager.getSpanCount()];
       }
       return min(staggeredGridLayoutManager.findFirstVisibleItemPositions(itemPositionsHolder));
     }
 
-    static int findLastVisibleItemPosition(
-        StaggeredGridLayoutManager staggeredGridLayoutManager) {
+    static int findLastVisibleItemPosition(StaggeredGridLayoutManager staggeredGridLayoutManager) {
       if (itemPositionsHolder == null) {
         itemPositionsHolder = new int[staggeredGridLayoutManager.getSpanCount()];
       }


### PR DESCRIPTION
## Description
This implements support for `StaggeredGridLayoutManager` + better error messaging for unsupported `LayoutManager` types in `RecyclerToListViewScrollListener`. I couldn't find any tests, so let me know if you'd rather test this another way.

## Motivation and Context
Currently, only `LinearLayoutManager` is supported even though it's trivial to also support `StaggeredGridLayoutManager`. There is no error handling for this either if it's not a supported type today, just a non-obvious class cast failure at runtime.

> Make sure you've run `gradlew clean check jar assemble` before commit.

Master appears to be red, so this fails for me locally