### PR TITLE
Add an updated proguard plugin to compile on Java 17.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
           - uses: actions/checkout@v3
           - uses: actions/setup-java@v3
             with:
-              java-version: '11'
+              java-version: '17'
               distribution: 'zulu'
           - uses: gradle/gradle-build-action@v2
           - name: Build and run unit tests with Gradle

--- a/build.gradle
+++ b/build.gradle
@@ -20,6 +20,7 @@ buildscript {
         classpath libs.ksp.gradle
         classpath libs.coroutines.binarycompat.gradle
         classpath libs.dokka.gradle
+        classpath 'com.guardsquare:proguard-gradle:' + (JavaVersion.current().isCompatibleWith(JavaVersion.VERSION_11) ? '7.3.2' : '7.1.0')
     }
 }
 


### PR DESCRIPTION
Related to #5003. This at least lets Glide compile on Java 17. I'm not sure if it has any down stream impact on users of Glide.
