### PR TITLE
Add support for width / height to the SvgDecoder

### DIFF
--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgDecoder.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgDecoder.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.samples.svg;
 
+import static com.bumptech.glide.request.target.Target.SIZE_ORIGINAL;
+
 import androidx.annotation.NonNull;
 import com.bumptech.glide.load.Options;
 import com.bumptech.glide.load.ResourceDecoder;
@@ -24,6 +26,12 @@ public class SvgDecoder implements ResourceDecoder<InputStream, SVG> {
       throws IOException {
     try {
       SVG svg = SVG.getFromInputStream(source);
+      if (width != SIZE_ORIGINAL) {
+        svg.setDocumentWidth(width);
+      }
+      if (height != SIZE_ORIGINAL) {
+        svg.setDocumentHeight(height);
+      }
       return new SimpleResource<>(svg);
     } catch (SVGParseException ex) {
       throw new IOException("Cannot load SVG from stream", ex);


### PR DESCRIPTION
## Description
Modify the sample SvgDecoder to use parameters width and height that are
passed into the decode() method.

## Motivation and Context
The sample SvgDecoder does not currently use parameters with and height
that are passed into the decode() method. This can be misleading for
Glide users and causes basic functionality such as image scaling to not
work properly. This change adds code to change the SVG document width
and height according to the provided parameters.