### PR TITLE
Move size resolution from GlideImage to GlidePainter

### DIFF
--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Sizes.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Sizes.kt
@@ -2,13 +2,12 @@
 
 package com.bumptech.glide.integration.compose
 
-import androidx.compose.ui.unit.Constraints
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.integration.ktx.InternalGlideApi
 import com.bumptech.glide.integration.ktx.Size
 import com.bumptech.glide.integration.ktx.isValidGlideDimension
-import com.bumptech.glide.request.target.Target
 import kotlinx.coroutines.CompletableDeferred
+import kotlin.math.roundToInt
 
 internal class SizeObserver {
   private val size = CompletableDeferred<Size>()
@@ -32,12 +31,11 @@ internal fun RequestBuilder<out Any?>.overrideSize(): Size? =
 internal fun RequestBuilder<out Any?>.isOverrideSizeSet(): Boolean =
   overrideWidth.isValidGlideDimension() && overrideHeight.isValidGlideDimension()
 
-internal fun Constraints.inferredGlideSize(): Size? {
-  val width = if (hasBoundedWidth) maxWidth else Target.SIZE_ORIGINAL
-  val height = if (hasBoundedHeight) maxHeight else Target.SIZE_ORIGINAL
+internal fun androidx.compose.ui.geometry.Size.toGlideSize(): Size? {
+  val width = width.roundToInt();
+  val height = height.roundToInt();
   if (!width.isValidGlideDimension() || !height.isValidGlideDimension()) {
-    return null
+    return null;
   }
-  return Size(width, height)
+  return Size(width, height);
 }
-


### PR DESCRIPTION
If we want to expose GlidePainter as a separate API, we need some way to do size resolution. Rather than awkwardly figuring out a way to shoehorn a Modifier into the API, we can instead look at the painter's size in onDraw. 

I've also simplified some of the size handling code to remove SizeObserver. All the async size resolution logic is now in AsyncGlideSize.