### PR TITLE
Log instead of throwing parsing manifests.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/module/ManifestParser.java
+++ b/library/src/main/java/com/bumptech/glide/module/ManifestParser.java
@@ -60,11 +60,13 @@ public final class ManifestParser {
           }
         }
       }
+      if (Log.isLoggable(TAG, Log.DEBUG)) {
+        Log.d(TAG, "Finished loading Glide modules");
+      }
     } catch (PackageManager.NameNotFoundException e) {
-      throw new RuntimeException("Unable to find metadata to parse GlideModules", e);
-    }
-    if (Log.isLoggable(TAG, Log.DEBUG)) {
-      Log.d(TAG, "Finished loading Glide modules");
+      if (Log.isLoggable(TAG, Log.ERROR)) {
+        Log.e(TAG, "Failed to parse glide modules", e);
+      }
     }
 
     return modules;

--- a/library/test/src/test/java/com/bumptech/glide/module/ManifestParserTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/module/ManifestParserTest.java
@@ -1,7 +1,6 @@
 package com.bumptech.glide.module;
 
 import static com.google.common.truth.Truth.assertThat;
-import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,7 +20,6 @@ import com.bumptech.glide.Registry;
 import java.util.List;
 import org.junit.Before;
 import org.junit.Test;
-import org.junit.function.ThrowingRunnable;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
@@ -125,20 +123,12 @@ public class ManifestParserTest {
   }
 
   @Test
-  public void parse_withMissingName_throwsRuntimeException() throws NameNotFoundException {
+  public void parse_withMissingName_doesNotThrow() throws NameNotFoundException {
     PackageManager pm = mock(PackageManager.class);
     doThrow(new NameNotFoundException("name")).when(pm).getApplicationInfo(anyString(), anyInt());
     when(context.getPackageManager()).thenReturn(pm);
 
-    assertThrows(
-        "Unable to find metadata to parse GlideModules",
-        RuntimeException.class,
-        new ThrowingRunnable() {
-          @Override
-          public void run() {
-            parser.parse();
-          }
-        });
+    parser.parse();
   }
 
   private void addModuleToManifest(Class<?> moduleClass) {


### PR DESCRIPTION
Fixes AS's preview mode when manifest parsing is enabled.