### PR TITLE
Make consistent with #2771

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/data/AssetPathFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/AssetPathFetcher.java
@@ -30,14 +30,13 @@ public abstract class AssetPathFetcher<T> implements DataFetcher<T> {
   public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super T> callback) {
     try {
       data = loadResource(assetManager, assetPath);
+      callback.onDataReady(data);
     } catch (IOException e) {
       if (Log.isLoggable(TAG, Log.DEBUG)) {
         Log.d(TAG, "Failed to load data from asset manager", e);
       }
       callback.onLoadFailed(e);
-      return;
     }
-    callback.onDataReady(data);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/data/LocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/LocalUriFetcher.java
@@ -42,14 +42,13 @@ public abstract class LocalUriFetcher<T> implements DataFetcher<T> {
       @NonNull Priority priority, @NonNull DataCallback<? super T> callback) {
     try {
       data = loadResource(uri, contentResolver);
+      callback.onDataReady(data);
     } catch (FileNotFoundException e) {
       if (Log.isLoggable(TAG, Log.DEBUG)) {
         Log.d(TAG, "Failed to open Uri", e);
       }
       callback.onLoadFailed(e);
-      return;
     }
-    callback.onDataReady(data);
   }
 
   @Override

--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/ThumbFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/ThumbFetcher.java
@@ -59,15 +59,13 @@ public class ThumbFetcher implements DataFetcher<InputStream> {
       @NonNull Priority priority, @NonNull DataCallback<? super InputStream> callback) {
     try {
       inputStream = openThumbInputStream();
+      callback.onDataReady(inputStream);
     } catch (FileNotFoundException e) {
       if (Log.isLoggable(TAG, Log.DEBUG)) {
         Log.d(TAG, "Failed to find thumbnail file", e);
       }
       callback.onLoadFailed(e);
-      return;
     }
-
-    callback.onDataReady(inputStream);
   }
 
   private InputStream openThumbInputStream() throws FileNotFoundException {

--- a/library/src/main/java/com/bumptech/glide/load/model/ByteBufferFileLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ByteBufferFileLoader.java
@@ -59,15 +59,13 @@ public class ByteBufferFileLoader implements ModelLoader<File, ByteBuffer> {
       ByteBuffer result;
       try {
         result = ByteBufferUtil.fromFile(file);
+        callback.onDataReady(result);
       } catch (IOException e) {
         if (Log.isLoggable(TAG, Log.DEBUG)) {
           Log.d(TAG, "Failed to obtain ByteBuffer for file", e);
         }
         callback.onLoadFailed(e);
-        return;
       }
-
-      callback.onDataReady(result);
     }
 
     @Override

--- a/library/src/main/java/com/bumptech/glide/load/model/FileLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/FileLoader.java
@@ -69,14 +69,13 @@ public class FileLoader<Data> implements ModelLoader<File, Data> {
     public void loadData(@NonNull Priority priority, @NonNull DataCallback<? super Data> callback) {
       try {
         data = opener.open(file);
+        callback.onDataReady(data);
       } catch (FileNotFoundException e) {
         if (Log.isLoggable(TAG, Log.DEBUG)) {
           Log.d(TAG, "Failed to open file", e);
         }
         callback.onLoadFailed(e);
-        return;
       }
-      callback.onDataReady(data);
     }
 
     @Override


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

In #2771, `HttpUrlFetcher#loadData` was refactored ([here](https://github.com/bumptech/glide/pull/2771/files#diff-6e349798f5099eef01d1d3bce3b36058L55-L70)), but its similar method, `AssetPathFetcher#loadData` was not modified.
I thought the modification is needed for consistency.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

This PR makes this project stay consistent.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->