### PR TITLE
Fix Failure to render image: RecyclableBufferedInputStream$InvalidMarkException Issue

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -331,7 +331,7 @@ public final class Downsampler {
     int orientation;
     try {
       orientation = imageReader.getImageOrientation();
-    } catch (InvalidMarkException e) {
+    } catch (IOException e) {
       orientation = ImageHeaderParser.UNKNOWN_ORIENTATION;
     }
 

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -23,6 +23,7 @@ import com.bumptech.glide.load.engine.Resource;
 import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.load.resource.bitmap.DownsampleStrategy.SampleSizeRounding;
+import com.bumptech.glide.load.resource.bitmap.RecyclableBufferedInputStream.InvalidMarkException;
 import com.bumptech.glide.request.RequestOptions;
 import com.bumptech.glide.request.target.Target;
 import com.bumptech.glide.util.LogTime;
@@ -327,7 +328,13 @@ public final class Downsampler {
       isHardwareConfigAllowed = false;
     }
 
-    int orientation = imageReader.getImageOrientation();
+    int orientation;
+    try {
+      orientation = imageReader.getImageOrientation();
+    } catch (InvalidMarkException e) {
+      orientation = ImageHeaderParser.UNKNOWN_ORIENTATION;
+    }
+
     int degreesToRotate = TransformationUtils.getExifOrientationDegrees(orientation);
     boolean isExifOrientationRequired = TransformationUtils.isExifOrientationRequired(orientation);
 


### PR DESCRIPTION
### Description 
This PR fixes #4517 issue
When we try to load Image More than 5 MB that doesn't have specific Orientation, we try to get Image Orientation by decoding stream. But If Image resource size is bigger than 5MB it throw error. 
But By adding this code it sets default Orientation.( Only if the image is bigger than 5MB)

### Motivation and Context

It can't Load png file more than 5MB.
Example file is https://www.sample-videos.com/img/Sample-png-image-5mb.png