### PR TITLE
Read library glide module names from Java indexes

### DIFF
--- a/annotation/ksp/src/main/kotlin/com/bumptech/glide/annotation/ksp/GlideSymbolProcessor.kt
+++ b/annotation/ksp/src/main/kotlin/com/bumptech/glide/annotation/ksp/GlideSymbolProcessor.kt
@@ -144,6 +144,7 @@ object GlideSymbolProcessorConstants {
   // This variable is visible only for testing
   // TODO(b/174783094): Add @VisibleForTesting when internal is supported.
   val PACKAGE_NAME: String = GlideSymbolProcessor::class.java.`package`.name
+  val JAVA_ANNOTATION_PACKAGE_NAME: String = "com.bumptech.glide.annotation.compiler"
   const val SINGLE_APP_MODULE_ERROR = "You can have at most one AppGlideModule, but found: %s"
   const val DUPLICATE_LIBRARY_MODULE_ERROR =
     "LibraryGlideModules %s are included more than once, keeping only one!"

--- a/glide/build.gradle
+++ b/glide/build.gradle
@@ -1,5 +1,18 @@
 import com.android.build.gradle.api.LibraryVariant
 
+/**
+ * This module is used for two things:
+ *     <ul>
+ *         <li>Compiling a single unified set of javadocs for Glide
+ *         <li>Providing a jar version of Glide for internal libraries, like
+ *         Glide's annotation processor.
+ *     </ul>
+ *
+ * <p>Previously this module was used to produce a release jar for Glide, but
+ * we've long since stopped releasing the jar. Now all release artifacts come
+ * from the upload script, which uploads aars for each production submodule
+ */
+
 apply plugin: 'java'
 
 // The paths of Android projects that should be included only in Javadoc, not in the jar.
@@ -16,6 +29,10 @@ static def getAndroidPathsForJavadoc() {
             ':third_party:disklrucache',
             ':third_party:gif_decoder',
     ]
+}
+
+static def getAndroidPathsForJar() {
+    [':library', ':third_party:disklrucache', ':third_party:gif_decoder']
 }
 
 // The paths of Java projects that should be included only in Javadoc, not in the jar.
@@ -43,8 +60,16 @@ def getAndroidProjectsForJavadoc() {
     asProjects(getAndroidPathsForJavadoc())
 }
 
+def getAndroidLibraryVariantsForJar() {
+    getAndroidLibraryVariantsForProjects(asProjects(getAndroidPathsForJar()))
+}
+
 def getAndroidLibraryVariantsForJavadoc() {
-    getAndroidProjectsForJavadoc().collect { project ->
+    getAndroidLibraryVariantsForProjects(getAndroidProjectsForJavadoc())
+}
+
+def getAndroidLibraryVariantsForProjects(projects) {
+    projects.collect { project ->
         project.android.libraryVariants.findAll { type ->
             type.buildType.name.equalsIgnoreCase("release")
         }
@@ -114,7 +139,7 @@ javadocJarTask.dependsOn(javadocTask)
 
 jar {
     from files(
-            getAndroidLibraryVariantsForJavadoc().collect { LibraryVariant variant ->
+            getAndroidLibraryVariantsForJar().collect { LibraryVariant variant ->
                 variant.getJavaCompileProvider().get().destinationDirectory
             }
     )


### PR DESCRIPTION
Progress for #5043

Annotation processors (including ksp) only run on newly compiled code. Libraries have been previously compiled, so an annotation processor will not be run on them. To find any LibraryGlideModules included in those libraries, we look for specific generated classes in those libraries that we call Indexes. Indexes contain an annotation listing the class names of any LibraryGlideModules. Indexes are generated by Glide's annotation processors for each library and are exported as part of the library.

To preserve the package private visibility of the existing Java Index annotation, I created a new Index annotation for the KSP processor. This lets us reference the KSP Index annotation directly.

Unfortunately it also means that the Java and KSP Index classes are not the same. While it's only a small amount of duplicated code, it's a significant compatibility issue because the KSP and Java processors no longer produce the same Index class.

In particular the KSP processor looks only for its Index class and not for the Java processor's Index class. This is unfortunate because Glide's libraries are always processed by the Java annotation processor, not the KSP processor. In turn this means that Glide's KSP processor effectively ignores any of Glide's integration libraries.

To fix this in the short term I've made the KSP processor look for both its Indexes and the Java annotation processors Indexes. A more robust fix would be to merge the two Index processors so that the annotation processors are mutually compatible. I'll do that in a follow-up.

I've written tests, but they're somewhat involved so I'll send them as a follow-up.
