### PR TITLE
Allow HTTP traffic on specific domains to sample modules

### DIFF
--- a/samples/flickr/src/main/AndroidManifest.xml
+++ b/samples/flickr/src/main/AndroidManifest.xml
@@ -1,6 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.samples.flickr">
+  xmlns:tools="http://schemas.android.com/tools"
+  package="com.bumptech.glide.samples.flickr">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <!--
@@ -13,7 +14,9 @@
         android:label="@string/app_name"
         android:icon="@android:drawable/sym_def_app_icon"
         android:allowBackup="false"
-        android:theme="@style/Theme.AppCompat">
+        android:networkSecurityConfig="@xml/network_security_config"
+        android:theme="@style/Theme.AppCompat"
+        tools:targetApi="n">
 
         <activity
             android:name=".FlickrSearchActivity"

--- a/samples/flickr/src/main/res/xml/network_security_config.xml
+++ b/samples/flickr/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">staticflickr.com</domain>
+  </domain-config>
+</network-security-config>

--- a/samples/imgur/src/main/AndroidManifest.xml
+++ b/samples/imgur/src/main/AndroidManifest.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
+  xmlns:tools="http://schemas.android.com/tools"
   package="com.bumptech.glide.samples.imgur">
   <uses-permission android:name="android.permission.INTERNET" />
   <!--
@@ -14,7 +15,9 @@
     android:roundIcon="@mipmap/ic_launcher_round"
     android:supportsRtl="true"
     android:theme="@style/AppTheme"
-    android:name="com.bumptech.glide.samples.imgur.ImgurApplication">
+    android:networkSecurityConfig="@xml/network_security_config"
+    android:name="com.bumptech.glide.samples.imgur.ImgurApplication"
+    tools:targetApi="n">
     <activity android:name="com.bumptech.glide.samples.imgur.MainActivity">
       <intent-filter>
         <action android:name="android.intent.action.MAIN"/>

--- a/samples/imgur/src/main/res/xml/network_security_config.xml
+++ b/samples/imgur/src/main/res/xml/network_security_config.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<network-security-config>
+  <domain-config cleartextTrafficPermitted="true">
+    <domain includeSubdomains="true">imgur.com</domain>
+  </domain-config>
+</network-security-config>


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
imgur sample is not showing some images because of the HTTP urls.
Also Flickr is not working completely due to HTTP traffic.

## Motivation and Context
We can also setup example here for other to allow a single domain to use HTTP url.