### PR TITLE
Only start RequestManagers, not lifecycles when creating with visible parents

### DIFF
--- a/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
+++ b/library/src/main/java/com/bumptech/glide/manager/SupportRequestManagerFragment.java
@@ -154,7 +154,7 @@ public class SupportRequestManagerFragment extends Fragment {
     rootRequestManagerFragment =
         Glide.get(context)
             .getRequestManagerRetriever()
-            .getSupportRequestManagerFragment(context, fragmentManager);
+            .getSupportRequestManagerFragment(fragmentManager);
     if (!equals(rootRequestManagerFragment)) {
       rootRequestManagerFragment.addChildRequestManagerFragment(this);
     }


### PR DESCRIPTION
This avoids registering ConnectivityReceivers if a RequestManager's Fragment is subsequently discarded without ever actually being added thanks to commitAllowingStateLoss. In turn avoiding registering the receiver avoids a memory leak.

A better solution would be to make the ConnectivityReceiver a singleton, but that requires breaking API changes to add/remove listeners. We could also probably use WeakReferences. 