### PR TITLE
Option to ignore exif orientation

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -112,8 +112,8 @@ public final class Downsampler {
           "com.bumptech.glide.load.resource.bitmap.Downsampler.AllowHardwareDecode", false);
 
   /**
-   * Indicates if the {@link androidx.exifinterface.media.ExifInterface.TAG_ORIENTATION} should be
-   * ignored and load the bitmap without rotating the decoded image
+   * Indicates if {@link androidx.exifinterface.media.ExifInterface.TAG_ORIENTATION} should be
+   * ignored and load the bitmap without rotating the decoded image.
    */
   public static final Option<Boolean> IGNORE_EXIF_ORIENTATION =
       Option.memory(
@@ -303,7 +303,8 @@ public final class Downsampler {
     }
 
     int orientation =
-        ignoreExifOrientation ? ExifInterface.ORIENTATION_NORMAL
+        ignoreExifOrientation
+            ? ExifInterface.ORIENTATION_NORMAL
             : imageReader.getImageOrientation();
     int degreesToRotate =
         ignoreExifOrientation ? 0 : TransformationUtils.getExifOrientationDegrees(orientation);

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -596,7 +596,7 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
     return set(BitmapEncoder.COMPRESSION_QUALITY, quality);
   }
 
-  /** Sets the value for key {@link Downsampler#IGNORE_EXIF_ORIENTATION} */
+  /** Sets the value for key {@link Downsampler#IGNORE_EXIF_ORIENTATION}. */
   @NonNull
   @CheckResult
   public T ignoreExifOrientation(boolean ignoreExifOrientation) {

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -596,6 +596,13 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
     return set(BitmapEncoder.COMPRESSION_QUALITY, quality);
   }
 
+  /** Sets the value for key {@link Downsampler#IGNORE_EXIF_ORIENTATION} */
+  @NonNull
+  @CheckResult
+  public T ignoreExifOrientation(boolean ignoreExifOrientation) {
+    return set(Downsampler.IGNORE_EXIF_ORIENTATION, ignoreExifOrientation);
+  }
+
   /**
    * Sets the time position of the frame to extract from a video.
    *


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

This PR adds an option to request for ignoring the `EXIF` orientation parsing in `Downsampler`.  

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

Addresses: https://github.com/bumptech/glide/issues/665. For some applications (like ours), the application keeps track of the orientation not stored as the EXIF data. 

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->