### PR TITLE
Do not set requireOriginal on Android photo picker uris.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
@@ -20,7 +20,7 @@ public final class MediaStoreUtil {
         && MediaStore.AUTHORITY.equals(uri.getAuthority());
   }
 
-  // Android picker uris contains "picker" segment:
+  // Android picker uris contain "picker" segment:
   // https://android.googlesource.com/platform/packages/providers/MediaProvider/+/refs/heads/master/src/com/android/providers/media/PickerUriResolver.java#58
   public static boolean isAndroidPickerUri(Uri uri) {
     return isMediaStoreUri(uri) && uri.getPathSegments().contains("picker");

--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
@@ -20,6 +20,12 @@ public final class MediaStoreUtil {
         && MediaStore.AUTHORITY.equals(uri.getAuthority());
   }
 
+  // Android picker uris contains "picker" segment:
+  // https://android.googlesource.com/platform/packages/providers/MediaProvider/+/refs/heads/master/src/com/android/providers/media/PickerUriResolver.java#58
+  public static boolean isAndroidPickerUri(Uri uri) {
+    return isMediaStoreUri(uri) && uri.getPathSegments().contains("picker");
+  }
+
   private static boolean isVideoUri(Uri uri) {
     return uri.getPathSegments().contains("video");
   }

--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
@@ -20,7 +20,7 @@ public final class MediaStoreUtil {
         && MediaStore.AUTHORITY.equals(uri.getAuthority());
   }
 
-  // Android picker uris contain "picker" segment:
+  // Android picker uris contain a "picker" segment:
   // https://android.googlesource.com/platform/packages/providers/MediaProvider/+/refs/heads/master/src/com/android/providers/media/PickerUriResolver.java#58
   public static boolean isAndroidPickerUri(Uri uri) {
     return isMediaStoreUri(uri) && uri.getPathSegments().contains("picker");

--- a/library/src/main/java/com/bumptech/glide/load/model/stream/QMediaStoreUriLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/stream/QMediaStoreUriLoader.java
@@ -156,6 +156,11 @@ public final class QMediaStoreUriLoader<DataT> implements ModelLoader<Uri, DataT
       if (Environment.isExternalStorageLegacy()) {
         return fileDelegate.buildLoadData(queryForFilePath(uri), width, height, options);
       } else {
+        // Android Picker uris have MediaStore authority and does not accept requireOriginal.
+        if (MediaStoreUtil.isAndroidPickerUri(uri)) {
+          return uriDelegate.buildLoadData(uri, width, height, options);
+        }
+
         Uri toLoad = isAccessMediaLocationGranted() ? MediaStore.setRequireOriginal(uri) : uri;
         return uriDelegate.buildLoadData(toLoad, width, height, options);
       }

--- a/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtilTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtilTest.java
@@ -1,0 +1,30 @@
+package com.bumptech.glide.load.data.mediastore;
+
+import static com.google.common.truth.Truth.assertThat;
+
+import android.net.Uri;
+import android.provider.MediaStore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 18)
+public class MediaStoreUtilTest {
+
+  @Test
+  public void isAndroidPickerUri_notAndroidPickerUri_returnsFalse() {
+    Uri mediaStoreUri = Uri.withAppendedPath(MediaStore.Video.Media.EXTERNAL_CONTENT_URI, "123");
+
+    assertThat(MediaStoreUtil.isAndroidPickerUri(mediaStoreUri)).isFalse();
+  }
+
+  @Test
+  public void isAndroidPickerUri_identifiesAndroidPickerUri_returnsTrue() {
+    Uri androidPickerUri =
+        Uri.parse("content://media/picker/0/com.android.providers.media.photopicker/media/123");
+
+    assertThat(MediaStoreUtil.isAndroidPickerUri(androidPickerUri)).isTrue();
+  }
+}


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Load Android photo picker uris directly without setting requireOriginal.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
For apps that are targeting Android Q and have android.Manifest.permission#ACCESS_MEDIA_LOCATION, Glide will automatically request with requireOriginal to avoid location redaction. Android recently introduced a photo picker (https://developer.android.com/training/data-storage/shared/photopicker), whose uris have MediaStore authority but does not accept requireOriginal. Glide should load those picker uris directly.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->