### PR TITLE
Avoid launching Glide's flow's clear

### DIFF
--- a/integration/ktx/src/main/java/com/bumptech/glide/integration/ktx/Flows.kt
+++ b/integration/ktx/src/main/java/com/bumptech/glide/integration/ktx/Flows.kt
@@ -154,9 +154,7 @@ private fun <ResourceT : Any> RequestBuilder<ResourceT>.flow(
     val target = FlowTarget(this, size)
     requestBuilder.intoDirect(target)
     awaitClose {
-      launch {
-        requestManager.clear(target)
-      }
+      requestManager.clear(target)
     }
   }
 }


### PR DESCRIPTION
Launching the clear means a long delay when a lot of requests build up,
which in turns adds latency when requests are churning (ie scrolling
quickly through a list).

It was added to avoid clearing a Target in response to a Target
callback, but that only happens in certain types of forced main thread
requests, which won't happen in prod. In fact I've already removed the
behavior from the tests, so it's entirely bad.
