### PR TITLE
Keep InternalRewriter.rewrite to ensure it is not inlined

### DIFF
--- a/library/proguard-rules.txt
+++ b/library/proguard-rules.txt
@@ -6,6 +6,9 @@
   **[] $VALUES;
   public *;
 }
+-keep class com.bumptech.glide.load.data.ParcelFileDescriptorRewinder$InternalRewinder {
+  *** rewind();
+}
 
 # Uncomment for DexGuard only
 #-keepresourcexmlelements manifest/application/meta-data@value=GlideModule


### PR DESCRIPTION


<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
The function could be inlined into ParcelFileDescriptorRewinder.rewriteAndGet resulting in verification errors on pre api-level 21 devices. Such an error was reported here: https://issuetracker.google.com/issues/149193062

<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->