### PR TITLE
Fixed "PackageManager features are not supported" in preview mode of jetpack compose

### DIFF
--- a/library/src/main/java/com/bumptech/glide/module/ManifestParser.java
+++ b/library/src/main/java/com/bumptech/glide/module/ManifestParser.java
@@ -30,9 +30,17 @@ public final class ManifestParser {
   @SuppressWarnings("ConstantConditions")
   @Nullable
   private ApplicationInfo getOurApplicationInfo() throws NameNotFoundException {
-    return context
-        .getPackageManager()
-        .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+    try {
+      return context
+          .getPackageManager()
+          .getApplicationInfo(context.getPackageName(), PackageManager.GET_META_DATA);
+    } catch (NameNotFoundException e) {
+      if (e.getMessage().equals("PackageManager features are not supported")) {
+        // Only happens in preview mode in jetpack compose
+        return null;
+      }
+      throw e;
+    }
   }
 
   @SuppressWarnings("deprecation")


### PR DESCRIPTION
## Description
The Following error occurs when using glide in the latest stable version of Android Studio(Flamingo 2022.2.1 Patch 1) And Jetpack compose with @Preview.

```
android.content.pm.PackageManager$NameNotFoundException: PackageManager features are not supported  
at com.android.layoutlib.bridge.android.BridgePackageManager.getApplicationInfo(BridgePackageManager.java:179)
at com.bumptech.glide.module.ManifestParser.getOurApplicationInfo(ManifestParser.java:69)
at com.bumptech.glide.module.ManifestParser.parse(ManifestParser.java:86)
at com.bumptech.glide.Glide.initializeGlide(Glide.java:225)
at com.bumptech.glide.Glide.initializeGlide(Glide.java:213)
at com.bumptech.glide.Glide.checkAndInitializeGlide(Glide.java:155)
at com.bumptech.glide.Glide.get(Glide.java:135)
at com.bumptech.glide.Glide.getRetriever(Glide.java:513)
at com.bumptech.glide.Glide.with(Glide.java:540)
at com.bumptech.glide.integration.compose.GlideImageKt.GlideImage(GlideImage.kt:107)
...
```

```
public class TestTest {
    @OptIn(ExperimentalGlideComposeApi::class)
    @Preview
    @Composable
    public fun Test() {
        val resourceId = android.R.drawable.star_big_on
        GlideImage(
                model = resourceId,
                contentDescription = "test",
        )
    }
}
```

I guesss it used to return null, but now it seems to thow NameNotFoundException.

This issue can be solved by adding "if LocalInspectionMode.current" and ignoring it only when jetpack compose @Preview, 
but this is not possible because compose method can not call from ManifestParser.java.

This is not a good practice, but I implemented it so that it is reflected only when the error message string matches.

