### PR TITLE
fix caching and resizing in SVG sample  

### DIFF
--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/MainActivity.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/MainActivity.java
@@ -13,6 +13,7 @@ import android.widget.ImageView;
 import android.widget.TextView;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.RequestBuilder;
+import com.bumptech.glide.RequestManager;
 import com.bumptech.glide.util.Preconditions;
 import java.io.File;
 
@@ -33,7 +34,7 @@ public class MainActivity extends Activity {
     imageViewNet = (ImageView) findViewById(R.id.svg_image_view2);
 
     requestBuilder =
-        GlideApp.with(this)
+        Glide.with(getApplicationContext())
             .as(PictureDrawable.class)
             .placeholder(R.drawable.image_loading)
             .error(R.drawable.image_error)
@@ -49,10 +50,10 @@ public class MainActivity extends Activity {
 
   public void clearCache(View v) {
     Log.w(TAG, "clearing cache");
-    GlideRequests glideRequests = GlideApp.with(this);
+    RequestManager glideRequests = Glide.with(getApplicationContext());
     glideRequests.clear(imageViewRes);
     glideRequests.clear(imageViewNet);
-    GlideApp.get(this).clearMemory();
+    Glide.get(this).clearMemory();
     File cacheDir = Preconditions.checkNotNull(Glide.getPhotoCacheDir(this));
     if (cacheDir.isDirectory()) {
       for (File child : cacheDir.listFiles()) {

--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgDecoder.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgDecoder.java
@@ -26,6 +26,12 @@ public class SvgDecoder implements ResourceDecoder<InputStream, SVG> {
       throws IOException {
     try {
       SVG svg = SVG.getFromInputStream(source);
+
+      // if viewBox is not set, resizing will not work properly, so set it to the actual size
+      if (svg.getDocumentViewBox() == null) {
+        svg.setDocumentViewBox(0f, 0f, svg.getDocumentWidth(), svg.getDocumentHeight());
+      }
+
       if (width != SIZE_ORIGINAL) {
         svg.setDocumentWidth(width);
       }

--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgEncoder.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgEncoder.java
@@ -1,0 +1,68 @@
+package com.bumptech.glide.samples.svg;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.Picture;
+import com.bumptech.glide.load.EncodeStrategy;
+import com.bumptech.glide.load.Options;
+import com.bumptech.glide.load.ResourceEncoder;
+import com.bumptech.glide.load.engine.Resource;
+import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
+import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
+import com.caverock.androidsvg.SVG;
+import java.io.File;
+import com.bumptech.glide.load.resource.bitmap.BitmapEncoder;
+import com.bumptech.glide.load.resource.bitmap.BitmapResource;
+
+/**
+ * This class encodes SVG resources into bitmap form.
+ *
+ * Note: This class is required to make Glide's DiskCacheStrategy work correctly.
+ * Glide uses this class to encode SVG resources, which allows it to cache the resulting
+ * bitmaps on disk. Without this class, Glide wouldn't know how to convert SVG resources
+ * into a form it can cache, which would prevent DiskCacheStrategy from functioning as expected.
+ */
+public class SvgEncoder implements ResourceEncoder<SVG> {
+  private ArrayPool arrayPool; // An ArrayPool used in the encoding process
+  private BitmapPool bitmapPool; // A BitmapPool used in the encoding process
+  private BitmapEncoder bitmapEncoder; // An instance of BitmapEncoder to delegate the actual encoding process
+
+  // Constructor that initializes the ArrayPool, BitmapPool, and BitmapEncoder
+  public SvgEncoder(ArrayPool arrayPool, BitmapPool bitmapPool) {
+    this.arrayPool = arrayPool;
+    this.bitmapPool = bitmapPool;
+    this.bitmapEncoder = new BitmapEncoder(arrayPool);
+  }
+
+  // Encodes the provided SVG resource into bitmap form
+  @Override
+  public boolean encode(Resource<SVG> data, File file, Options options) {
+    SVG svg = data.get(); // Retrieve SVG from the resource
+    Picture picture = svg.renderToPicture(); // Render SVG to Picture
+    int width = picture.getWidth(); // Get width of the picture
+    int height = picture.getHeight(); // Get height of the picture
+    Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888); // Create Bitmap of specified size
+    Canvas canvas = new Canvas(bitmap); // Create Canvas to draw the Bitmap
+
+    // Draw the picture onto the canvas, thereby transferring it to the bitmap
+    picture.draw(canvas);
+
+    // Obtain a BitmapResource from the bitmap
+    BitmapResource resource = BitmapResource.obtain(bitmap, bitmapPool);
+    // Encode the BitmapResource if possible
+    boolean isEncoded = resource != null && bitmapEncoder.encode(resource, file, options);
+
+    // To free memory ASAP, recycle the bitmap
+    bitmap.recycle();
+
+    // Return the status of encoding
+    return isEncoded;
+  }
+
+  // Return the EncodeStrategy of the bitmapEncoder
+  @Override
+  public EncodeStrategy getEncodeStrategy(Options options) {
+    return bitmapEncoder.getEncodeStrategy(options);
+  }
+}
+

--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgModule.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgModule.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.samples.svg;
 
 import android.content.Context;
 import android.graphics.drawable.PictureDrawable;
+import android.util.Log;
 import androidx.annotation.NonNull;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Registry;
@@ -16,9 +17,11 @@ public class SvgModule extends AppGlideModule {
   @Override
   public void registerComponents(
       @NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
+    Log.d("SvgModule", "working!!");
     registry
         .register(SVG.class, PictureDrawable.class, new SvgDrawableTranscoder())
-        .append(InputStream.class, SVG.class, new SvgDecoder());
+        .append(InputStream.class, SVG.class, new SvgDecoder())
+        .append(SVG.class, new SvgEncoder(glide.getArrayPool(), glide.getBitmapPool()));
   }
 
   // Disable manifest parsing to avoid adding similar modules twice.

--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgModule.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgModule.java
@@ -2,7 +2,6 @@ package com.bumptech.glide.samples.svg;
 
 import android.content.Context;
 import android.graphics.drawable.PictureDrawable;
-import android.util.Log;
 import androidx.annotation.NonNull;
 import com.bumptech.glide.Glide;
 import com.bumptech.glide.Registry;
@@ -17,7 +16,6 @@ public class SvgModule extends AppGlideModule {
   @Override
   public void registerComponents(
       @NonNull Context context, @NonNull Glide glide, @NonNull Registry registry) {
-    Log.d("SvgModule", "working!!");
     registry
         .register(SVG.class, PictureDrawable.class, new SvgDrawableTranscoder())
         .append(InputStream.class, SVG.class, new SvgDecoder())


### PR DESCRIPTION
## Description
The current SVG loading images example has issue with caching using `diskCacheStrategy` and resizing using `override`.
This PR aims to fix those both issues.

## Motivation and Context
It took some time to understand why `diskCacheStrategy` and resizing (for some SVG images) with `override` doesn't work the problem was in missing `SvgEncoder` and missing `viewBox` in SVG.