### PR TITLE
Update README.md with updated proguard rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,15 @@ Depending on your ProGuard (DexGuard) config and usage, you may need to include 
 
 ```pro
 -keep public class * implements com.bumptech.glide.module.GlideModule
--keep public class * extends com.bumptech.glide.module.AppGlideModule
+-keep class * extends com.bumptech.glide.module.AppGlideModule {
+ <init>(...);
+}
 -keep public enum com.bumptech.glide.load.ImageHeaderParser$** {
   **[] $VALUES;
   public *;
+}
+-keep class com.bumptech.glide.load.data.ParcelFileDescriptorRewinder$InternalRewinder {
+  *** rewind();
 }
 
 # for DexGuard only


### PR DESCRIPTION
## Description
Updates proguard rules following the rules in `glide/library/proguard-rules.txt`

## Motivation and Context
The rules suggested in the README are not in sync with the ones in the library.
This will just copy-paste the rules used there.
Also those rules are necessary to fix https://github.com/bumptech/glide/issues/4177 