### PR TITLE
avif: Update the depdendency version to 4.13.1

### DIFF
--- a/_posts/2022-01-26-avif.md
+++ b/_posts/2022-01-26-avif.md
@@ -20,7 +20,7 @@ First make sure you've followed the [setup instructions][2] for Applications.
 Then add a Gradle dependency on the AVIF integration library:
 
 ```groovy
-compile "com.github.bumptech.glide:avif-integration:4.13.0"
+compile "com.github.bumptech.glide:avif-integration:4.13.1"
 ```
 
 Adding a Gradle dependency on the AVIF integration library will cause Glide to start automatically using the bundled AVIF decoder for decoding and rendering AVIF images.


### PR DESCRIPTION
4.13.0 was missing an annotationProcessor depdendency causing it
to not include the AvifGlideModule correctly (Issue #4751).

4.13.1 fixes that issue and should be the preferred version
for public documentation.