### PR TITLE
Remove unused dependency on :glide in ksp

### DIFF
--- a/annotation/ksp/build.gradle
+++ b/annotation/ksp/build.gradle
@@ -6,7 +6,6 @@ plugins {
 dependencies {
     implementation("com.squareup:kotlinpoet:1.12.0")
     implementation project(":annotation")
-    implementation project(":glide")
     implementation 'com.google.devtools.ksp:symbol-processing-api:1.7.0-1.0.6'
     ksp("dev.zacsweers.autoservice:auto-service-ksp:1.0.0")
     implementation("com.google.auto.service:auto-service-annotations:1.0.1")


### PR DESCRIPTION
We don't actually require this dependency to build and it produces a bad dependency on the pom file.

Fixes #4908
