### PR TITLE
Update gradle wrapper, fix some deprecations

### DIFF
--- a/annotation/compiler/build.gradle
+++ b/annotation/compiler/build.gradle
@@ -32,8 +32,8 @@ def repackagedJar = file("${packagingFolder}/repackaged.jar")
 def proguardedJar = file("${packagingFolder}/proguarded.jar")
 
 task compiledJar(type: Jar, dependsOn: classes) {
-    destinationDir = packagingFolder
-    archiveName = 'compiled.jar'
+    destinationDirectory.set(packagingFolder)
+    archiveFileName.set('compiled.jar')
     from sourceSets.main.output
 }
 

--- a/annotation/compiler/test/build.gradle
+++ b/annotation/compiler/test/build.gradle
@@ -27,11 +27,11 @@ afterEvaluate {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
     }
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -4,7 +4,7 @@ plugins {
 }
 
 android {
-    compileSdkVersion 30
+    compileSdk 30
     buildToolsVersion "30.0.3"
 
     compileOptions {
@@ -13,8 +13,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion 19
-        targetSdkVersion 30
+        minSdk 19
+        targetSdk 30
         versionCode 1
         versionName "1.0"
 

--- a/build.gradle
+++ b/build.gradle
@@ -134,7 +134,7 @@ subprojects { project ->
         if (project.hasProperty("android")
                 && project.name != 'pmd' ) {
             android {
-                lintOptions {
+                lint {
                     warningsAsErrors true
                     quiet true
                     // Caught by the violations plugin.

--- a/build.gradle
+++ b/build.gradle
@@ -115,8 +115,8 @@ subprojects { project ->
     apply plugin: "se.bjurr.violations.violations-gradle-plugin"
 
     task violations(type: ViolationsTask) {
-        minSeverity 'INFO'
-        detailLevel 'VERBOSE'
+        minSeverity = 'INFO'
+        detailLevel = 'VERBOSE'
         maxViolations = 0
         diffMaxViolations = 0
 

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -115,7 +115,7 @@ javadocJarTask.dependsOn(javadocTask)
 jar {
     from files(
             getAndroidLibraryVariantsForJavadoc().collect { LibraryVariant variant ->
-                variant.getJavaCompileProvider().get().destinationDir
+                variant.getJavaCompileProvider().get().destinationDirectory
             }
     )
     exclude "**/R.class"

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -35,8 +35,8 @@ def getAndroidSdkDirectory() {
     project(':library').android.sdkDirectory
 }
 
-def getAndroidCompileSdkVersion() {
-    project(':library').android.compileSdkVersion
+def getAndroidCompileSdk() {
+    project(':library').android.compileSdk
 }
 
 def getAndroidProjectsForJavadoc() {
@@ -58,7 +58,7 @@ def getSourceFilesForJavadoc() {
 }
 
 def getAndroidJar() {
-    "${getAndroidSdkDirectory()}/platforms/${getAndroidCompileSdkVersion()}/android.jar"
+    "${getAndroidSdkDirectory()}/platforms/${getAndroidCompileSdk()}/android.jar"
 }
 
 project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -26,12 +26,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId 'com.bumptech.glide.instrumentation'
-        minSdkVersion 16 as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk 16 as int
+        targetSdk TARGET_SDK_VERSION as int
         versionCode 1
         versionName '1.0'
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"

--- a/integration/avif/build.gradle
+++ b/integration/avif/build.gradle
@@ -9,11 +9,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/integration/concurrent/build.gradle
+++ b/integration/concurrent/build.gradle
@@ -14,11 +14,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName = VERSION_NAME as String
     }

--- a/integration/cronet/build.gradle
+++ b/integration/cronet/build.gradle
@@ -15,11 +15,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion 16 as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk 16 as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/integration/gifencoder/build.gradle
+++ b/integration/gifencoder/build.gradle
@@ -14,7 +14,7 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     sourceSets {
         main {
@@ -23,8 +23,8 @@ android {
     }
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName = VERSION_NAME as String
     }

--- a/integration/okhttp/build.gradle
+++ b/integration/okhttp/build.gradle
@@ -9,11 +9,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/integration/okhttp3/build.gradle
+++ b/integration/okhttp3/build.gradle
@@ -9,11 +9,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/integration/recyclerview/build.gradle
+++ b/integration/recyclerview/build.gradle
@@ -7,11 +7,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/integration/volley/build.gradle
+++ b/integration/volley/build.gradle
@@ -18,11 +18,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName VERSION_NAME as String
     }

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -54,11 +54,11 @@ if (project.plugins.hasPlugin('net.ltgt.errorprone')) {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
         consumerProguardFiles 'proguard-rules.txt'
     }

--- a/library/pmd/build.gradle
+++ b/library/pmd/build.gradle
@@ -32,8 +32,8 @@ tasks.create('pmd', Pmd) {
     ignoreFailures = true
 
     reports {
-        xml.enabled = true
-        html.enabled = false
+        xml.required.set(true)
+        html.required.set(false)
     }
 }
 

--- a/library/test/build.gradle
+++ b/library/test/build.gradle
@@ -38,11 +38,11 @@ android.testOptions.unitTests.all { Test testTask ->
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
     }
 

--- a/mocks/build.gradle
+++ b/mocks/build.gradle
@@ -8,11 +8,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionName = VERSION_NAME as String
     }

--- a/samples/contacturi/build.gradle
+++ b/samples/contacturi/build.gradle
@@ -7,12 +7,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.contacturi'
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionCode 1
         versionName '1.0'

--- a/samples/flickr/build.gradle
+++ b/samples/flickr/build.gradle
@@ -13,12 +13,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.flickr'
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionCode 1
         versionName '1.0'

--- a/samples/gallery/build.gradle
+++ b/samples/gallery/build.gradle
@@ -28,12 +28,12 @@ kotlin {
 }
 
 android {
-    compileSdkVersion 32
+    compileSdk 32
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.gallery'
-        minSdkVersion 29
-        targetSdkVersion 32
+        minSdk 29
+        targetSdk 32
         versionCode 1
         versionName '1.0'
     }

--- a/samples/giphy/build.gradle
+++ b/samples/giphy/build.gradle
@@ -12,12 +12,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.giphy'
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionCode 1
         versionName '1.0'
     }

--- a/samples/imgur/build.gradle
+++ b/samples/imgur/build.gradle
@@ -1,12 +1,12 @@
 apply plugin: 'com.android.application'
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId "com.bumptech.glide.samples.imgur"
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionCode 1
         versionName "1.0"
 

--- a/samples/svg/build.gradle
+++ b/samples/svg/build.gradle
@@ -8,12 +8,12 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
         applicationId 'com.bumptech.glide.samples.svg'
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
 
         versionCode 1
         versionName '1.0'

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -175,22 +175,22 @@ afterEvaluate { project ->
                     project.clean.dependsOn(cleanJavadocTask)
 
                     task androidJavadocsJar(type: Jar, dependsOn: androidJavadocs) {
-                        classifier = 'javadoc'
+                        archiveClassifier.set('javadoc')
                         from androidJavadocs.destinationDir
-                        baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
+                        archiveBaseName.set("${JAR_PREFIX}${project.name}${JAR_POSTFIX}")
                     }
 
                     task androidSourcesJar(type: Jar) {
-                        classifier = 'sources'
+                        archiveClassifier.set('sources')
                         from project.android.sourceSets.main.java.source
-                        baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
+                        archiveBaseName.set("${JAR_PREFIX}${project.name}${JAR_POSTFIX}")
                     }
 
                     task androidLibraryJar(type: Jar, dependsOn: compileDebugJavaWithJavac /* == variant.javaCompile */) {
                         from compileDebugJavaWithJavac.destinationDir
                         exclude '**/R.class'
                         exclude '**/R$*.class'
-                        baseName "${JAR_PREFIX}${project.name}${JAR_POSTFIX}"
+                        archiveBaseName.set("${JAR_PREFIX}${project.name}${JAR_POSTFIX}")
                     }
 
                     artifact androidLibraryJar
@@ -203,12 +203,12 @@ afterEvaluate { project ->
                     artifact project.tasks.bundleDebugAar
                 } else if (project.plugins.hasPlugin('java')) {
                     task sourcesJar(type: Jar, dependsOn: classes) {
-                        classifier = 'sources'
+                        archiveClassifier.set('sources')
                         from sourceSets.main.allSource
                     }
 
                     task javadocsJar(type: Jar, dependsOn: javadoc) {
-                        classifier = 'javadoc'
+                        archiveClassifier.set('javadoc')
                         from javadoc.destinationDir
                     }
 

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -150,7 +150,7 @@ afterEvaluate { project ->
 
                     def getAndroidSdkDirectory = project.android.sdkDirectory
 
-                    def getAndroidJar = "${getAndroidSdkDirectory}/platforms/${project.android.compileSdkVersion}/android.jar"
+                    def getAndroidJar = "${getAndroidSdkDirectory}/platforms/${project.android.compileSdk}/android.jar"
 
                     task androidJavadocs(type: Javadoc, dependsOn: assembleDebug) {
                         source = variants.collect { it.getJavaCompileProvider().get().source }

--- a/testutil/build.gradle
+++ b/testutil/build.gradle
@@ -9,11 +9,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
     }
 

--- a/third_party/disklrucache/build.gradle
+++ b/third_party/disklrucache/build.gradle
@@ -14,11 +14,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
         versionName VERSION_NAME as String
         consumerProguardFiles 'proguard-rules.txt'
     }

--- a/third_party/gif_decoder/build.gradle
+++ b/third_party/gif_decoder/build.gradle
@@ -12,11 +12,11 @@ dependencies {
 }
 
 android {
-    compileSdkVersion COMPILE_SDK_VERSION as int
+    compileSdk COMPILE_SDK_VERSION as int
 
     defaultConfig {
-        minSdkVersion MIN_SDK_VERSION as int
-        targetSdkVersion TARGET_SDK_VERSION as int
+        minSdk MIN_SDK_VERSION as int
+        targetSdk TARGET_SDK_VERSION as int
     }
 }
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description

### 1st commit
- Updated gradle wrapper to 7.3.3 using Git Bash.

The command I ran was `./gradlew wrapper --gradle-version 7.3.3 --distribution-type bin` in Git Bash. You can independently verify the integrity of these files by running this command on your own machine and then using a file comparison tool (like WinMerge for example) to compare the results between this PR and your machine.

The updated JAR's integrity can be verified through this as well: https://gradle.org/release-checksums/

### 2nd commit
- The second commit fixes some gradle script deprecations and access violations.

### 3rd commit
- The third commit fixes some Android Gradle Plugin deprecations.

## Motivation and Context
Some things are deprecated, so I'm fixing them :)
