### PR TITLE
Change Log Level

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/GlideException.java
@@ -116,7 +116,7 @@ public final class GlideException extends Exception {
   public void logRootCauses(String tag) {
     List<Throwable> causes = getRootCauses();
     for (int i = 0, size = causes.size(); i < size; i++) {
-      Log.i(tag, "Root cause (" + (i + 1) + " of " + size + ")", causes.get(i));
+      Log.e(tag, "Root cause (" + (i + 1) + " of " + size + ")", causes.get(i));
     }
   }
 


### PR DESCRIPTION
## Description
Change log level for exception

## Motivation and Context
To be easy debugging,
if has some problem in image loading, it occured exception stacktrace log but it is info level
Many cases can not check to info level
so i think it need to be change Log level
