### PR TITLE
Fix cancelAll() termination condition

### DIFF
--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -219,7 +219,7 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
   }
 
   private void cancelAll() {
-    for (int i = 0; i < maxPreload; i++) {
+    for (int i = 0; i < preloadTargetQueue.queue.size(); i++) {
       requestManager.clear(preloadTargetQueue.next(0, 0));
     }
   }

--- a/library/src/main/java/com/bumptech/glide/ListPreloader.java
+++ b/library/src/main/java/com/bumptech/glide/ListPreloader.java
@@ -225,7 +225,7 @@ public class ListPreloader<T> implements AbsListView.OnScrollListener {
   }
 
   private static final class PreloadTargetQueue {
-    private final Queue<PreloadTarget> queue;
+    @Synthetic final Queue<PreloadTarget> queue;
 
     // The loop is short and the only point is to create the objects.
     @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")


### PR DESCRIPTION
The method `cancellAll()` was using the field maxPreload to determine when the for loop should terminate, which was always off by one compared to the size of the preloadTargetQueue, and therefore, not all the pre-loaded requests would be canceled. This issue was raised in https://github.com/bumptech/glide/issues/3693.

## Description
https://github.com/bumptech/glide/issues/3693 is the issue that this was raised in.

## Motivation and Context
This change will unsure that every pre-loaded request within the queue gets canceled. 