### PR TITLE
Deduplicate status and cleared calls in ErrorRequestCoordinator

### DIFF
--- a/library/test/src/test/java/com/bumptech/glide/request/ErrorRequestCoordinatorTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/ErrorRequestCoordinatorTest.java
@@ -235,11 +235,6 @@ public class ErrorRequestCoordinatorTest {
   }
 
   @Test
-  public void canSetImage_withError_andNullParent_andNotFailedPrimary_returnsFalse() {
-    assertThat(coordinator.canSetImage(error)).isFalse();
-  }
-
-  @Test
   public void canSetImage_withNotFailedPrimary_parentCanSetImage_returnsTrue() {
     coordinator = newCoordinator(parent);
     coordinator.setRequests(primary, error);
@@ -309,8 +304,16 @@ public class ErrorRequestCoordinatorTest {
   }
 
   @Test
-  public void canNotifyStatusChanged_withError_failedPrimary_nullParent_returnsTrue() {
+  public void canNotifyStatusChanged_withErrorRequest_failedPrimary_nullParent_errorIsNotFailed_returnsFalse() {
     coordinator.onRequestFailed(primary);
+
+    assertThat(coordinator.canNotifyStatusChanged(error)).isFalse();
+  }
+
+  @Test
+  public void canNotifyStatusChanged_withErrorRequest_failedPrimary_nullParent_failedError_returnsTrue() {
+    coordinator.onRequestFailed(primary);
+    coordinator.onRequestFailed(error);
 
     assertThat(coordinator.canNotifyStatusChanged(error)).isTrue();
   }
@@ -325,14 +328,26 @@ public class ErrorRequestCoordinatorTest {
   }
 
   @Test
-  public void canNotifyStatusChanged_withError_failedPrimary_nonNullParentCanNotify_returnsTrue() {
+  public void canNotifyStatusChanged_withError_failedPrimary_notFailedError_nonNullParentCanNotify_returnsFalse() {
     coordinator = newCoordinator(parent);
     coordinator.setRequests(primary, error);
     coordinator.onRequestFailed(primary);
     when(parent.canNotifyStatusChanged(coordinator)).thenReturn(true);
 
-    assertThat(coordinator.canNotifyStatusChanged(primary)).isTrue();
+    assertThat(coordinator.canNotifyStatusChanged(error)).isFalse();
   }
+
+  @Test
+  public void canNotifyStatusChanged_withError_failedPrimary_failedError_nonNullParentCanNotify_returnsTrue() {
+    coordinator = newCoordinator(parent);
+    coordinator.setRequests(primary, error);
+    coordinator.onRequestFailed(primary);
+    when(parent.canNotifyStatusChanged(coordinator)).thenReturn(true);
+    coordinator.onRequestFailed(error);
+
+    assertThat(coordinator.canNotifyStatusChanged(error)).isTrue();
+  }
+
 
   @Test
   public void isAnyResourceSet_primaryNotSet_nullParent_returnsFalse() {
@@ -532,9 +547,19 @@ public class ErrorRequestCoordinatorTest {
   }
 
   @Test
-  public void canNotifyCleared_errorRequest_primaryFailed_nullParent_returnsTrue() {
+  public void canNotifyCleared_errorRequest_primaryFailed_nullParent_returnsFalse() {
     coordinator.onRequestFailed(primary);
-    assertThat(coordinator.canNotifyCleared(error)).isTrue();
+    assertThat(coordinator.canNotifyCleared(error)).isFalse();
+  }
+
+  @Test
+  public void canNotifyCleared_primaryRequest_primaryFailed_nonNullParentCanNotNotify_returnsFalse() {
+    coordinator = newCoordinator(parent);
+    coordinator.setRequests(primary, error);
+    when(parent.canNotifyCleared(coordinator)).thenReturn(false);
+    coordinator.onRequestFailed(primary);
+
+    assertThat(coordinator.canNotifyCleared(primary)).isFalse();
   }
 
   @Test
@@ -548,13 +573,23 @@ public class ErrorRequestCoordinatorTest {
   }
 
   @Test
-  public void canNotifyCleared_errorRequest_primaryFailed_nonNullParentCanNotify_returnsTrue() {
+  public void canNotifyCleared_errorRequest_primaryFailed_nonNullParentCanNotify_returnsFalse() {
     coordinator = newCoordinator(parent);
     coordinator.setRequests(primary, error);
     when(parent.canNotifyCleared(coordinator)).thenReturn(true);
     coordinator.onRequestFailed(primary);
 
-    assertThat(coordinator.canNotifyCleared(error)).isTrue();
+    assertThat(coordinator.canNotifyCleared(error)).isFalse();
+  }
+
+  @Test
+  public void canNotifyCleared_primaryRequest_primaryFailed_nonNullParentCanNotify_returnsTrue() {
+    coordinator = newCoordinator(parent);
+    coordinator.setRequests(primary, error);
+    when(parent.canNotifyCleared(coordinator)).thenReturn(true);
+    coordinator.onRequestFailed(primary);
+
+    assertThat(coordinator.canNotifyCleared(primary)).isTrue();
   }
 
   private static ErrorRequestCoordinator newCoordinator() {


### PR DESCRIPTION
Previously we'd let both the the primary and the error request notify when the status of a request changes (ie cleared -> running). That would lead to duplicate running calls, once for the primary request, then when it failed, again for the error request.

This change also relaxes the requirements for canSetImage to be either request because we only ever run one at a time. It also simplifies canNotifyCleared to just the primary. For notifyCleared we just need one or the other request to do it, it doesn't particularly matter which one. There's no defined agreement over whether the primary's placehodler will be used, or the error if both have placeholders. Using the primary's always seems more coherent.