### PR TITLE
Documentation: Remove jcenter reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ Or use Gradle:
 ```gradle
 repositories {
   google()
-  jcenter()
+  mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
## Description
- Documentation update. Replace jcenter with mavenCentral

## Motivation and Context
- jcenter is being shutdown and has been deprecated in AGP
- fixes #4498 