### PR TITLE
Use KSP in the gallery sample, remove references to generated API.

### DIFF
--- a/samples/gallery/build.gradle
+++ b/samples/gallery/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-kapt'
 apply plugin: "org.jetbrains.kotlin.plugin.parcelize"
+apply plugin: 'com.google.devtools.ksp'
 
 dependencies {
     implementation project(':library')
@@ -18,7 +18,7 @@ dependencies {
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-android:$JETBRAINS_KOTLINX_COROUTINES_VERSION"
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$JETBRAINS_KOTLIN_VERSION"
 
-    kapt project(':annotation:compiler')
+    ksp project(':annotation:ksp')
 }
 
 kotlin {

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/GalleryModule.kt
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/GalleryModule.kt
@@ -1,8 +1,15 @@
 package com.bumptech.glide.samples.gallery
 
+import android.content.Context
+import com.bumptech.glide.GlideBuilder
 import com.bumptech.glide.annotation.GlideModule
 import com.bumptech.glide.module.AppGlideModule
 
 /** Ensures that Glide's generated API is created for the Gallery sample.  */
 @GlideModule
-class GalleryModule : AppGlideModule()
+class GalleryModule : AppGlideModule() {
+  override fun applyOptions(context: Context, builder: GlideBuilder) {
+    super.applyOptions(context, builder)
+    builder.setIsActiveResourceRetentionAllowed(true)
+  }
+}

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/HorizontalGalleryFragment.kt
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/HorizontalGalleryFragment.kt
@@ -11,6 +11,7 @@ import androidx.lifecycle.lifecycleScope
 import androidx.lifecycle.repeatOnLifecycle
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.GridLayoutManager
+import com.bumptech.glide.Glide
 import com.bumptech.glide.integration.recyclerview.RecyclerViewPreloader
 import kotlinx.coroutines.launch
 
@@ -40,7 +41,7 @@ class HorizontalGalleryFragment : Fragment() {
     recyclerView.layoutManager = layoutManager
     recyclerView.setHasFixedSize(true)
 
-    val glideRequests = GlideApp.with(this)
+    val glideRequests = Glide.with(this)
     adapter = RecyclerAdapter(requireContext(), glideRequests)
     val preloader = RecyclerViewPreloader(glideRequests, adapter, adapter, 3)
     recyclerView.addOnScrollListener(preloader)

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.kt
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/MainActivity.kt
@@ -8,6 +8,7 @@ import androidx.core.app.ActivityCompat
 import androidx.core.content.ContextCompat
 import androidx.fragment.app.Fragment
 import androidx.fragment.app.FragmentActivity
+import com.bumptech.glide.Glide
 import com.bumptech.glide.MemoryCategory
 
 /** Displays a [HorizontalGalleryFragment].  */
@@ -15,7 +16,7 @@ class MainActivity : FragmentActivity() {
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
     setContentView(R.layout.main_activity)
-    GlideApp.get(this).setMemoryCategory(MemoryCategory.HIGH)
+    Glide.get(this).setMemoryCategory(MemoryCategory.HIGH)
     if (ContextCompat.checkSelfPermission(this, Manifest.permission.READ_EXTERNAL_STORAGE)
       != PackageManager.PERMISSION_GRANTED
     ) {

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/RecyclerAdapter.kt
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/RecyclerAdapter.kt
@@ -15,6 +15,7 @@ import com.bumptech.glide.samples.gallery.RecyclerAdapter.ListViewHolder
 import com.bumptech.glide.ListPreloader.PreloadSizeProvider
 import com.bumptech.glide.ListPreloader.PreloadModelProvider
 import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.RequestManager
 import com.bumptech.glide.load.Key
 import com.bumptech.glide.signature.MediaStoreSignature
 import com.bumptech.glide.util.Preconditions
@@ -22,12 +23,12 @@ import com.bumptech.glide.util.Preconditions
 /** Displays [com.bumptech.glide.samples.gallery.MediaStoreData] in a recycler view.  */
 internal class RecyclerAdapter(
   context: Context,
-  glideRequests: GlideRequests,
+  glideRequests: RequestManager,
 ) : RecyclerView.Adapter<ListViewHolder?>(), PreloadSizeProvider<MediaStoreData?>,
     PreloadModelProvider<MediaStoreData?> {
   private var data: List<MediaStoreData> = emptyList()
   private val screenWidth: Int
-  private val requestBuilder: GlideRequest<Drawable>
+  private val requestBuilder: RequestBuilder<Drawable>
   private var actualDimensions: IntArray? = null
 
   override fun onCreateViewHolder(viewGroup: ViewGroup, viewType: Int): ListViewHolder {


### PR DESCRIPTION
This helps verify that the ksp process works and shows the changes required when the generated API is not available