### PR TITLE
[#3420, #3421] Fix load fails due to fitCenter computing zero-dimension bitmap size 

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
@@ -295,6 +295,21 @@ public class DownsamplerEmulatorTest {
         .run();
   }
 
+  // fixes issues #3420 #3421
+  @Test
+  public void calculateScaling_shouldNotProduceBitmapWithZeroDimension() throws IOException {
+    new Tester(DownsampleStrategy.FIT_CENTER)
+        .setTargetDimensions(100, 100)
+        .givenImageWithDimensionsOf(10, 1000, atAndAbove(KITKAT).with(formats(JPEG).expect(2, 100)))
+        .givenImageWithDimensionsOf(6, 1000, atAndAbove(KITKAT).with(formats(JPEG).expect(1, 100)))
+        .givenImageWithDimensionsOf(5, 1000, atAndAbove(KITKAT).with(formats(JPEG).expect(1, 100)))
+        .givenImageWithDimensionsOf(4, 1000, atAndAbove(KITKAT).with(allFormats().expect(1, 125)))
+        .givenImageWithDimensionsOf(2, 1000, atAndAbove(KITKAT).with(allFormats().expect(1, 250)))
+        .givenImageWithDimensionsOf(1, 1000, atAndAbove(KITKAT).with(allFormats().expect(1, 500)))
+        .givenImageWithDimensionsOf(1000, 2, atAndAbove(KITKAT).with(allFormats().expect(250, 1)))
+        .run();
+  }
+
   @Test
   public void calculateScaling_withFitCenter() throws IOException {
     new Tester(DownsampleStrategy.FIT_CENTER)

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
@@ -146,13 +146,24 @@ public abstract class DownsampleStrategy {
         float widthPercentage = requestedWidth / (float) sourceWidth;
         float heightPercentage = requestedHeight / (float) sourceHeight;
 
-        return Math.min(widthPercentage, heightPercentage);
+        return Math.min(
+            adjustToNotProduceZeroDimensionBitmap(heightPercentage, sourceWidth),
+            adjustToNotProduceZeroDimensionBitmap(widthPercentage, sourceHeight)
+        );
       } else {
         // Similar to AT_LEAST, but only require one dimension or the other to be >= requested
         // rather than both.
         int maxIntegerFactor =
             Math.max(sourceHeight / requestedHeight, sourceWidth / requestedWidth);
         return maxIntegerFactor == 0 ? 1f : 1f / Integer.highestOneBit(maxIntegerFactor);
+      }
+    }
+
+    private float adjustToNotProduceZeroDimensionBitmap(float dimensionPercentage, int sourceOtherDimension) {
+      if (dimensionPercentage * sourceOtherDimension <= 0.5f) {
+        return 0.5f / (float) sourceOtherDimension;
+      } else {
+        return dimensionPercentage;
       }
     }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
@@ -147,8 +147,8 @@ public abstract class DownsampleStrategy {
         float heightPercentage = requestedHeight / (float) sourceHeight;
 
         return Math.min(
-            adjustToNotProduceZeroDimensionBitmap(heightPercentage, sourceWidth),
-            adjustToNotProduceZeroDimensionBitmap(widthPercentage, sourceHeight)
+          adjustToNotProduceZeroDimensionBitmap(heightPercentage, sourceWidth),
+          adjustToNotProduceZeroDimensionBitmap(widthPercentage, sourceHeight)
         );
       } else {
         // Similar to AT_LEAST, but only require one dimension or the other to be >= requested
@@ -160,7 +160,7 @@ public abstract class DownsampleStrategy {
     }
 
     private float adjustToNotProduceZeroDimensionBitmap(float dimensionPercentage, int sourceOtherDimension) {
-      if (dimensionPercentage * sourceOtherDimension <= 0.5f) {
+      if (dimensionPercentage * sourceOtherDimension < 0.5f) {
         return 0.5f / (float) sourceOtherDimension;
       } else {
         return dimensionPercentage;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategy.java
@@ -147,9 +147,8 @@ public abstract class DownsampleStrategy {
         float heightPercentage = requestedHeight / (float) sourceHeight;
 
         return Math.min(
-          adjustToNotProduceZeroDimensionBitmap(heightPercentage, sourceWidth),
-          adjustToNotProduceZeroDimensionBitmap(widthPercentage, sourceHeight)
-        );
+            adjustToNotProduceZeroDimensionBitmap(heightPercentage, sourceWidth),
+            adjustToNotProduceZeroDimensionBitmap(widthPercentage, sourceHeight));
       } else {
         // Similar to AT_LEAST, but only require one dimension or the other to be >= requested
         // rather than both.
@@ -159,7 +158,8 @@ public abstract class DownsampleStrategy {
       }
     }
 
-    private float adjustToNotProduceZeroDimensionBitmap(float dimensionPercentage, int sourceOtherDimension) {
+    private float adjustToNotProduceZeroDimensionBitmap(
+        float dimensionPercentage, int sourceOtherDimension) {
       if (dimensionPercentage * sourceOtherDimension < 0.5f) {
         return 0.5f / (float) sourceOtherDimension;
       } else {

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -178,8 +178,8 @@ public final class TransformationUtils {
     // Take the floor of the target width/height, not round. If the matrix
     // passed into drawBitmap rounds differently, we want to slightly
     // overdraw, not underdraw, to avoid artifacts from bitmap reuse.
-    targetWidth = (int) (minPercentage * inBitmap.getWidth());
-    targetHeight = (int) (minPercentage * inBitmap.getHeight());
+    targetWidth = Math.max((int) (minPercentage * inBitmap.getWidth()), 1);
+    targetHeight = Math.max((int) (minPercentage * inBitmap.getHeight()), 1);
 
     Bitmap.Config config = getNonNullConfig(inBitmap);
     Bitmap toReuse = pool.get(targetWidth, targetHeight, config);

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
@@ -98,6 +98,21 @@ public class DownsampleStrategyTest {
     assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(100, 100, 100, 100)).isEqualTo(1f);
   }
 
+  // fixes issues #3420 #3421
+  @Test
+  public void testCenterInside_adjustScaleTypeToAvoidProducingBitmapWithZeroDimension() {
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(5, 1000, 100, 100))
+        .isEqualTo(0.1f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(4, 1000, 100, 100))
+        .isEqualTo(0.125f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2, 1000, 100, 100))
+        .isEqualTo(0.25f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(1, 1000, 100, 100))
+        .isEqualTo(0.5f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2000, 1, 100, 100))
+        .isEqualTo(0.5f);
+  }
+
   @Test
   public void testCenterOutside_scalesImageToFitAroundRequestedBounds() {
     assertThat(DownsampleStrategy.CENTER_OUTSIDE.getScaleFactor(100, 200, 300, 300))

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DownsampleStrategyTest.java
@@ -101,16 +101,11 @@ public class DownsampleStrategyTest {
   // fixes issues #3420 #3421
   @Test
   public void testCenterInside_adjustScaleTypeToAvoidProducingBitmapWithZeroDimension() {
-    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(5, 1000, 100, 100))
-        .isEqualTo(0.1f);
-    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(4, 1000, 100, 100))
-        .isEqualTo(0.125f);
-    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2, 1000, 100, 100))
-        .isEqualTo(0.25f);
-    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(1, 1000, 100, 100))
-        .isEqualTo(0.5f);
-    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2000, 1, 100, 100))
-        .isEqualTo(0.5f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(5, 1000, 100, 100)).isEqualTo(0.1f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(4, 1000, 100, 100)).isEqualTo(0.125f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2, 1000, 100, 100)).isEqualTo(0.25f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(1, 1000, 100, 100)).isEqualTo(0.5f);
+    assertThat(DownsampleStrategy.FIT_CENTER.getScaleFactor(2000, 1, 100, 100)).isEqualTo(0.5f);
   }
 
   @Test


### PR DESCRIPTION
## Description
Limit bitmap scaling in fitCenter to not produce zero-dimension bitmap and avoid error during image load. 
FIX: 
[- #3420 load fails due to fitCenter computing zero-dimension bitmap size ](https://github.com/bumptech/glide/issues/3420)
[- #3421 load fails: wrong rounding and division by zero with fitCenter() ](https://github.com/bumptech/glide/issues/3421)