### PR TITLE
Add `isInitialized` visible for testing method

### DIFF
--- a/library/src/main/java/com/bumptech/glide/Glide.java
+++ b/library/src/main/java/com/bumptech/glide/Glide.java
@@ -183,6 +183,11 @@ public class Glide implements ComponentCallbacks2 {
     }
   }
 
+  @VisibleForTesting
+  public static synchronized boolean isInitialized() {
+    return glide != null;
+  }
+
   /**
    * Allows hardware Bitmaps to be used prior to the first frame in the app being drawn as soon as
    * this method is called.

--- a/library/test/src/test/java/com/bumptech/glide/InitializeGlideTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/InitializeGlideTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide;
 
+import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 
 import android.content.Context;
@@ -68,5 +69,17 @@ public class InitializeGlideTest {
     assertThrows(TestException.class, initializeGlide);
     // Make sure the second exception isn't hidden by some Glide initialization related exception.
     assertThrows(TestException.class, initializeGlide);
+  }
+
+  @Test
+  public void isInitialized_whenNotInitialized_returnsFalse() {
+    assertThat(Glide.isInitialized()).isFalse();
+  }
+
+  @Test
+  public void isInitialized_whenInitialized_returnsTrue() {
+    Glide.get(context);
+
+    assertThat(Glide.isInitialized()).isTrue();
   }
 }


### PR DESCRIPTION
Glide provides an `init` method for test authors and rule writers to initialize Glide with custom executors but due to the transparent way it self initializes and tears down when re-initialized it makes it hard to assert the state of Glide. One easy way to misconfigure Glide when using dependency injection is for something to obtain an instance before the test has called `init`, in this case the instance that was read will be torn down but will typically fail in mysterious ways; Glide doesn't throw an exception when a torn down instance is attempted to be loaded from, usually the request will be rejected by the executors because they've been shutdown.

Adding `isInitialized` allows test authors and rule writers to assert that Glide has not been initialized before the test initializes Glide.