### PR TITLE
Run regression tests when resources are present or we're regenerating.

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/CenterCropRegressionTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/CenterCropRegressionTest.java
@@ -34,7 +34,8 @@ public class CenterCropRegressionTest {
   @Before
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
-    bitmapRegressionTester = new BitmapRegressionTester(getClass(), testName);
+    bitmapRegressionTester =
+        BitmapRegressionTester.newInstance(getClass(), testName).assumeShouldRun();
     canonical = new CanonicalBitmap();
   }
 

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/CenterInsideRegressionTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/CenterInsideRegressionTest.java
@@ -34,7 +34,8 @@ public class CenterInsideRegressionTest {
   @Before
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
-    bitmapRegressionTester = new BitmapRegressionTester(getClass(), testName);
+    bitmapRegressionTester =
+        BitmapRegressionTester.newInstance(getClass(), testName).assumeShouldRun();
     canonical = new CanonicalBitmap();
   }
 

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/CircleCropRegressionTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/CircleCropRegressionTest.java
@@ -34,7 +34,8 @@ public class CircleCropRegressionTest {
   @Before
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
-    bitmapRegressionTester = new BitmapRegressionTester(getClass(), testName);
+    bitmapRegressionTester =
+        BitmapRegressionTester.newInstance(getClass(), testName).assumeShouldRun();
     canonical = new CanonicalBitmap();
   }
 

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/FitCenterRegressionTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/FitCenterRegressionTest.java
@@ -36,7 +36,8 @@ public class FitCenterRegressionTest {
   @Before
   public void setUp() {
     context = ApplicationProvider.getApplicationContext();
-    bitmapRegressionTester = new BitmapRegressionTester(getClass(), testName);
+    bitmapRegressionTester =
+        BitmapRegressionTester.newInstance(getClass(), testName).assumeShouldRun();
     canonical = new CanonicalBitmap();
   }
 

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/RoundedCornersRegressionTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/RoundedCornersRegressionTest.java
@@ -43,7 +43,8 @@ public class RoundedCornersRegressionTest {
   @Before
   public void setUp() throws Exception {
     context = ApplicationProvider.getApplicationContext();
-    bitmapRegressionTester = new BitmapRegressionTester(getClass(), testName);
+    bitmapRegressionTester =
+        BitmapRegressionTester.newInstance(getClass(), testName).assumeShouldRun();
     canonicalBitmap = new CanonicalBitmap();
   }
 

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/test/BitmapRegressionTester.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/test/BitmapRegressionTester.java
@@ -1,6 +1,7 @@
 package com.bumptech.glide.test;
 
 import static com.bumptech.glide.testutil.BitmapSubject.assertThat;
+import static org.junit.Assume.assumeTrue;
 
 import android.content.Context;
 import android.graphics.Bitmap;
@@ -41,17 +42,37 @@ public final class BitmapRegressionTester {
   private static final String GENERATED_FILES_DIR = "test_files";
   private static final String SEPARATOR = "_";
 
+  private static final int RESOURCE_ID_NOT_FOUND = 0;
+
   private final Class<?> testClass;
   private final TestName testName;
   private final Context context = ApplicationProvider.getApplicationContext();
 
-  public BitmapRegressionTester(Class<?> testClass, TestName testName) {
+  public static AssumeCanRun newInstance(Class<?> testClass, TestName testName) {
+    return new AssumeCanRun(new BitmapRegressionTester(testClass, testName));
+  }
+
+  private BitmapRegressionTester(Class<?> testClass, TestName testName) {
     this.testClass = testClass;
     this.testName = testName;
 
     if (testClass.getAnnotation(RegressionTest.class) == null) {
       throw new IllegalArgumentException(
           testClass + " must be annotated with " + RegressionTest.class);
+    }
+  }
+
+  public static final class AssumeCanRun {
+
+    private final BitmapRegressionTester regressionTester;
+
+    private AssumeCanRun(BitmapRegressionTester regressionTester) {
+      this.regressionTester = regressionTester;
+    }
+    public BitmapRegressionTester assumeShouldRun() {
+      boolean shouldRun = regressionTester.shouldRun();
+      assumeTrue(shouldRun);
+      return regressionTester;
     }
   }
 
@@ -166,17 +187,24 @@ public final class BitmapRegressionTester {
     }
   }
 
+  private boolean shouldRun() {
+    return writeNewExpected() || getResourceId() != RESOURCE_ID_NOT_FOUND;
+  }
+
   private boolean writeNewExpected() {
     File testFiles = getTestFilesDir();
     return new File(testFiles, REGENERATE_SIGNAL_FILE_NAME).exists();
   }
 
+  private int getResourceId() {
+    return context
+        .getResources()
+        .getIdentifier(getResourceName(), RESOURCE_TYPE, context.getPackageName());
+  }
+
   private Bitmap decodeExpected() {
-    int resourceId =
-        context
-            .getResources()
-            .getIdentifier(getResourceName(), RESOURCE_TYPE, context.getPackageName());
-    if (resourceId == 0) {
+    int resourceId = getResourceId();
+    if (resourceId == RESOURCE_ID_NOT_FOUND) {
       throw new IllegalArgumentException(
           "Failed to find resource for: "
               + getResourceName()


### PR DESCRIPTION
Previously the regression tests would run always, which means that they'd fail 100% of the time for any device, emulator or SDK combination that we hadn't previously generated resources for.

By ignoring these tests when the resources are missing and we aren't trying to generate them, we make the emulator test output much more useful for additional device types or emulators (ie those used for testing features, but not in our regular test suite).