### PR TITLE
Add Gif bounce effect

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -163,11 +163,6 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
   @VisibleForTesting
   static class GifDecoderFactory {
     GifDecoder build(
-        GifDecoder.BitmapProvider provider, GifHeader header, ByteBuffer data, int sampleSize) {
-      return new StandardGifDecoder(provider, header, data, sampleSize, false);
-    }
-
-    GifDecoder build(
         GifDecoder.BitmapProvider provider,
         GifHeader header,
         ByteBuffer data,

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -110,7 +110,8 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
               : Bitmap.Config.ARGB_8888;
 
       int sampleSize = getSampleSize(header, width, height);
-      GifDecoder gifDecoder = gifDecoderFactory.build(provider, header, byteBuffer, sampleSize);
+      boolean bounce = options.get(GifOptions.BOUNCE);
+      GifDecoder gifDecoder = gifDecoderFactory.build(provider, header, byteBuffer, sampleSize, bounce);
       gifDecoder.setDefaultBitmapConfig(config);
       gifDecoder.advance();
       Bitmap firstFrame = gifDecoder.getNextFrame();
@@ -161,8 +162,8 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
   @VisibleForTesting
   static class GifDecoderFactory {
     GifDecoder build(
-        GifDecoder.BitmapProvider provider, GifHeader header, ByteBuffer data, int sampleSize) {
-      return new StandardGifDecoder(provider, header, data, sampleSize);
+        GifDecoder.BitmapProvider provider, GifHeader header, ByteBuffer data, int sampleSize, boolean bounce) {
+      return new StandardGifDecoder(provider, header, data, sampleSize, bounce);
     }
   }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -163,6 +163,11 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
   @VisibleForTesting
   static class GifDecoderFactory {
     GifDecoder build(
+        GifDecoder.BitmapProvider provider, GifHeader header, ByteBuffer data, int sampleSize) {
+      return new StandardGifDecoder(provider, header, data, sampleSize, false);
+    }
+
+    GifDecoder build(
         GifDecoder.BitmapProvider provider,
         GifHeader header,
         ByteBuffer data,

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoder.java
@@ -111,7 +111,8 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
 
       int sampleSize = getSampleSize(header, width, height);
       boolean bounce = options.get(GifOptions.BOUNCE);
-      GifDecoder gifDecoder = gifDecoderFactory.build(provider, header, byteBuffer, sampleSize, bounce);
+      GifDecoder gifDecoder =
+          gifDecoderFactory.build(provider, header, byteBuffer, sampleSize, bounce);
       gifDecoder.setDefaultBitmapConfig(config);
       gifDecoder.advance();
       Bitmap firstFrame = gifDecoder.getNextFrame();
@@ -162,7 +163,11 @@ public class ByteBufferGifDecoder implements ResourceDecoder<ByteBuffer, GifDraw
   @VisibleForTesting
   static class GifDecoderFactory {
     GifDecoder build(
-        GifDecoder.BitmapProvider provider, GifHeader header, ByteBuffer data, int sampleSize, boolean bounce) {
+        GifDecoder.BitmapProvider provider,
+        GifHeader header,
+        ByteBuffer data,
+        int sampleSize,
+        boolean bounce) {
       return new StandardGifDecoder(provider, header, data, sampleSize, bounce);
     }
   }

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifOptions.java
@@ -26,8 +26,8 @@ public final class GifOptions {
       Option.memory("com.bumptech.glide.load.resource.gif.GifOptions.DisableAnimation", false);
 
   /**
-   * If set to {@code true}, the GIF will play from the first frame to the last frame, and vice versa.
-   * Defaults to {@code false}
+   * If set to {@code true}, the GIF will play from the first frame to the last frame, and vice
+   * versa. Defaults to {@code false}
    */
   public static final Option<Boolean> BOUNCE =
       Option.memory("com.bumptech.glide.load.resource.gif.GifOptions.Bounce", false);

--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifOptions.java
@@ -25,6 +25,13 @@ public final class GifOptions {
   public static final Option<Boolean> DISABLE_ANIMATION =
       Option.memory("com.bumptech.glide.load.resource.gif.GifOptions.DisableAnimation", false);
 
+  /**
+   * If set to {@code true}, the GIF will play from the first frame to the last frame, and vice versa.
+   * Defaults to {@code false}
+   */
+  public static final Option<Boolean> BOUNCE =
+      Option.memory("com.bumptech.glide.load.resource.gif.GifOptions.Bounce", false);
+
   private GifOptions() {
     // Utility class.
   }

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
@@ -3,6 +3,7 @@ package com.bumptech.glide.load.resource.gif;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
+import static org.mockito.ArgumentMatchers.anyBoolean;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
@@ -60,7 +61,11 @@ public class ByteBufferGifDecoderTest {
     when(parserPool.obtain(isA(ByteBuffer.class))).thenReturn(parser);
 
     when(decoderFactory.build(
-            isA(GifDecoder.BitmapProvider.class), eq(gifHeader), isA(ByteBuffer.class), anyInt()))
+            isA(GifDecoder.BitmapProvider.class),
+            eq(gifHeader),
+            isA(ByteBuffer.class),
+            anyInt(),
+            anyBoolean()))
         .thenReturn(gifDecoder);
 
     List<ImageHeaderParser> parsers = new ArrayList<>();

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
@@ -60,7 +60,11 @@ public class ByteBufferGifDecoderTest {
     when(parserPool.obtain(isA(ByteBuffer.class))).thenReturn(parser);
 
     when(decoderFactory.build(
-            isA(GifDecoder.BitmapProvider.class), eq(gifHeader), isA(ByteBuffer.class), anyInt(), false))
+            isA(GifDecoder.BitmapProvider.class),
+            eq(gifHeader),
+            isA(ByteBuffer.class),
+            anyInt(),
+            false))
         .thenReturn(gifDecoder);
 
     List<ImageHeaderParser> parsers = new ArrayList<>();

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
@@ -60,7 +60,7 @@ public class ByteBufferGifDecoderTest {
     when(parserPool.obtain(isA(ByteBuffer.class))).thenReturn(parser);
 
     when(decoderFactory.build(
-            isA(GifDecoder.BitmapProvider.class), eq(gifHeader), isA(ByteBuffer.class), anyInt()))
+            isA(GifDecoder.BitmapProvider.class), eq(gifHeader), isA(ByteBuffer.class), anyInt(), false))
         .thenReturn(gifDecoder);
 
     List<ImageHeaderParser> parsers = new ArrayList<>();

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
@@ -60,11 +60,7 @@ public class ByteBufferGifDecoderTest {
     when(parserPool.obtain(isA(ByteBuffer.class))).thenReturn(parser);
 
     when(decoderFactory.build(
-            isA(GifDecoder.BitmapProvider.class),
-            eq(gifHeader),
-            isA(ByteBuffer.class),
-            anyInt(),
-            false))
+            isA(GifDecoder.BitmapProvider.class), eq(gifHeader), isA(ByteBuffer.class), anyInt()))
         .thenReturn(gifDecoder);
 
     List<ImageHeaderParser> parsers = new ArrayList<>();

--- a/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
+++ b/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/MainActivity.java
@@ -19,6 +19,8 @@ import androidx.recyclerview.widget.RecyclerView.ViewHolder;
 import com.bumptech.glide.ListPreloader;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader;
+import com.bumptech.glide.load.resource.gif.GifOptions;
+import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.ViewPreloadSizeProvider;
 import java.util.Collections;
@@ -136,9 +138,11 @@ public class MainActivity extends Activity implements Api.Monitor {
             }
           });
 
