### PR TITLE
Improve the annotation of Encoder interface

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/Encoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/Encoder.java
@@ -14,8 +14,8 @@ public interface Encoder<T> {
    * successfully and should be committed.
    *
    * @param data The data to write.
-   * @param file The File to write the data to.
-   * @param options The put of options to apply when encoding.
+   * @param file The file to write the data to.
+   * @param options The set of options to apply when encoding.
    */
   boolean encode(@NonNull T data, @NonNull File file, @NonNull Options options);
 }


### PR DESCRIPTION
**Description:**

- Improve the annotation of Encoder interface

**Motivation and Context:**
Issue 1: “@​param​ file The F​​ile to write the data to.”

- F​ is unnecessarily capitalized

- Suggest editing annotation to: “@​param​ file The ​f​ile to write the data to.”

Issue 2: “@​param​ options The ​put​ ​of options to apply when encoding.”

- Options.java is described as a set of Option objects placed within an ArrayMap.

- Suggest that “​put​”​ ​could be changed to “​set​” or “​map​” to be more clear as to what the annotation “options” represents.