### PR TITLE
Move namespace from AndroidManifest to build.gradle files.

### DIFF
--- a/annotation/ksp/test/build.gradle
+++ b/annotation/ksp/test/build.gradle
@@ -9,8 +9,8 @@ android {
     defaultConfig {
         minSdkVersion MIN_SDK_VERSION as int
         targetSdkVersion TARGET_SDK_VERSION as int
-        versionName VERSION_NAME as String
     }
+    namespace 'com.bumptech.glide.annotation.ksp.test'
 }
 
 dependencies {

--- a/annotation/ksp/test/src/main/AndroidManifest.xml
+++ b/annotation/ksp/test/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.bumptech.glide.annotation.ksp.test">
+    xmlns:tools="http://schemas.android.com/tools">
 </manifest>

--- a/benchmark/build.gradle
+++ b/benchmark/build.gradle
@@ -15,8 +15,6 @@ android {
     defaultConfig {
         minSdk 19
         targetSdk TARGET_SDK_VERSION as int
-        versionCode 1
-        versionName "1.0"
 
         testInstrumentationRunner 'androidx.benchmark.junit4.AndroidBenchmarkRunner'
     }
@@ -29,6 +27,7 @@ android {
             proguardFiles getDefaultProguardFile("proguard-android-optimize.txt"), "benchmark-proguard-rules.pro"
         }
     }
+    namespace 'com.bumptech.glide.benchmark'
 }
 
 dependencies {

--- a/benchmark/src/androidTest/AndroidManifest.xml
+++ b/benchmark/src/androidTest/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.bumptech.glide.benchmark">
+  xmlns:tools="http://schemas.android.com/tools">
 
   <!--
       Important: disable debugging for accurate performance results

--- a/benchmark/src/main/AndroidManifest.xml
+++ b/benchmark/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bumptech.glide.benchmark">
+<manifest>
   <application />
 </manifest>

--- a/instrumentation/build.gradle
+++ b/instrumentation/build.gradle
@@ -42,5 +42,6 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    namespace 'com.bumptech.glide.instrumentation'
 }
 

--- a/instrumentation/src/main/AndroidManifest.xml
+++ b/instrumentation/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:tools="http://schemas.android.com/tools"
-    package="com.bumptech.glide.instrumentation">
+    xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
   <uses-permission android:name="android.permission.SYSTEM_ALERT_WINDOW" />
   <application tools:ignore="MissingApplicationIcon" >

--- a/integration/avif/build.gradle
+++ b/integration/avif/build.gradle
@@ -15,13 +15,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.avif'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/avif/src/main/AndroidManifest.xml
+++ b/integration/avif/src/main/AndroidManifest.xml
@@ -1,2 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.integration.avif" />
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/integration/compose/build.gradle
+++ b/integration/compose/build.gradle
@@ -35,6 +35,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.bumptech.glide.integration.compose'
 }
 
 // Enable strict mode, but exclude tests.

--- a/integration/compose/src/main/AndroidManifest.xml
+++ b/integration/compose/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.integration.compose">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <uses-sdk android:minSdkVersion="21" />
 </manifest>

--- a/integration/concurrent/build.gradle
+++ b/integration/concurrent/build.gradle
@@ -20,13 +20,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName = VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.concurrent'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/concurrent/src/main/AndroidManifest.xml
+++ b/integration/concurrent/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest
-  package="com.bumptech.glide.integration.concurrent">
+<manifest>
 
     <application>
     </application>

--- a/integration/cronet/build.gradle
+++ b/integration/cronet/build.gradle
@@ -21,13 +21,13 @@ android {
         minSdk 16 as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.cronet'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/cronet/src/main/AndroidManifest.xml
+++ b/integration/cronet/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.integration.cronet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application>
         <meta-data
             android:name="com.bumptech.glide.integration.cronet.CronetGlideModule"

--- a/integration/cronet/src/test/AndroidManifest.xml
+++ b/integration/cronet/src/test/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.integration.cronet">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application />
   <uses-sdk android:minSdkVersion="14" android:targetSdkVersion="26"/>
 </manifest>

--- a/integration/gifencoder/build.gradle
+++ b/integration/gifencoder/build.gradle
@@ -26,13 +26,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName = VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.gifencoder'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/gifencoder/src/main/AndroidManifest.xml
+++ b/integration/gifencoder/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest
-  package="com.bumptech.glide.integration.gifencoder">
+<manifest>
 
     <application>
     </application>

--- a/integration/ktx/build.gradle
+++ b/integration/ktx/build.gradle
@@ -29,6 +29,7 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+    namespace 'com.bumptech.glide.integration.ktx'
 }
 
 // Enable strict mode, but exclude tests.

