### PR TITLE
Use android.compileSdkVersion instead of android.compileSdk

### DIFF
--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -35,8 +35,8 @@ def getAndroidSdkDirectory() {
     project(':library').android.sdkDirectory
 }
 
-def getAndroidCompileSdk() {
-    project(':library').android.compileSdk
+def getAndroidCompileSdkVersion() {
+    project(':library').android.compileSdkVersion
 }
 
 def getAndroidProjectsForJavadoc() {
@@ -58,7 +58,7 @@ def getSourceFilesForJavadoc() {
 }
 
 def getAndroidJar() {
-    "${getAndroidSdkDirectory()}/platforms/${getAndroidCompileSdk()}/android.jar"
+    "${getAndroidSdkDirectory()}/platforms/${getAndroidCompileSdkVersion()}/android.jar"
 }
 
 project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"

--- a/scripts/ci_unit.sh
+++ b/scripts/ci_unit.sh
@@ -11,4 +11,5 @@ set -e
   -x :samples:svg:build \
   :instrumentation:assembleAndroidTest \
   :benchmark:assembleAndroidTest \
+  :glide:debugJavadoc \
   --parallel

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -146,7 +146,7 @@ afterEvaluate { project ->
 
                     def getAndroidSdkDirectory = project.android.sdkDirectory
 
-                    def getAndroidJar = "${getAndroidSdkDirectory}/platforms/${project.android.compileSdk}/android.jar"
+                    def getAndroidJar = "${getAndroidSdkDirectory}/platforms/${project.android.compileSdkVersion}/android.jar"
 
                     task androidJavadocs(type: Javadoc, dependsOn: assembleDebug) {
                         source = variants.collect { it.getJavaCompileProvider().get().source }


### PR DESCRIPTION
While you can set the sdk integer with compileSdk, you don't appear to
be able to read it from the project using that shortcut. Instead reads
still need to be done via the not yet deprecated compileSdkVersion.

Fixes a regression introduced in
https://github.com/bumptech/glide/pull/4828. I'm not clear on why the
presubmits did not catch the issue then, but started to after that cl.
I've explicitly started running the failing tasks in the hopes of
avoiding this in the future.
