### PR TITLE
Update example URL README.md from HTTP to HTTPS

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Simple use cases will look something like this:
   ...
   ImageView imageView = (ImageView) findViewById(R.id.my_image_view);
 
-  Glide.with(this).load("http://goo.gl/gEgYUd").into(imageView);
+  Glide.with(this).load("https://goo.gl/gEgYUd").into(imageView);
 }
 
 // For a simple image list:


### PR DESCRIPTION
## Description
Updated the example URL in the README.md from HTTP to HTTPS. Android by default does not allow HTTP connections anymore unless `android:usesCleartextTraffic="true"` is set in the manifest.

Resolves issue #4631 

## Motivation and Context
Updating the README.md to avoid confusion for users of Glide for a non-Glide related issue. 