--- a/integration/ktx/src/main/AndroidManifest.xml
+++ b/integration/ktx/src/main/AndroidManifest.xml
@@ -1,2 +1,2 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bumptech.glide.integration.ktx" />
+<manifest />

--- a/integration/okhttp/build.gradle
+++ b/integration/okhttp/build.gradle
@@ -15,13 +15,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.okhttp'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/okhttp/src/main/AndroidManifest.xml
+++ b/integration/okhttp/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest
-  package="com.bumptech.glide.integration.okhttp">
+<manifest>
 
     <application />
 </manifest>

--- a/integration/okhttp3/build.gradle
+++ b/integration/okhttp3/build.gradle
@@ -15,13 +15,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.okhttp'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/okhttp3/src/main/AndroidManifest.xml
+++ b/integration/okhttp3/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.integration.okhttp">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <meta-data

--- a/integration/recyclerview/build.gradle
+++ b/integration/recyclerview/build.gradle
@@ -13,13 +13,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.recyclerview'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/recyclerview/src/main/AndroidManifest.xml
+++ b/integration/recyclerview/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="com.bumptech.glide.integration.recyclerview">
+<manifest>
     <application />
 </manifest>

--- a/integration/volley/build.gradle
+++ b/integration/volley/build.gradle
@@ -24,13 +24,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.integration.volley'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/integration/volley/src/main/AndroidManifest.xml
+++ b/integration/volley/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.integration.volley">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application>
         <meta-data

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -59,7 +59,6 @@ android {
     defaultConfig {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
-        versionName VERSION_NAME as String
         consumerProguardFiles 'proguard-rules.txt'
     }
 
@@ -67,6 +66,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide'
 }
 
 // Change the name to make it a little more obvious where the main library

--- a/library/src/main/AndroidManifest.xml
+++ b/library/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.bumptech.glide">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <application/>
 </manifest>

--- a/library/test/build.gradle
+++ b/library/test/build.gradle
@@ -45,7 +45,6 @@ android {
     defaultConfig {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
@@ -63,4 +62,5 @@ android {
             resources.srcDirs += ['../../exifsamples']
         }
     }
+    namespace 'com.bumptech.glide.test'
 }

--- a/library/test/src/main/AndroidManifest.xml
+++ b/library/test/src/main/AndroidManifest.xml
@@ -1,4 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest package="com.bumptech.glide.test">
+<manifest>
     <application/>
 </manifest>

--- a/mocks/build.gradle
+++ b/mocks/build.gradle
@@ -14,13 +14,13 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
 
-        versionName = VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.mocks'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/mocks/src/main/AndroidManifest.xml
+++ b/mocks/src/main/AndroidManifest.xml
@@ -1,4 +1,3 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  package="com.bumptech.glide.mocks">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
   <application />
 </manifest>

--- a/samples/contacturi/build.gradle
+++ b/samples/contacturi/build.gradle
@@ -22,6 +22,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.samples.contacturi'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/samples/contacturi/src/main/AndroidManifest.xml
+++ b/samples/contacturi/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.samples.contacturi" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.READ_CONTACTS" />
 

--- a/samples/flickr/build.gradle
+++ b/samples/flickr/build.gradle
@@ -28,6 +28,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.samples.flickr'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/samples/flickr/src/main/AndroidManifest.xml
+++ b/samples/flickr/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.bumptech.glide.samples.flickr">
+  xmlns:tools="http://schemas.android.com/tools">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <!--

