### PR TITLE
TranscoderRegistry.getTranscodeClasses method should return registered transcode classes

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistry.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/transcode/TranscoderRegistry.java
@@ -60,6 +60,7 @@ public class TranscoderRegistry {
   }
 
   @NonNull
+  @SuppressWarnings("unchecked")
   public synchronized <Z, R> List<Class<R>> getTranscodeClasses(
       @NonNull Class<Z> resourceClass, @NonNull Class<R> transcodeClass) {
     List<Class<R>> transcodeClasses = new ArrayList<>();
@@ -70,8 +71,9 @@ public class TranscoderRegistry {
     }
 
     for (Entry<?, ?> entry : transcoders) {
-      if (entry.handles(resourceClass, transcodeClass)) {
-        transcodeClasses.add(transcodeClass);
+      if (entry.handles(resourceClass, transcodeClass)
+          && !transcodeClasses.contains((Class<R>) entry.toClass)) {
+        transcodeClasses.add((Class<R>) entry.toClass);
       }
     }
 


### PR DESCRIPTION
## Description
The original `TranscoderRegistry.getTranscodeClasses` method always add the argument `transcode` to the result list `transcodeClasses`. For the purpose of this method, it should return the registered transcode classes, as `ResourceDecoderRegistry.getResourceClasses` do.

## Motivation and Context
This bug has not caused an error because element in the result of `getTranscodeClasses` has not been used yet.