### PR TITLE
GlideUrl.equals with respect to headers elements

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/model/GlideUrl.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/GlideUrl.java
@@ -132,7 +132,8 @@ public class GlideUrl implements Key {
   public boolean equals(Object o) {
     if (o instanceof GlideUrl) {
       GlideUrl other = (GlideUrl) o;
-      return getCacheKey().equals(other.getCacheKey()) && headers.equals(other.headers);
+      return getCacheKey().equals(other.getCacheKey()) &&
+          headers.getHeaders().equals(other.headers.getHeaders());
     }
     return false;
   }
@@ -141,7 +142,9 @@ public class GlideUrl implements Key {
   public int hashCode() {
     if (hashCode == 0) {
       hashCode = getCacheKey().hashCode();
-      hashCode = 31 * hashCode + headers.hashCode();
+      Map<String, String> headersMap = headers.getHeaders();
+      int headersHashcode = headersMap.isEmpty() ? 0 : headersMap.hashCode();
+      hashCode = 31 * hashCode + headersHashcode;
     }
     return hashCode;
   }

--- a/library/test/src/test/java/com/bumptech/glide/load/model/GlideUrlTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/GlideUrlTest.java
@@ -7,6 +7,8 @@ import static org.mockito.Mockito.mock;
 import com.google.common.testing.EqualsTester;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Map;
+import java.util.Map.Entry;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
@@ -106,15 +108,47 @@ public class GlideUrlTest {
     Headers otherHeaders = mock(Headers.class);
     String url = "http://www.google.com";
     String otherUrl = "http://mail.google.com";
+    Map<String, String> dummyHeadersMap = Map.of("HEADER_NAME", "HEADER_VALUE");
+    Map<String, String> otherDummyHeadersMap = Map.of("HEADER_NAME", "HEADER_VALUE", "HEADER_NAME_2", "HEADER_VALUE_2");
+    LazyHeaders.Builder lazyHeadersBuilder = new LazyHeaders.Builder();
+    LazyHeaders.Builder otherLazyHeadersBuilder = new LazyHeaders.Builder();
+    for (Entry<String, String> e: dummyHeadersMap.entrySet()) {
+      lazyHeadersBuilder.addHeader(e.getKey(), e.getValue());
+    }
+    for (Entry<String, String> e: otherDummyHeadersMap.entrySet()) {
+      otherLazyHeadersBuilder.addHeader(e.getKey(), e.getValue());
+    }
     new EqualsTester()
         .addEqualityGroup(
             new GlideUrl(url),
             new GlideUrl(url),
             new GlideUrl(new URL(url)),
-            new GlideUrl(new URL(url)))
-        .addEqualityGroup(new GlideUrl(otherUrl), new GlideUrl(new URL(otherUrl)))
-        .addEqualityGroup(new GlideUrl(url, headers), new GlideUrl(new URL(url), headers))
-        .addEqualityGroup(new GlideUrl(url, otherHeaders), new GlideUrl(new URL(url), otherHeaders))
+            new GlideUrl(new URL(url)),
+            new GlideUrl(url, headers),
+            new GlideUrl(new URL(url), headers),
+            new GlideUrl(url, otherHeaders),
+            new GlideUrl(new URL(url), otherHeaders),
+            new GlideUrl(url, new LazyHeaders.Builder().build()))
+        .addEqualityGroup(
+            new GlideUrl(otherUrl),
+            new GlideUrl(otherUrl),
+            new GlideUrl(new URL(otherUrl)),
+            new GlideUrl(new URL(otherUrl)),
+            new GlideUrl(otherUrl, headers),
+            new GlideUrl(new URL(otherUrl), headers),
+            new GlideUrl(otherUrl, otherHeaders),
+            new GlideUrl(new URL(otherUrl), otherHeaders),
+            new GlideUrl(otherUrl, new LazyHeaders.Builder().build()))
+        .addEqualityGroup(
+            new GlideUrl(url, () -> dummyHeadersMap),
+            new GlideUrl(url, () -> dummyHeadersMap),
+            new GlideUrl(new URL(url), () -> dummyHeadersMap),
+            new GlideUrl(url, lazyHeadersBuilder.build()))
+        .addEqualityGroup(
+            new GlideUrl(url, () -> otherDummyHeadersMap),
+            new GlideUrl(url, () -> otherDummyHeadersMap),
+            new GlideUrl(new URL(url), () -> otherDummyHeadersMap),
+            new GlideUrl(new URL(url), otherLazyHeadersBuilder.build()))
         .testEquals();
   }
 }


### PR DESCRIPTION
GlideUrl equality by headers elements, not headers objects themself.

Why it is needed.
As a kotlin user you can easily create GlideUrl like this
```
GlideUrl(someUrl) {
    someMapOfHeaders
}
```
It will be an anonymous implementation of Headers interface, and now two GlideUrl with same url and headers won't be equal. Which is wrong in my opinion. It causes image flickering when data updates and GlideUrls constructed like this.