### PR TITLE
fixed placeholders load drawable resources with wrong context

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableDecoderCompat.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableDecoderCompat.java
@@ -4,6 +4,8 @@ import android.content.Context;
 import android.content.res.Resources;
 import android.content.res.Resources.Theme;
 import android.graphics.drawable.Drawable;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
 import androidx.annotation.DrawableRes;
 import androidx.annotation.Nullable;
 import androidx.appcompat.content.res.AppCompatResources;
@@ -65,13 +67,27 @@ public final class DrawableDecoderCompat {
 
   private static Drawable loadDrawableV7(
       Context context, @DrawableRes int id, @Nullable Theme theme) {
-    Context resourceContext = theme != null ? new ContextThemeWrapper(context, theme) : context;
+    Context resourceContext;
+    if (theme != null) {
+      ContextThemeWrapper contextThemeWrapper = new ContextThemeWrapper(context, theme);
+      if (VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+        contextThemeWrapper.applyOverrideConfiguration(theme.getResources().getConfiguration());
+      }
+      resourceContext = contextThemeWrapper;
+    } else {
+      resourceContext = context;
+    }
     return AppCompatResources.getDrawable(resourceContext, id);
   }
 
   private static Drawable loadDrawableV4(
       Context context, @DrawableRes int id, @Nullable Theme theme) {
-    Resources resources = context.getResources();
+    Resources resources;
+    if (theme != null && VERSION.SDK_INT >= VERSION_CODES.LOLLIPOP) {
+      resources = theme.getResources();
+    } else {
+      resources = context.getResources();
+    }
     return ResourcesCompat.getDrawable(resources, id, theme);
   }
 }


### PR DESCRIPTION
…t mode

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

issues #3778 #3751

fix unable to find night resources when using night mode

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

when using 'AppCompatDelegate.seDefaultNightMode' change theme mode, glide will not use the right resources.

in ContextThemeWrapper if mOverrideConfiguration is null it will get resource by 'mBase.getResources()', in 'DrawableDecoderCompat' mBase is applicationContext, should use 'applyOverrideConfiguration' to get resource from current theme.

ResourcesCompat.getDrawable() resource should use 'theme.getResources' rather than 'context.getResources' because context is  applicationContext


<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->