### PR TITLE
Implement equals/hashcode for RequestOptions and TransitionOptions

### DIFF
--- a/integration/compose/build.gradle
+++ b/integration/compose/build.gradle
@@ -60,6 +60,7 @@ dependencies {
     androidTestImplementation "androidx.test.espresso:espresso-core:$ANDROID_X_TEST_ESPRESSO_VERSION"
     androidTestImplementation "androidx.test.espresso.idling:idling-concurrent:$ANDROID_X_TEST_ESPRESSO_VERSION"
     androidTestImplementation "androidx.test.ext:junit:$ANDROID_X_TEST_JUNIT_VERSION"
+    androidTestImplementation "androidx.compose.material:material:$ANDROID_X_COMPOSE_VERSION"
 }
 
 apply from: "${rootProject.projectDir}/scripts/upload.gradle"

--- a/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/GenericTransitionOptions.java
@@ -55,4 +55,18 @@ public final class GenericTransitionOptions<TranscodeType>
       @NonNull TransitionFactory<? super TranscodeType> transitionFactory) {
     return new GenericTransitionOptions<TranscodeType>().transition(transitionFactory);
   }
+
+  // Make sure that we're not equal to any other concrete implementation of TransitionOptions.
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof GenericTransitionOptions && super.equals(o);
+  }
+
+  // Our class doesn't include any additional properties, so we don't need to modify hashcode, but
+  // keep it here as a reminder in case we add properties.
+  @SuppressWarnings("PMD.UselessOverridingMethod")
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/library/src/main/java/com/bumptech/glide/RequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/RequestBuilder.java
@@ -42,6 +42,7 @@ import java.net.URL;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.concurrent.Executor;
 
 /**
@@ -80,6 +81,7 @@ public class RequestBuilder<TranscodeType> extends BaseRequestOptions<RequestBui
   @Nullable private Float thumbSizeMultiplier;
   private boolean isDefaultTransitionOptionsSet = true;
   private boolean isModelSet;
+
   private boolean isThumbnailBuilt;
 
   // We only override the method to change the return type, not the functionality.
@@ -1250,5 +1252,38 @@ public class RequestBuilder<TranscodeType> extends BaseRequestOptions<RequestBui
         glideContext.getEngine(),
         transitionOptions.getTransitionFactory(),
         callbackExecutor);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof RequestBuilder<?>) {
+      RequestBuilder<?> that = (RequestBuilder<?>) o;
+      return super.equals(that)
+          && Objects.equals(transcodeClass, that.transcodeClass)
+          && transitionOptions.equals(that.transitionOptions)
+          && Objects.equals(model, that.model)
+          && Objects.equals(requestListeners, that.requestListeners)
+          && Objects.equals(thumbnailBuilder, that.thumbnailBuilder)
+          && Objects.equals(errorBuilder, that.errorBuilder)
+          && Objects.equals(thumbSizeMultiplier, that.thumbSizeMultiplier)
+          && isDefaultTransitionOptionsSet == that.isDefaultTransitionOptionsSet
+          && isModelSet == that.isModelSet;
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    int hashCode = super.hashCode();
+    hashCode = Util.hashCode(transcodeClass, hashCode);
+    hashCode = Util.hashCode(transitionOptions, hashCode);
+    hashCode = Util.hashCode(model, hashCode);
+    hashCode = Util.hashCode(requestListeners, hashCode);
+    hashCode = Util.hashCode(thumbnailBuilder, hashCode);
+    hashCode = Util.hashCode(errorBuilder, hashCode);
+    hashCode = Util.hashCode(thumbSizeMultiplier, hashCode);
+    hashCode = Util.hashCode(isDefaultTransitionOptionsSet, hashCode);
+    hashCode = Util.hashCode(isModelSet, hashCode);
+    return hashCode;
   }
 }

--- a/library/src/main/java/com/bumptech/glide/TransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/TransitionOptions.java
@@ -7,9 +7,12 @@ import com.bumptech.glide.request.transition.ViewAnimationFactory;
 import com.bumptech.glide.request.transition.ViewPropertyAnimationFactory;
 import com.bumptech.glide.request.transition.ViewPropertyTransition;
 import com.bumptech.glide.util.Preconditions;
+import com.bumptech.glide.util.Util;
 
 /**
  * A base class for setting a transition to use on a resource when a load completes.
+ *
+ * <p>Note: Implementations must implement equals/hashcode.
  *
  * @param <CHILD> The implementation of this class to return to chain methods.
  * @param <TranscodeType> The type of resource that will be animated.
@@ -96,5 +99,19 @@ public abstract class TransitionOptions<
   @SuppressWarnings("unchecked")
   private CHILD self() {
     return (CHILD) this;
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o instanceof TransitionOptions) {
+      TransitionOptions<?, ?> other = (TransitionOptions<?, ?>) o;
+      return Util.bothNullOrEqual(transitionFactory, other.transitionFactory);
+    }
+    return false;
+  }
+
+  @Override
+  public int hashCode() {
+    return transitionFactory != null ? transitionFactory.hashCode() : 0;
   }
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/BitmapTransitionOptions.java
@@ -125,4 +125,18 @@ public final class BitmapTransitionOptions
   public BitmapTransitionOptions crossFade(@NonNull DrawableCrossFadeFactory.Builder builder) {
     return transitionUsing(builder.build());
   }
+
+  // Make sure that we're not equal to any other concrete implementation of TransitionOptions.
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof BitmapTransitionOptions && super.equals(o);
+  }
+
+  // Our class doesn't include any additional properties, so we don't need to modify hashcode, but
+  // keep it here as a reminder in case we add properties.
+  @SuppressWarnings("PMD.UselessOverridingMethod")
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/drawable/DrawableTransitionOptions.java
@@ -105,4 +105,19 @@ public final class DrawableTransitionOptions
   public DrawableTransitionOptions crossFade(@NonNull DrawableCrossFadeFactory.Builder builder) {
     return crossFade(builder.build());
   }
+
+  // Make sure that we're not equal to any other concrete implementation of TransitionOptions.
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof DrawableTransitionOptions && super.equals(o);
+  }
+
+  // Our class doesn't include any additional properties, so we don't need to modify hashcode, but
+  // keep it here as a reminder in case we add properties.
+  @SuppressWarnings("PMD.UselessOverridingMethod")
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }
+

--- a/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestOptions.java
@@ -279,4 +279,18 @@ public class RequestOptions extends BaseRequestOptions<RequestOptions> {
     }
     return noAnimationOptions;
   }
+
+  // Make sure that we're not equal to any other concrete implementation of RequestOptions.
+  @Override
+  public boolean equals(Object o) {
+    return o instanceof RequestOptions && super.equals(o);
+  }
+
+  // Our class doesn't include any additional properties, so we don't need to modify hashcode, but
+  // keep it here as a reminder in case we add properties.
+  @SuppressWarnings("PMD.UselessOverridingMethod")
+  @Override
+  public int hashCode() {
+    return super.hashCode();
+  }
 }

--- a/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
@@ -11,9 +11,12 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.app.Application;
+import android.net.Uri;
 import android.widget.ImageView;
+import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
 import com.bumptech.glide.load.DataSource;
+import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.load.resource.SimpleResource;
 import com.bumptech.glide.request.Request;
 import com.bumptech.glide.request.RequestListener;
@@ -23,6 +26,7 @@ import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.request.target.ViewTarget;
 import com.bumptech.glide.tests.BackgroundUtil.BackgroundTester;
 import com.bumptech.glide.tests.TearDownGlide;
+import com.google.common.testing.EqualsTester;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -159,13 +163,129 @@ public class RequestBuilderTest {
         .onResourceReady(any(), any(), isA(Target.class), isA(DataSource.class), anyBoolean());
   }
 
+  @Test
+  public void testEquals() {
+    Object firstModel = new Object();
+    Object secondModel = new Object();
+
+    RequestListener<Object> firstListener = new RequestListener<>() {
+      @Override
+      public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Object> target,
+          boolean isFirstResource) {
+        return false;
+      }
+
+      @Override
+      public boolean onResourceReady(Object resource, Object model, Target<Object> target,
+          DataSource dataSource, boolean isFirstResource) {
+        return false;
+      }
+    };
+    RequestListener<Object> secondListener = new RequestListener<>() {
+      @Override
+      public boolean onLoadFailed(@Nullable GlideException e, Object model, Target<Object> target,
+          boolean isFirstResource) {
+        return false;
+      }
+
+      @Override
+      public boolean onResourceReady(Object resource, Object model, Target<Object> target,
+          DataSource dataSource, boolean isFirstResource) {
+        return false;
+      }
+    };
+
+    new EqualsTester()
+        .addEqualityGroup(new Object())
+        .addEqualityGroup(
+            newRequestBuilder(Object.class),
+            newRequestBuilder(Object.class)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).load((Object) null),
+            newRequestBuilder(Object.class).load((Object) null),
+            newRequestBuilder(Object.class).load((Uri) null)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).load(firstModel),
+            newRequestBuilder(Object.class).load(firstModel)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).load(secondModel),
+            newRequestBuilder(Object.class).load(secondModel)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).load(Uri.EMPTY),
+            newRequestBuilder(Object.class).load(Uri.EMPTY)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Uri.class).load(Uri.EMPTY),
+            newRequestBuilder(Uri.class).load(Uri.EMPTY)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).centerCrop(),
+            newRequestBuilder(Object.class).centerCrop()
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).addListener(firstListener),
+            newRequestBuilder(Object.class).addListener(firstListener)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).addListener(secondListener),
+            newRequestBuilder(Object.class).addListener(secondListener)
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).error(newRequestBuilder(Object.class)),
+            newRequestBuilder(Object.class).error(newRequestBuilder(Object.class))
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).error(firstModel),
+            newRequestBuilder(Object.class).error(firstModel),
+            newRequestBuilder(Object.class).error(newRequestBuilder(Object.class).load(firstModel))
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class).error(secondModel),
+            newRequestBuilder(Object.class).error(secondModel),
+            newRequestBuilder(Object.class).error(newRequestBuilder(Object.class).load(secondModel))
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class)
+                .error(newRequestBuilder(Object.class).load(firstModel).centerCrop()),
+            newRequestBuilder(Object.class)
+                .error(newRequestBuilder(Object.class).load(firstModel).centerCrop())
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class)
+                .thumbnail(newRequestBuilder(Object.class).load(firstModel)),
+            newRequestBuilder(Object.class)
+                .thumbnail(newRequestBuilder(Object.class).load(firstModel))
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class)
+                .thumbnail(newRequestBuilder(Object.class).load(secondModel)),
+            newRequestBuilder(Object.class)
+                .thumbnail(newRequestBuilder(Object.class).load(secondModel))
+        )
+        .addEqualityGroup(
+            newRequestBuilder(Object.class)
+                .transition(new GenericTransitionOptions<>().dontTransition()),
+            newRequestBuilder(Object.class)
+                .transition(new GenericTransitionOptions<>().dontTransition())
+        )
+        .testEquals();
+  }
+
   private RequestBuilder<Object> getNullModelRequest() {
+    return newRequestBuilder(Object.class).load((Object) null);
+  }
+
+  private <ModelT> RequestBuilder<ModelT> newRequestBuilder(Class<ModelT> modelClass) {
     when(glideContext.buildImageViewTarget(isA(ImageView.class), isA(Class.class)))
         .thenReturn(mock(ViewTarget.class));
     when(glideContext.getDefaultRequestOptions()).thenReturn(new RequestOptions());
     when(requestManager.getDefaultRequestOptions()).thenReturn(new RequestOptions());
     when(requestManager.getDefaultTransitionOptions(any(Class.class)))
         .thenReturn(new GenericTransitionOptions<>());
-    return new RequestBuilder<>(glide, requestManager, Object.class, context).load((Object) null);
+    return new RequestBuilder<>(glide, requestManager, modelClass, context);
   }
 }

--- a/library/test/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/RequestOptionsTest.java
@@ -559,7 +559,29 @@ public class RequestOptionsTest {
     Drawable second = new GradientDrawable();
     assertThat(first).isNotEqualTo(second);
     assertThat(Util.bothNullOrEqual(first, second)).isFalse();
+    // Make sure we're not equal to any other subclass of RequestOptions.
+    class FakeOptions extends BaseRequestOptions<FakeOptions>{
+      @Override
+      public boolean equals(Object o) {
+        return o instanceof FakeOptions && super.equals(o);
+      }
+
+      // Our class doesn't include any additional properties, so we don't need to modify hashcode, but
+      // keep it here as a reminder in case we add properties.
+      @SuppressWarnings("PMD.UselessOverridingMethod")
+      @Override
+      public int hashCode() {
+        return super.hashCode();
+      }
+    }
     new EqualsTester()
+        .addEqualityGroup(
+            new RequestOptions(),
+            new RequestOptions(),
+            new RequestOptions().skipMemoryCache(false),
+            new RequestOptions().onlyRetrieveFromCache(false),
+            new RequestOptions().useUnlimitedSourceGeneratorsPool(false))
+        .addEqualityGroup(new FakeOptions(), new FakeOptions())
         .addEqualityGroup(
             new RequestOptions().sizeMultiplier(.7f), new RequestOptions().sizeMultiplier(.7f))
         .addEqualityGroup(new RequestOptions().sizeMultiplier(0.8f))
@@ -579,11 +601,6 @@ public class RequestOptionsTest {
         .addEqualityGroup(new RequestOptions().fallback(second))
         .addEqualityGroup(
             new RequestOptions().skipMemoryCache(true), new RequestOptions().skipMemoryCache(true))
-        .addEqualityGroup(
-            new RequestOptions(),
-            new RequestOptions().skipMemoryCache(false),
-            new RequestOptions().onlyRetrieveFromCache(false),
-            new RequestOptions().useUnlimitedSourceGeneratorsPool(false))
         .addEqualityGroup(
             new RequestOptions().override(100), new RequestOptions().override(100, 100))
         .addEqualityGroup(


### PR DESCRIPTION
It's a little tricky to get this right because we've defined equals/hashcode in the base classes, but are implementing them in the concrete classes. I think this implementation is actually safe because the base classes are abstract. However making equals transitive requires the weird equals() only implementations in the classes that have no properties but are concrete implementations of the base classes.

A safer way to do this would be to move the the equals/hashcode implementation out of the base class and re-implement it in each subclass. However that would require exposing a bunch of internal instance variables to subclasses. Given the existing structure and the public nature of the base classes, this seems like a reasonable compromise.

Fixes #4916