### PR TITLE
Disable java 7 source obsolete warning.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -140,6 +140,8 @@ subprojects { project ->
             "-Werror",
             //Enable all warnings.
             "-Xlint:all",
+            // Disable warnings about source 7 being obsolete.
+            "-Xlint:-options",
             // Java expects every annotation to have a processor, but we use
             // javax.annotation.Nullable, which doesn't have one.
             "-Xlint:-processing",


### PR DESCRIPTION
We treat warnings as errors, so this warning breaks the build in AS in some versions. It's not immediately actionable, so we might as well disable the warning.
