### PR TITLE
Deduplicate HTTP Uri ModelLoaders

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -50,7 +50,6 @@ import com.bumptech.glide.load.model.UnitModelLoader;
 import com.bumptech.glide.load.model.UriLoader;
 import com.bumptech.glide.load.model.UrlUriLoader;
 import com.bumptech.glide.load.model.stream.HttpGlideUrlLoader;
-import com.bumptech.glide.load.model.stream.HttpUriLoader;
 import com.bumptech.glide.load.model.stream.MediaStoreImageThumbLoader;
 import com.bumptech.glide.load.model.stream.MediaStoreVideoThumbLoader;
 import com.bumptech.glide.load.model.stream.QMediaStoreUriLoader;
@@ -540,7 +539,6 @@ public class Glide implements ComponentCallbacks2 {
         .append(String.class, ParcelFileDescriptor.class, new StringLoader.FileDescriptorFactory())
         .append(
             String.class, AssetFileDescriptor.class, new StringLoader.AssetFileDescriptorFactory())
-        .append(Uri.class, InputStream.class, new HttpUriLoader.Factory())
         .append(Uri.class, InputStream.class, new AssetUriLoader.StreamFactory(context.getAssets()))
         .append(
             Uri.class,

--- a/library/src/main/java/com/bumptech/glide/load/model/stream/HttpUriLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/stream/HttpUriLoader.java
@@ -1,54 +1,32 @@
 package com.bumptech.glide.load.model.stream;
 
 import android.net.Uri;
-import androidx.annotation.NonNull;
-import com.bumptech.glide.load.Options;
 import com.bumptech.glide.load.model.GlideUrl;
 import com.bumptech.glide.load.model.ModelLoader;
-import com.bumptech.glide.load.model.ModelLoaderFactory;
-import com.bumptech.glide.load.model.MultiModelLoaderFactory;
+import com.bumptech.glide.load.model.UrlUriLoader;
 import java.io.InputStream;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashSet;
-import java.util.Set;
 
-/** Loads {@link InputStream}s from http or https {@link Uri}s. */
-public class HttpUriLoader implements ModelLoader<Uri, InputStream> {
-  private static final Set<String> SCHEMES =
-      Collections.unmodifiableSet(new HashSet<>(Arrays.asList("http", "https")));
-
-  private final ModelLoader<GlideUrl, InputStream> urlLoader;
+/**
+ * Loads {@link InputStream}s from http or https {@link Uri}s.
+ *
+ * @deprecated Use {@link UrlUriLoader} instead
+ */
+@Deprecated
+public class HttpUriLoader extends UrlUriLoader<InputStream> {
 
   // Public API.
   @SuppressWarnings("WeakerAccess")
   public HttpUriLoader(ModelLoader<GlideUrl, InputStream> urlLoader) {
-    this.urlLoader = urlLoader;
+    super(urlLoader);
   }
 
-  @Override
-  public LoadData<InputStream> buildLoadData(
-      @NonNull Uri model, int width, int height, @NonNull Options options) {
-    return urlLoader.buildLoadData(new GlideUrl(model.toString()), width, height, options);
-  }
-
-  @Override
-  public boolean handles(@NonNull Uri model) {
-    return SCHEMES.contains(model.getScheme());
-  }
-
-  /** Factory for loading {@link InputStream}s from http/https {@link Uri}s. */
-  public static class Factory implements ModelLoaderFactory<Uri, InputStream> {
-
-    @NonNull
-    @Override
-    public ModelLoader<Uri, InputStream> build(MultiModelLoaderFactory multiFactory) {
-      return new HttpUriLoader(multiFactory.build(GlideUrl.class, InputStream.class));
-    }
-
-    @Override
-    public void teardown() {
-      // Do nothing.
-    }
+  /**
+   * Factory for loading {@link InputStream}s from http/https {@link Uri}s.
+   *
+   * @deprecated Use {@link UrlUriLoader.StreamFactory} instead
+   */
+  @Deprecated
+  public static class Factory extends StreamFactory {
+    // Defer to StreamFactory's implementation
   }
 }

--- a/library/test/src/test/java/com/bumptech/glide/load/model/UrlUriLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/UrlUriLoaderTest.java
@@ -1,4 +1,4 @@
-package com.bumptech.glide.load.model.stream;
+package com.bumptech.glide.load.model;
 
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -6,8 +6,6 @@ import static org.mockito.Mockito.verify;
 
 import android.net.Uri;
 import com.bumptech.glide.load.Options;
-import com.bumptech.glide.load.model.GlideUrl;
-import com.bumptech.glide.load.model.ModelLoader;
 import java.io.InputStream;
 import java.net.MalformedURLException;
 import org.junit.Before;
@@ -20,18 +18,18 @@ import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 18)
-public class HttpUriLoaderTest {
+public class UrlUriLoaderTest {
   private static final int IMAGE_SIDE = 100;
   private static final Options OPTIONS = new Options();
 
   @Mock private ModelLoader<GlideUrl, InputStream> urlLoader;
-  private HttpUriLoader loader;
+  private UrlUriLoader<InputStream> loader;
 
   @Before
   public void setUp() {
     MockitoAnnotations.initMocks(this);
 
-    loader = new HttpUriLoader(urlLoader);
+    loader = new UrlUriLoader<>(urlLoader);
   }
 
   @Test


### PR DESCRIPTION
## Description

This change deduplicates the identical efforts made by `UrlUriLoader` and `HttpUriLoader` by deprecating `HttpUriLoader` and removing it from the registry.

Fixes #2943

## Motivation and Context

Glide had two essentially identical ModelLoaders: UrlUriLoader and HttpUriLoader. They both were being used to defer HTTP/HTTPS Uris to another ModelLoader.

Best-case scenario, this was a harmless distraction; but in some bad cases, it was possible for both ModelLoaders to fire, duplicating work.

With this change, only one of the two HTTP Uri ModelLoaders are entered into the registry. The one no longer being used has been deprecated as well.

I chose to deprecate HttpUriLoader because it can be implemented as a UrlUriLoader (but not vice versa, due to generics). To demonstrate that it still behaves the same, the test (which now targets UrlUriLoader) is unchanged but still passes.

## Note

This PR was originally opened as #4316 but went stale while I was on vacation. I've rebased onto the latest `master` and am more than happy to work with maintainers to figure out how to get this merged (if this fix is desired).