### PR TITLE
Update dagger to use androidx in Imgur sample and update ci tests

### DIFF
--- a/samples/imgur/build.gradle
+++ b/samples/imgur/build.gradle
@@ -11,7 +11,6 @@ android {
         versionName "1.0"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-
     }
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_1_7
@@ -30,9 +29,6 @@ dependencies {
 
     implementation libs.dagger
     implementation libs.dagger.android
-    implementation (libs.dagger.android.support) {
-        exclude group: "com.android.support"
-    }
     annotationProcessor libs.dagger.compiler
     annotationProcessor libs.dagger.android.processor
 

--- a/samples/imgur/src/main/java/com/bumptech/glide/samples/imgur/ImgurApplication.java
+++ b/samples/imgur/src/main/java/com/bumptech/glide/samples/imgur/ImgurApplication.java
@@ -1,7 +1,7 @@
 package com.bumptech.glide.samples.imgur;
 
 import dagger.android.AndroidInjector;
-import dagger.android.support.DaggerApplication;
+import dagger.android.DaggerApplication;
 
 /** Runs Dagger injection in the Imgur sample. */
 public final class ImgurApplication extends DaggerApplication {

--- a/samples/imgur/src/main/java/com/bumptech/glide/samples/imgur/ImgurApplicationComponent.java
+++ b/samples/imgur/src/main/java/com/bumptech/glide/samples/imgur/ImgurApplicationComponent.java
@@ -3,14 +3,14 @@ package com.bumptech.glide.samples.imgur;
 import com.bumptech.glide.samples.imgur.api.ApiModule;
 import dagger.Component;
 import dagger.android.AndroidInjector;
-import dagger.android.support.AndroidSupportInjectionModule;
+import dagger.android.AndroidInjectionModule;
 import javax.inject.Singleton;
 
 /** Specifies Dagger modules for {@link ImgurApplication}. */
 @Singleton
 @Component(
     modules = {
-      AndroidSupportInjectionModule.class,
+      AndroidInjectionModule.class,
       MainActivityModule.class,
       ApplicationModule.class,
       ApiModule.class

--- a/scripts/ci_unit.sh
+++ b/scripts/ci_unit.sh
@@ -2,15 +2,35 @@
 
 set -e
 
-# TODO(judds): Remove the KSP tests when support is available to run them in
-# Google3
 ./gradlew build \
-  -x :samples:flickr:build \
-  -x :samples:giphy:build \
-  -x :samples:contacturi:build \
-  -x :samples:gallery:build \
-  -x :samples:imgur:build \
-  -x :samples:svg:build \
+  -x :library:test:testDebugUnitTest \
+  :library:test:assembleDebugUnitTest \
+  -x :library:testDebugUnitTest \
+  :library:assembleDebugUnitTest \
+  -x :annotation:ksp:test:testDebugUnitTest \
+  :annotation:ksp:test:assembleDebugUnitTest \
+  -x :third_party:disklrucache:testDebugUnitTest \
+  :third_party:disklrucache:assembleDebugUnitTest \
+  -x :integration:cronet:testDebugUnitTest \
+  :integration:cronet:assembleDebugUnitTest \
+  -x :integration:gifencoder:testDebugUnitTest \
+  :integration:gifencoder:assembleDebugUnitTest \
+  -x :integration:ktx:testDebugUnitTest \
+  :integration:ktx:assembleDebugUnitTest \
+  -x :integration:concurrent:testDebugUnitTest \
+  :integration:concurrent:assembleDebugUnitTest \
+  -x :integration:volley:testDebugUnitTest \
+  :integration:volley:assembleDebugUnitTest \
+  -x :integration:sqljournaldiskcache:testDebugUnitTest \
+  :integration:sqljournaldiskcache:assembleDebugUnitTest \
+  -x :third_party:gif_decoder:testDebugUnitTest \
+  :third_party:gif_decoder:assembleDebugUnitTest \
+  :samples:flickr:build \
+  :samples:giphy:build \
+  :samples:contacturi:build \
+  :samples:gallery:build \
+  :samples:imgur:build \
+  :samples:svg:build \
   :instrumentation:assembleAndroidTest \
   :benchmark:assembleAndroidTest \
   :glide:releaseJavadoc \

--- a/settings.gradle
+++ b/settings.gradle
@@ -55,7 +55,7 @@ dependencyResolutionManagement {
             // Versions for dependencies
             version('compose', '1.3.2')
             version('coroutines', '1.6.4')
-            version('dagger', '2.15')
+            version('dagger', '2.46.1')
             version('errorprone', '2.18.0')
             version('kotlin', '1.7.0')
             version('mockito', '5.3.1')


### PR DESCRIPTION
Imgur was broken because we removed jetifier in 8d7462119a65e208cdf6315e0141fb651f2c4623, but we still used an old version of Dagger that required a support library add-on. We didn't notice because we were avoiding building the samples in the external unit tests.

I've updated the version of Dagger to a newer version that uses androidx. I've also updated the ci unit tests to include the samples (and avoid some duplicate debug unit tests, they're all run identically as release tests). 