--- a/samples/gallery/build.gradle
+++ b/samples/gallery/build.gradle
@@ -52,6 +52,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    namespace 'com.bumptech.glide.samples.gallery'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/samples/gallery/src/main/AndroidManifest.xml
+++ b/samples/gallery/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.samples.gallery">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
   <uses-sdk
     android:minSdkVersion="29"

--- a/samples/giphy/build.gradle
+++ b/samples/giphy/build.gradle
@@ -26,6 +26,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.samples.giphy'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/samples/giphy/src/main/AndroidManifest.xml
+++ b/samples/giphy/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.samples.giphy">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <!--

--- a/samples/imgur/build.gradle
+++ b/samples/imgur/build.gradle
@@ -22,6 +22,7 @@ android {
             minifyEnabled false
         }
     }
+    namespace 'com.bumptech.glide.samples.imgur'
 }
 
 dependencies {

--- a/samples/imgur/src/main/AndroidManifest.xml
+++ b/samples/imgur/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-  xmlns:tools="http://schemas.android.com/tools"
-  package="com.bumptech.glide.samples.imgur">
+  xmlns:tools="http://schemas.android.com/tools">
   <uses-permission android:name="android.permission.INTERNET" />
   <!--
   Allows Glide to monitor connectivity status and restart failed requests if users go from a

--- a/samples/svg/build.gradle
+++ b/samples/svg/build.gradle
@@ -23,6 +23,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.samples.svg'
 }
 
 task run(type: Exec, dependsOn: 'installDebug') {

--- a/samples/svg/src/main/AndroidManifest.xml
+++ b/samples/svg/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="com.bumptech.glide.samples.svg" >
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <uses-permission android:name="android.permission.INTERNET"/>
 

--- a/scripts/upload.gradle
+++ b/scripts/upload.gradle
@@ -140,6 +140,7 @@ afterEvaluate { project ->
                 }
 
                 if (isAndroidProject) {
+
                     def variants = project.android.libraryVariants.findAll {
                         it.buildType.name.equalsIgnoreCase('release')
                     }

--- a/testutil/build.gradle
+++ b/testutil/build.gradle
@@ -14,11 +14,11 @@ android {
     defaultConfig {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
-        versionName VERSION_NAME as String
     }
 
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_11
         targetCompatibility JavaVersion.VERSION_11
     }
+    namespace 'com.bumptech.glide.testutil'
 }

--- a/testutil/src/main/AndroidManifest.xml
+++ b/testutil/src/main/AndroidManifest.xml
@@ -1,5 +1,4 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.testutil">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
     <application/>
 </manifest>

--- a/third_party/disklrucache/build.gradle
+++ b/third_party/disklrucache/build.gradle
@@ -16,7 +16,6 @@ android {
     defaultConfig {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
-        versionName VERSION_NAME as String
         consumerProguardFiles 'proguard-rules.txt'
     }
 
@@ -24,6 +23,7 @@ android {
         sourceCompatibility JavaVersion.VERSION_1_7
         targetCompatibility JavaVersion.VERSION_1_7
     }
+    namespace 'com.bumptech.glide.disklrucache'
 }
 
 def uploaderScript = "${rootProject.projectDir}/scripts/upload.gradle"

--- a/third_party/disklrucache/src/main/AndroidManifest.xml
+++ b/third_party/disklrucache/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          package="com.bumptech.glide.disklrucache">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
 
     <application/>
 </manifest>

--- a/third_party/gif_decoder/build.gradle
+++ b/third_party/gif_decoder/build.gradle
@@ -18,6 +18,7 @@ android {
         minSdk MIN_SDK_VERSION as int
         targetSdk TARGET_SDK_VERSION as int
     }
+    namespace 'com.bumptech.glide.gifdecoder'
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/third_party/gif_decoder/src/main/AndroidManifest.xml
+++ b/third_party/gif_decoder/src/main/AndroidManifest.xml
@@ -1,6 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
-<manifest
-  package="com.bumptech.glide.gifdecoder">
+<manifest>
 
     <application/>
 </manifest>


### PR DESCRIPTION
This fixes a bunch of warnings triggered by the gradle update 