### PR TITLE
Edit transforms docs for word error

### DIFF
--- a/_posts/2015-05-21-transformations.md
+++ b/_posts/2015-05-21-transformations.md
@@ -63,7 +63,7 @@ Or with the shortcut method:
 ```java
 Glide.with(fragment)
   .load(url)
-  .transform(new FitCenter(), new YourCustomTransformation())
+  .transforms(new FitCenter(), new YourCustomTransformation())
   .into(imageView);
 ```
 


### PR DESCRIPTION
I think `transform` should be `transforms` for the shortcut method, so just making a simple pr for this
