### PR TITLE
Deprecate .theme()

### DIFF
--- a/library/src/main/java/com/bumptech/glide/RequestBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/RequestBuilder.java
@@ -664,6 +664,8 @@ public class RequestBuilder<TranscodeType> extends BaseRequestOptions<RequestBui
     return applyResourceThemeAndSignature(requestBuilder);
   }
 
+  // We should be able to remove the usage of theme in a future release
+  @SuppressWarnings("deprecation")
   private RequestBuilder<TranscodeType> applyResourceThemeAndSignature(
       RequestBuilder<TranscodeType> requestBuilder) {
     return requestBuilder

--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -414,7 +414,13 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
    *
    * @param theme The theme to use when loading Drawables.
    * @return this request builder.
+   *
+   * @deprecated The theme will be automatically applied from the {@link android.content.Context}
+   * associated with the {@link com.bumptech.glide.RequestManager} used to start this load. If you
+   * have a use case where calling this method is required for some reason, please file an issue at
+   * https://github.com/bumptech/glide/issues/new.
    */
+  @Deprecated
   @NonNull
   @CheckResult
   public T theme(@Nullable Resources.Theme theme) {


### PR DESCRIPTION
We should now be able to pull the correct theme from the Context from the associated RequestManager, which makes this method largely not useful.

The only exception would be an attempt to do a themed loading using the Application Context where a theme of some Fragment or Activity is available. I assume that case is relatively rare and it's probably better to just do the load with the Fragment or Activity Context anyway.
