### PR TITLE
Mark RequestListener.onLoadFailed() model parameter as Nullable

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/RequestListener.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestListener.java
@@ -59,7 +59,10 @@ public interface RequestListener<R> {
    *     Target#onLoadFailed(Drawable)} to be called on {@code target}.
    */
   boolean onLoadFailed(
-      @Nullable GlideException e, Object model, Target<R> target, boolean isFirstResource);
+      @Nullable GlideException e,
+      @Nullable Object model,
+      Target<R> target,
+      boolean isFirstResource);
 
   /**
    * Called when a load completes successfully, immediately before {@link


### PR DESCRIPTION
## Description
Add a `@Nullable` annotation to the `model` parameter of the `RequestListener.onLoadFailed()` method.

## Motivation and Context
We had a crash happening when using Kotlin that could have been avoided if the `model` parameter was annotated as nullable. 
The crash happened with the following code:
```
override fun onLoadFailed(
    e: GlideException?,
    model: Any,
    target: Target<Drawable>,
    isFirstResource: Boolean
): Boolean {
    adView.setGone()
    return false
}
```
Then if the `model` turns out to be null, a `java.lang.IllegalArgumentExceptionParameter` happens.

Adding this annotation will prevent the issue. It also acts as documentations, indicating that the parameter can be null.