### PR TITLE
ExternalCacheDiskCacheFactory is Deprecated

### DIFF
--- a/_posts/2017-03-14-configuration.md
+++ b/_posts/2017-03-14-configuration.md
@@ -180,7 +180,7 @@ Applications can change the location to external storage if the media they displ
 public class YourAppGlideModule extends AppGlideModule {
   @Override
   public void applyOptions(Context context, GlideBuilder builder) {
-    builder.setDiskCache(new ExternalCacheDiskCacheFactory(context));
+    builder.setDiskCache(new ExternalPreferredCacheDiskCacheFactory(context));
   }
 }
 ```


### PR DESCRIPTION

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->

According to the [documentation](https://bumptech.github.io/glide/javadocs/490/com/bumptech/glide/load/engine/cache/ExternalCacheDiskCacheFactory.html),  `ExternalCacheDiskCacheFactory` is Deprecated and we should use `ExternalPreferredCacheDiskCacheFactory` instead.

