### PR TITLE
Add an internal RequestBuilder flow for async sizes.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,7 @@ apply plugin: 'binary-compatibility-validator'
 
 apiValidation {
     ignoredProjects += ["ksp", "test", "gallery"]
+    nonPublicMarkers += ["com.bumptech.glide.integration.ktx.InternalGlideApi"]
 }
 
 // See http://blog.joda.org/2014/02/turning-off-doclint-in-jdk-8-javadoc.html.

--- a/integration/ktx/api/ktx.api
+++ b/integration/ktx/api/ktx.api
@@ -2,12 +2,16 @@ public abstract interface annotation class com/bumptech/glide/integration/ktx/Ex
 }
 
 public final class com/bumptech/glide/integration/ktx/FlowsKt {
+	public static final fun flow (Lcom/bumptech/glide/RequestBuilder;)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flow (Lcom/bumptech/glide/RequestBuilder;I)Lkotlinx/coroutines/flow/Flow;
 	public static final fun flow (Lcom/bumptech/glide/RequestBuilder;II)Lkotlinx/coroutines/flow/Flow;
 }
 
 public abstract class com/bumptech/glide/integration/ktx/GlideFlowInstant {
 	public abstract fun getStatus ()Lcom/bumptech/glide/integration/ktx/Status;
+}
+
+public abstract interface annotation class com/bumptech/glide/integration/ktx/InternalGlideApi : java/lang/annotation/Annotation {
 }
 
 public final class com/bumptech/glide/integration/ktx/Placeholder : com/bumptech/glide/integration/ktx/GlideFlowInstant {

--- a/integration/ktx/build.gradle
+++ b/integration/ktx/build.gradle
@@ -43,6 +43,7 @@ dependencies {
     implementation "androidx.core:core-ktx:$ANDROID_X_CORE_KTX_VERSION"
     implementation "androidx.test:core-ktx:$ANDROID_X_TEST_CORE_KTX_VERSION"
     implementation "org.jetbrains.kotlinx:kotlinx-coroutines-core:$JETBRAINS_KOTLINX_COROUTINES_VERSION"
+    testImplementation "org.jetbrains.kotlin:kotlin-test-junit:$JETBRAINS_KOTLIN_VERSION"
     testImplementation "androidx.test.ext:junit-ktx:$ANDROID_X_TEST_JUNIT_KTX_VERSION"
     testImplementation "androidx.test.ext:junit:$ANDROID_X_TEST_JUNIT_VERSION"
     testImplementation "org.robolectric:robolectric:$ROBOLECTRIC_VERSION"

--- a/integration/ktx/src/main/java/com/bumptech/glide/integration/ktx/Internal.kt
+++ b/integration/ktx/src/main/java/com/bumptech/glide/integration/ktx/Internal.kt
@@ -1,0 +1,10 @@
+package com.bumptech.glide.integration.ktx
+
+@RequiresOptIn(
+  level = RequiresOptIn.Level.ERROR,
+  message = "An internal only API not intended for public use, may change, break or be removed" +
+    " at any time without warning."
+)
+@Retention(AnnotationRetention.BINARY)
+@kotlin.annotation.Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION)
+public annotation class InternalGlideApi


### PR DESCRIPTION
This will be used for the Compose integration. As the kdoc says, we
could consider expanding the visibility more broadly if we come up with
use cases beyond Glide's Compose integration.
