### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,8 +26,8 @@ Or use Gradle:
 
 ```gradle
 repositories {
-  mavenCentral()
   google()
+  jcenter()
 }
 
 dependencies {


### PR DESCRIPTION
## Description

Use jcenter instead of mavenCentral. It is specified by new Android projects.

## Motivation and Context

Since jcenter is specified by Android Studio automatically, I think using jcenter is more easy way to import Glide.