### PR TITLE
Use release instead of debug variant, fixup benchmark package.

### DIFF
--- a/annotation/compiler/test/build.gradle
+++ b/annotation/compiler/test/build.gradle
@@ -23,7 +23,7 @@ android {
 
 afterEvaluate {
     lint.enabled = false
-    compileDebugJavaWithJavac.enabled = false
+    compileReleaseJavaWithJavac.enabled = false
 }
 
 android {
@@ -92,6 +92,6 @@ task regenerateTestResources {
 }
 
 afterEvaluate {
-    regenerateTestResources.finalizedBy(testDebugUnitTest)
+    regenerateTestResources.finalizedBy(testReleaseUnitTest)
 }
 

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -4,17 +4,17 @@ plugins {
 }
 
 android {
-    compileSdk 30
+    compileSdk COMPILE_SDK_VERSION as int
     buildToolsVersion "30.0.3"
 
     compileOptions {
-        sourceCompatibility = 1.7
-        targetCompatibility = 1.7
+        sourceCompatibility = 1.8
+        targetCompatibility = 1.8
     }
 
     defaultConfig {
         minSdk 19
-        targetSdk 30
+        targetSdk TARGET_SDK_VERSION as int
         versionCode 1
         versionName "1.0"
 

--- a/benchmark/src/androidTest/java/com/bumptech/glide/benchmark/GlideBenchmarkRule.java
+++ b/benchmark/src/androidTest/java/com/bumptech/glide/benchmark/GlideBenchmarkRule.java
@@ -51,16 +51,6 @@ final class GlideBenchmarkRule implements TestRule {
     void act(BeforeDataT beforeData) throws Exception;
   }
 
-  <T> void runBenchmark(BeforeStep<T> beforeStep, LoadStep<T> loadStep) throws Exception {
-    runBenchmark(
-        beforeStep,
-        loadStep,
-        new AfterStep<T>() {
-          @Override
-          public void act(T beforeData) {}
-        });
-  }
-
   <T> void runBenchmark(BeforeStep<T> beforeStep, AfterStep<T> afterStep) throws Exception {
     runBenchmark(
         beforeStep,

--- a/build.gradle
+++ b/build.gradle
@@ -154,7 +154,7 @@ subprojects { project ->
             }
 
             android.variantFilter { variant ->
-                if(variant.buildType.name == 'release') {
+                if(variant.buildType.name == 'debug') {
                     variant.setIgnore(true)
                 }
             }

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -46,7 +46,7 @@ def getAndroidProjectsForJavadoc() {
 def getAndroidLibraryVariantsForJavadoc() {
     getAndroidProjectsForJavadoc().collect { project ->
         project.android.libraryVariants.findAll { type ->
-            type.buildType.name.equalsIgnoreCase("debug")
+            type.buildType.name.equalsIgnoreCase("release")
         }
     }.sum()
 }
@@ -65,7 +65,7 @@ project.archivesBaseName = "${POM_ARTIFACT_ID}-${VERSION_NAME}"
 
 // Generate javadocs and sources containing batched documentation and sources for all internal
 // projects.
-def javadocTask = tasks.create("debugJavadoc", Javadoc) {
+def javadocTask = tasks.create("releaseJavadoc", Javadoc) {
     source = getSourceFilesForJavadoc()
 
     doFirst {
@@ -79,7 +79,7 @@ def javadocTask = tasks.create("debugJavadoc", Javadoc) {
                         // Finds dependencies of Android packages that would otherwise be
                         // ignored (Volley in particular)
                         getAndroidProjectsForJavadoc().collect { Project project ->
-                            project.file('build/intermediates/classes/debug')
+                            project.file('build/intermediates/javac/release/classes')
                         }
         )
     }
@@ -94,12 +94,12 @@ def javadocTask = tasks.create("debugJavadoc", Javadoc) {
     exclude '**/R.java'
 }
 
-def cleanJavadocTask = task("cleanDebugJavadoc", type: Delete) {
+def cleanJavadocTask = task("cleanReleaseJavadoc", type: Delete) {
     delete javadocTask.destinationDir
 } as Task
 clean.dependsOn(cleanJavadocTask)
 
-def javadocJarTask = task("debugJavadocJar", type: Jar) {
+def javadocJarTask = task("releaseJavadocJar", type: Jar) {
     from javadocTask.destinationDir
 } as Task
 
@@ -107,8 +107,8 @@ javadocJarTask.dependsOn(javadocTask)
 
 (getAndroidProjectsForJavadoc()).each {
     project ->
-        debugJavadoc.dependsOn(project.tasks.compileDebugSources)
-        jar.dependsOn(project.tasks.compileDebugSources)
+        releaseJavadoc.dependsOn(project.tasks.compileReleaseSources)
+        jar.dependsOn(project.tasks.compileReleaseSources)
 }
 
 
@@ -125,7 +125,7 @@ jar {
 }
  
 artifacts {
-    archives debugJavadocJar {
+    archives releaseJavadocJar {
         classifier 'javadoc'
     }
 }

--- a/library/pmd/build.gradle
+++ b/library/pmd/build.gradle
@@ -7,7 +7,7 @@ pmd {
 }
 
 tasks.create('pmd', Pmd) {
-    dependsOn library.tasks.compileDebugJavaWithJavac
+    dependsOn library.tasks.compileReleaseJavaWithJavac
     targetJdk = TargetJdk.VERSION_1_7
 
     description 'Run pmd'
@@ -19,7 +19,7 @@ tasks.create('pmd', Pmd) {
     ruleSetFiles = files("${library.projectDir}/pmd-ruleset.xml")
     source library.android.sourceSets.main.java.srcDirs
     classpath = files()
-    classpath += files(library.tasks.compileDebugJavaWithJavac.destinationDir)
+    classpath += files(library.tasks.compileReleaseJavaWithJavac.destinationDir)
     doFirst {
         classpath += library.classPathForQuality()
     }

--- a/library/test/build.gradle
+++ b/library/test/build.gradle
@@ -22,7 +22,7 @@ tasks.withType(JavaCompile) {
 
 afterEvaluate {
     lint.enabled = false
-    compileDebugJavaWithJavac.enabled = false
+    compileReleaseJavaWithJavac.enabled = false
 }
 
 android.testOptions.unitTests.all { Test testTask ->

--- a/scripts/ci_unit.sh
+++ b/scripts/ci_unit.sh
@@ -13,6 +13,6 @@ set -e
   -x :samples:svg:build \
   :instrumentation:assembleAndroidTest \
   :benchmark:assembleAndroidTest \
-  :glide:debugJavadoc \
+  :glide:releaseJavadoc \
   :annotation:ksp:test:test \
   --parallel

--- a/scripts/update_javadocs.sh
+++ b/scripts/update_javadocs.sh
@@ -43,7 +43,7 @@ fi
 
 git checkout master
 GIT_COMMIT_SHA="$(git rev-parse HEAD)"
-./gradlew clean debugJavadocJar javadoc
+./gradlew clean releaseJavadocJar javadoc
 rm -rf $TEMP_DIR
 cp -r glide/build/docs/javadoc $TEMP_DIR
 

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -141,18 +141,18 @@ afterEvaluate { project ->
 
                 if (isAndroidProject) {
                     def variants = project.android.libraryVariants.findAll {
-                        it.buildType.name.equalsIgnoreCase('debug')
+                        it.buildType.name.equalsIgnoreCase('release')
                     }
 
                     def getAndroidSdkDirectory = project.android.sdkDirectory
 
                     def getAndroidJar = "${getAndroidSdkDirectory}/platforms/${project.android.compileSdkVersion}/android.jar"
 
-                    task androidJavadocs(type: Javadoc, dependsOn: assembleDebug) {
+                    task androidJavadocs(type: Javadoc, dependsOn: assembleRelease) {
                         source = variants.collect { it.getJavaCompileProvider().get().source }
                         classpath = files(
                                 getAndroidJar,
-                                project.file("build/intermediates/classes/debug")
+                                project.file("build/intermediates/javac/release/classes")
                         )
                         doFirst {
                             classpath += files(variants.collect { it.getJavaCompileProvider().get().classpath.files })
@@ -182,8 +182,8 @@ afterEvaluate { project ->
                         archiveBaseName.set("${JAR_PREFIX}${project.name}${JAR_POSTFIX}")
                     }
 
-                    task androidLibraryJar(type: Jar, dependsOn: compileDebugJavaWithJavac /* == variant.javaCompile */) {
-                        from compileDebugJavaWithJavac.destinationDir
+                    task androidLibraryJar(type: Jar, dependsOn: compileReleaseJavaWithJavac /* == variant.javaCompile */) {
+                        from compileReleaseJavaWithJavac.destinationDir
                         exclude '**/R.class'
                         exclude '**/R$*.class'
                         archiveBaseName.set("${JAR_PREFIX}${project.name}${JAR_POSTFIX}")
@@ -192,11 +192,7 @@ afterEvaluate { project ->
                     artifact androidLibraryJar
                     artifact androidSourcesJar
                     artifact androidJavadocsJar
-                    // This is unnecessary with a release variant because by default the release variant
-                    // includes the release aar in archives. Since we've disabled our release variants and
-                    // want to include an aar, we need to manually specify the task that produces the aar
-                    // here.
-                    artifact project.tasks.bundleDebugAar
+                    artifact project.tasks.bundleReleaseAar
                 } else if (project.plugins.hasPlugin('java')) {
                     task sourcesJar(type: Jar, dependsOn: classes) {
                         archiveClassifier.set('sources')

--- a/third_party/disklrucache/build.gradle
+++ b/third_party/disklrucache/build.gradle
@@ -2,9 +2,6 @@ apply plugin: 'com.android.library'
 
 checkstyle {
     toolVersion = "6.6"
-}
-
-checkstyle {
     configFile = new File(projectDir, 'checkstyle.xml')
 }
 


### PR DESCRIPTION
From Glide's perspective these two variants are exactly the same. We don't do any different configuration for release vs debug. However, the Kotlin binary-compatibility-validator only works on the release variant and it doesn't appear to be configurable to work on a different variant. To use that plugin, we need to have a release variant.

The net output here should be the same as before, just with Relase* task names instead of Debug* task names.

The benchmark project changes seem to be unrelated, but I think they're
actually required by some additional checks that the tools run by
default on release variants but not debug variants.