+      RequestOptions options = new RequestOptions().set(GifOptions.BOUNCE, true);
+
       // clearOnDetach let's us stop animating GifDrawables that RecyclerView hasn't yet recycled
       // but that are currently off screen.
-      requestBuilder.load(result).into(holder.gifView).clearOnDetach();
+      requestBuilder.load(result).apply(options).into(holder.gifView).clearOnDetach();
 
       preloadSizeProvider.setView(holder.gifView);
     }

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -124,6 +124,18 @@ public class StandardGifDecoder implements GifDecoder {
   // Public API.
   @SuppressWarnings("unused")
   public StandardGifDecoder(
+      @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData) {
+    this(provider, gifHeader, rawData, 1 /*sampleSize*/, false);
+  }
+
+  @SuppressWarnings("unused")
+  public StandardGifDecoder(
+      @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
+      int sampleSize) {
+    this(provider, gifHeader, rawData, sampleSize, false);
+  }
+
+  public StandardGifDecoder(
       @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
       int sampleSize, boolean bounce) {
     this(provider);

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -106,6 +106,8 @@ public class StandardGifDecoder implements GifDecoder {
   private int[] mainScratch;
 
   private int framePointer;
+  private boolean bounce = false;
+  private boolean frameBackward = false;
   private GifHeader header;
   private Bitmap previousImage;
   private boolean savePrevious;
@@ -130,6 +132,14 @@ public class StandardGifDecoder implements GifDecoder {
       @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
       int sampleSize) {
     this(provider);
+    setData(gifHeader, rawData, sampleSize);
+  }
+
+  public StandardGifDecoder(
+      @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
+      int sampleSize, boolean bounce) {
+    this(provider);
+    this.bounce = bounce;
     setData(gifHeader, rawData, sampleSize);
   }
 
@@ -162,7 +172,17 @@ public class StandardGifDecoder implements GifDecoder {
 
   @Override
   public void advance() {
-    framePointer = (framePointer + 1) % header.frameCount;
+    int nextPointer = bounce && frameBackward && framePointer > 0 ? -1 : 1;
+    framePointer = (framePointer + nextPointer) % header.frameCount;
+
+    if (bounce) {
+      if (framePointer == header.frameCount - 1) {
+        frameBackward = true;
+      }
+      if (framePointer == 0) {
+        frameBackward = false;
+      }
+    }
   }
 
   @Override

--- a/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
+++ b/third_party/gif_decoder/src/main/java/com/bumptech/glide/gifdecoder/StandardGifDecoder.java
@@ -124,18 +124,6 @@ public class StandardGifDecoder implements GifDecoder {
   // Public API.
   @SuppressWarnings("unused")
   public StandardGifDecoder(
-      @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData) {
-    this(provider, gifHeader, rawData, 1 /*sampleSize*/);
-  }
-
-  public StandardGifDecoder(
-      @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
-      int sampleSize) {
-    this(provider);
-    setData(gifHeader, rawData, sampleSize);
-  }
-
-  public StandardGifDecoder(
       @NonNull GifDecoder.BitmapProvider provider, GifHeader gifHeader, ByteBuffer rawData,
       int sampleSize, boolean bounce) {
     this(provider);


### PR DESCRIPTION
## Description
Added GifOptions.BOUNCE option, which, when activated, changes the GIF playback support.

GifOptions.BOUNCE = false (default, as before):
1st frame, 2nd frame, 3d frame, 1st frame, 2nd frame, 3d frame, etc.

GifOptions.BOUNCE = true
1st frame, 2nd frame, 3d frame, 2nd frame, 1st frame, etc.

## Motivation and Context
We are making an application where GIFs have to be played this way.
We currently have it done using transcoding GIFs (adding extra frames), unfortunately the solution is bad, because it uses 2x more bandwidth transfer

At first I just wanted to fork this library but it couldn't be possible because Glide is not compatible with JitPack...

@sjudd Please reply. Such a feature can be included in this library? Because I don't know if I should fix tests etc.
I know that such a feature is not very universal, but even TikTok does something similar.