### PR TITLE
Avoid IllegalArgumentException in GifFrameLoader.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifFrameLoader.java
@@ -268,7 +268,11 @@ class GifFrameLoader {
     // already incremented the frame pointer and can't decode the same frame again. Instead we'll
     // just hang on to this next frame until start() or clear() are called.
     if (!isRunning) {
-      pendingTarget = delayTarget;
+      if (startFromFirstFrame) {
+        handler.obtainMessage(FrameLoaderCallback.MSG_CLEAR, delayTarget).sendToTarget();
+      } else {
+        pendingTarget = delayTarget;
+      }
       return;
     }
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
@@ -339,6 +339,18 @@ public class GifFrameLoaderTest {
   }
 
   @Test
+  public void onFrameReady_whenInvisible_setVisibleLater() {
+    loader = createGifFrameLoader(/*handler=*/ null);
+    // The target is invisible at this point.
+    loader.unsubscribe(callback);
+    loader.setNextStartFromFirstFrame();
+    DelayTarget loaded = mock(DelayTarget.class);
+    when(loaded.getResource()).thenReturn(Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888));
+    loader.onFrameReady(loaded);
+    loader.subscribe(callback);
+  }
+
+  @Test
   public void startFromFirstFrame_withPendingFrame_clearsPendingFrame() {
     loader = createGifFrameLoader(/*handler=*/ null);
     DelayTarget loaded = mock(DelayTarget.class);


### PR DESCRIPTION
## Description

Avoid IllegalArgumentException in GifFrameLoader.

## Motivation and Context

I encountered IllegalArgumentException, which is  thrown when the target is invisible and startFromFirstFrame is called  and the target subsequently becomes visible.

repo steps:
1. target.setVisible(false, ...)
2. drawable.startFromFirstFrame()
3. (after a while) target.setVisible(true, ...)