### PR TITLE
Add factory method to indicate when executors are not owned by Glide in tests.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/Engine.java
@@ -578,10 +578,18 @@ public class Engine
 
     @VisibleForTesting
     void shutdown() {
-      Executors.shutdownAndAwaitTermination(diskCacheExecutor);
-      Executors.shutdownAndAwaitTermination(sourceExecutor);
-      Executors.shutdownAndAwaitTermination(sourceUnlimitedExecutor);
-      Executors.shutdownAndAwaitTermination(animationExecutor);
+      if (!diskCacheExecutor.isExternal()) {
+        Executors.shutdownAndAwaitTermination(diskCacheExecutor);
+      }
+      if (!sourceExecutor.isExternal()) {
+        Executors.shutdownAndAwaitTermination(sourceExecutor);
+      }
+      if (!sourceUnlimitedExecutor.isExternal()) {
+        Executors.shutdownAndAwaitTermination(sourceUnlimitedExecutor);
+      }
+      if (!animationExecutor.isExternal()) {
+        Executors.shutdownAndAwaitTermination(animationExecutor);
+      }
     }
 
     @SuppressWarnings("unchecked")

--- a/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/executor/GlideExecutor.java
@@ -63,6 +63,7 @@ public final class GlideExecutor implements ExecutorService {
   private static volatile int bestThreadCount;
 
   private final ExecutorService delegate;
+  private final boolean isDelegateExternal;
 
   /**
    * Returns a new {@link Builder} with the {@link #DEFAULT_DISK_CACHE_EXECUTOR_THREADS} threads,
@@ -227,7 +228,29 @@ public final class GlideExecutor implements ExecutorService {
 
   @VisibleForTesting
   GlideExecutor(ExecutorService delegate) {
+    this(delegate, /* isDelegateExternal= */ false);
+  }
+
+  /**
+   * @param isDelegateExternal Whether the delegate executor is owned by Glide or external. See
+   *     {@link #isExternal()}.
+   */
+  @VisibleForTesting
+  GlideExecutor(ExecutorService delegate, boolean isDelegateExternal) {
     this.delegate = delegate;
+    this.isDelegateExternal = isDelegateExternal;
+  }
+
+  /**
+   * Returns true if this executor is not "owned" by Glide.
+   *
+   * <p>Typically this means the executor was created using {@link
+   * MockGlideExecutor#wrapExecutor(ExecutorService)}. Glide will not shutdown executors that are
+   * external during teardown. Typically this is only important in testing environments Glide is
+   * recreated and torn down between tests.
+   */
+  public boolean isExternal() {
+    return isDelegateExternal;
   }
 
   @Override

--- a/mocks/src/main/java/com/bumptech/glide/load/engine/executor/MockGlideExecutor.java
+++ b/mocks/src/main/java/com/bumptech/glide/load/engine/executor/MockGlideExecutor.java
@@ -17,10 +17,30 @@ public final class MockGlideExecutor {
     // Utility class.
   }
 
-  // Public API.
+  /**
+   * Returns a new Glide executor that delegates to the provided {@code executorService}.
+   *
+   * <p>The service provided will be considered managed by Glide and will be shutdown when {@link
+   * com.bumptech.glide.Glide#tearDown()} is called. To use an executor that should not be torn down
+   * by Glide use {@link #wrapExecutor(ExecutorService)}. If you're creating a new executor for a
+   * test (e.g. an idling resource executor) then typically you should use this method.
+   */
   @SuppressWarnings("WeakerAccess")
   public static GlideExecutor newTestExecutor(ExecutorService executorService) {
     return new GlideExecutor(executorService);
+  }
+
+  /**
+   * Wraps an external executor in a {@link GlideExecutor}.
+   *
+   * <p>This should only be used when the executor used in a test is externally managed and will be
+   * shutdown by the calling code or application, Glide will not shutdown the executor when {@link
+   * com.bumptech.glide.Glide#tearDown()} is called. Most users should prefer {@link
+   * #newTestExecutor(ExecutorService)}.
+   */
+  @SuppressWarnings("WeakerAccess")
+  public static GlideExecutor wrapExecutor(ExecutorService executorService) {
+    return new GlideExecutor(executorService, /* isDelegateExternal= */ true);
   }
 
   public static GlideExecutor newMainThreadExecutor() {


### PR DESCRIPTION
Previously Glide would shutdown all executors when `Glide.teardown` was called, which is also implicitly called when `Glide.init` is called and a Glide has either been previously explicitly or implicitly initialized. Some test environments wrap their own managed executors with `GlideExecutor` and these executors are not always owned by Glide.