### PR TITLE
feat:add a new preferred ColorSpace - NULL

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
+++ b/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.load;
 
 /**
- * Glide's supported handling of color spaces on Android O+, defaults to {@link #SRGB}.
+ * Glide's supported handling of color spaces on Android O+, defaults to null.
  *
  * <p>On Android O, Glide will always request SRGB and will ignore this option if set. A bug on
  * Android O prevents P3 images from being compressed correctly and can result in color distortion.

--- a/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
+++ b/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
@@ -29,8 +29,6 @@ package com.bumptech.glide.load;
  * Bitmap will actually use the requested color space.
  */
 public enum PreferredColorSpace {
-  /** don't set prefer ColorSpace. */
-  NULL,
   /** Prefers to decode images using {@link android.graphics.ColorSpace.Named#SRGB}. */
   SRGB,
   /** Prefers to decode images using {@link android.graphics.ColorSpace.Named#DISPLAY_P3}. */

--- a/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
+++ b/library/src/main/java/com/bumptech/glide/load/PreferredColorSpace.java
@@ -29,6 +29,8 @@ package com.bumptech.glide.load;
  * Bitmap will actually use the requested color space.
  */
 public enum PreferredColorSpace {
+  /** don't set prefer ColorSpace. */
+  NULL,
   /** Prefers to decode images using {@link android.graphics.ColorSpace.Named#SRGB}. */
   SRGB,
   /** Prefers to decode images using {@link android.graphics.ColorSpace.Named#DISPLAY_P3}. */

--- a/library/src/main/java/com/bumptech/glide/load/resource/ImageDecoderResourceDecoder.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/ImageDecoderResourceDecoder.java
@@ -129,17 +129,18 @@ public abstract class ImageDecoderResourceDecoder<T> implements ResourceDecoder<
             }
 
             decoder.setTargetSize(resizeWidth, resizeHeight);
-
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-              boolean isP3Eligible =
-                  preferredColorSpace == PreferredColorSpace.DISPLAY_P3
-                      && info.getColorSpace() != null
-                      && info.getColorSpace().isWideGamut();
-              decoder.setTargetColorSpace(
-                  ColorSpace.get(
-                      isP3Eligible ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB));
-            } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-              decoder.setTargetColorSpace(ColorSpace.get(ColorSpace.Named.SRGB));
+            if (preferredColorSpace != null) {
+              if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+                boolean isP3Eligible =
+                    preferredColorSpace == PreferredColorSpace.DISPLAY_P3
+                        && info.getColorSpace() != null
+                        && info.getColorSpace().isWideGamut();
+                decoder.setTargetColorSpace(
+                    ColorSpace.get(
+                        isP3Eligible ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB));
+              } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+                decoder.setTargetColorSpace(ColorSpace.get(ColorSpace.Named.SRGB));
+              }
             }
           }
         });

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -376,7 +376,7 @@ public final class Downsampler {
       }
     }
 
-    if(preferredColorSpace != PreferredColorSpace.NULL) {
+    if (preferredColorSpace != PreferredColorSpace.NULL) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         boolean isP3Eligible =
             preferredColorSpace == PreferredColorSpace.DISPLAY_P3

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -62,9 +62,7 @@ public final class Downsampler {
    * limitations.
    */
   public static final Option<PreferredColorSpace> PREFERRED_COLOR_SPACE =
-      Option.memory(
-          "com.bumptech.glide.load.resource.bitmap.Downsampler.PreferredColorSpace",
-          PreferredColorSpace.SRGB);
+      Option.memory("com.bumptech.glide.load.resource.bitmap.Downsampler.PreferredColorSpace");
   /**
    * Indicates the {@link com.bumptech.glide.load.resource.bitmap.DownsampleStrategy} option that
    * will be used to calculate the sample size to use to downsample an image given the original and
@@ -376,7 +374,7 @@ public final class Downsampler {
       }
     }
 
-    if (preferredColorSpace != PreferredColorSpace.NULL) {
+    if (preferredColorSpace != null) {
       if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
         boolean isP3Eligible =
             preferredColorSpace == PreferredColorSpace.DISPLAY_P3

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -376,15 +376,17 @@ public final class Downsampler {
       }
     }
 
-    if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
-      boolean isP3Eligible =
-          preferredColorSpace == PreferredColorSpace.DISPLAY_P3
-              && options.outColorSpace != null
-              && options.outColorSpace.isWideGamut();
-      options.inPreferredColorSpace =
-          ColorSpace.get(isP3Eligible ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB);
-    } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
-      options.inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB);
+    if(preferredColorSpace != PreferredColorSpace.NULL) {
+      if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
+        boolean isP3Eligible =
+            preferredColorSpace == PreferredColorSpace.DISPLAY_P3
+                && options.outColorSpace != null
+                && options.outColorSpace.isWideGamut();
+        options.inPreferredColorSpace =
+            ColorSpace.get(isP3Eligible ? ColorSpace.Named.DISPLAY_P3 : ColorSpace.Named.SRGB);
+      } else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.O) {
+        options.inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB);
+      }
     }
 
     Bitmap downsampled = decodeStream(imageReader, options, callbacks, bitmapPool);


### PR DESCRIPTION
This pr is primarily made in order to fix a compatibility issue. I found that on some phones, for example OnePlus 7t pro, some pictures loaded with Glide will be a bit dark shadow, while using BitmapFractory is normal. I found that Glide will default to setting a value for the inPreferredColorSpace property, it seems that some mobile phone manufacturers made some modifications here caused the problem, so I add a NULL option to avoid the problem