### PR TITLE
Change default search to "airplanes" in Flickr's commons project.

### DIFF
--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrSearchActivity.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/FlickrSearchActivity.java
@@ -44,7 +44,7 @@ public class FlickrSearchActivity extends AppCompatActivity
     implements SearchView.OnQueryTextListener {
   private static final String TAG = "FlickrSearchActivity";
   private static final String STATE_QUERY = "state_search_string";
-  private static final Query DEFAULT_QUERY = new SearchQuery("kitten");
+  private static final Query DEFAULT_QUERY = new SearchQuery("airplane").requireSafeOverQuality();
 
   private final QueryListener queryListener = new QueryListener();
   private final Set<PhotoViewer> photoViewers = new HashSet<>();

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/api/Api.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/api/Api.java
@@ -26,6 +26,13 @@ public final class Api {
   private static final LruCache<UrlCacheKey, String> CACHED_URLS =
       new LruCache<>(MAX_URLS_TO_CACHE);
   private static final int MAX_ITEMS_PER_PAGE = 300;
+  /**
+   * Safe search is on by default in Flickr's API and/or enabling it isn't very effective. Instead
+   * we'll force all images to be from Flickr's commons project, which tends to be historic images.
+   * Those appear much safer than a standard search.
+   */
+  private static final String SAFE_SEARCH = "&is_commons=1";
+
   private static final String PER_PAGE = "&per_page=" + MAX_ITEMS_PER_PAGE;
 
   private static final SparseArray<String> EDGE_TO_SIZE_KEY =
@@ -114,8 +121,12 @@ public final class Api {
     return result;
   }
 
-  static String getSearchUrl(String text) {
-    return getUrlForMethod("flickr.photos.search") + "&text=" + text + PER_PAGE;
+  static String getSearchUrl(String text, boolean requireSafeOverQuality) {
+    return getUrlForMethod("flickr.photos.search")
+        + "&text="
+        + text
+        + PER_PAGE
+        + (requireSafeOverQuality ? SAFE_SEARCH : "");
   }
 
   static String getRecentUrl() {

--- a/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/api/SearchQuery.java
+++ b/samples/flickr/src/main/java/com/bumptech/glide/samples/flickr/api/SearchQuery.java
@@ -18,9 +18,19 @@ public final class SearchQuery implements Query {
       };
 
   private final String queryString;
+  private boolean requireSafeOverQuality;
 
   public SearchQuery(String queryString) {
     this.queryString = queryString;
+  }
+
+  /**
+   * Requires the search to be as safe as possible, evne if it substantially limits the results in a
+   * way that might otherwise be unexpected.
+   */
+  public SearchQuery requireSafeOverQuality() {
+    requireSafeOverQuality = true;
+    return this;
   }
 
   private SearchQuery(Parcel in) {
@@ -44,7 +54,7 @@ public final class SearchQuery implements Query {
 
   @Override
   public String getUrl() {
-    return Api.getSearchUrl(queryString);
+    return Api.getSearchUrl(queryString, requireSafeOverQuality);
   }
 
   @Override


### PR DESCRIPTION
This hopefully reduces the odds of users seeing nsfw images when they
simply open the sample app. We could extend this to all searches in the
future if required, but doing so might result in some perceived search
quality loss.
