### PR TITLE
findActivity(view) to findActivity(contentView) ,because The view.con…

### DIFF
--- a/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
+++ b/library/src/main/java/com/bumptech/glide/manager/RequestManagerRetriever.java
@@ -230,9 +230,19 @@ public class RequestManagerRetriever implements Handler.Callback {
     }
 
     Preconditions.checkNotNull(view);
+    // The view.context might not be current Activity
+    View rootView = view.getRootView();
+    Preconditions.checkNotNull(rootView);
+    View contentView = rootView.findViewById(android.R.id.content);
+    if (contentView == null) {
+      contentView = rootView;
+    }
+    Preconditions.checkNotNull(contentView);
+    Context pageContext = contentView.getContext();
     Preconditions.checkNotNull(
-        view.getContext(), "Unable to obtain a request manager for a view without a Context");
-    Activity activity = findActivity(view.getContext());
+        pageContext, "Unable to obtain a request manager for a view without a Context");
+
+    Activity activity = findActivity(pageContext);
     // The view might be somewhere else, like a service.
     if (activity == null) {
       return get(view.getContext().getApplicationContext());


### PR DESCRIPTION
## Description
findActivity(view) to findActivity(contentView) 

## Motivation and Context
The view.context might not be current Activity.

for example:
View viewA = LayoutInflater.from(activityA).inflate(resId, activityA.viewGroupA, false)
activityB.viewGroupB.addView(viewA)
viewA.context == activityA

Although rarely used in this way, it does exist, The lifecycle of activityB should be bound, but the lifecycle of activityA is bound.