### PR TITLE
Use onIdle to avoid a race in FlowTests

### DIFF
--- a/integration/ktx/build.gradle
+++ b/integration/ktx/build.gradle
@@ -42,6 +42,8 @@ dependencies {
     api project(":library")
     implementation libs.androidx.core.ktx
     implementation libs.coroutines.core
+    testImplementation libs.androidx.espresso
+    testImplementation libs.androidx.espresso.idling
     testImplementation libs.androidx.test.ktx
     testImplementation libs.kotlin.junit
     testImplementation libs.androidx.test.ktx.junit

--- a/integration/ktx/src/test/java/com/bumptech/glide/load/engine/executor/GlideIdlingResourceInit.kt
+++ b/integration/ktx/src/test/java/com/bumptech/glide/load/engine/executor/GlideIdlingResourceInit.kt
@@ -1,0 +1,36 @@
+package com.bumptech.glide.load.engine.executor
+
+import androidx.test.core.app.ApplicationProvider
+import androidx.test.espresso.IdlingRegistry
+import androidx.test.espresso.idling.concurrent.IdlingThreadPoolExecutor
+import com.bumptech.glide.Glide
+import com.bumptech.glide.GlideBuilder
+import java.util.concurrent.LinkedBlockingQueue
+import java.util.concurrent.TimeUnit
+
+object GlideIdlingResources {
+
+    fun initGlide(builder: GlideBuilder? = null) {
+        val registry = IdlingRegistry.getInstance()
+        val executor =
+            IdlingThreadPoolExecutor(
+                "glide_test_thread",
+                /* corePoolSize = */ 1,
+                /* maximumPoolSize = */ 1,
+                /* keepAliveTime = */ 1,
+                TimeUnit.SECONDS,
+                LinkedBlockingQueue()
+            ) {
+                Thread(it)
+            }
+        val glideExecutor = GlideExecutor(executor)
+        Glide.init(
+            ApplicationProvider.getApplicationContext(),
+            (builder ?: GlideBuilder())
+                .setSourceExecutor(glideExecutor)
+                .setAnimationExecutor(glideExecutor)
+                .setDiskCacheExecutor(glideExecutor)
+        )
+        registry.register(executor)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -54,14 +54,14 @@ dependencyResolutionManagement {
 
             // Versions for dependencies
             version('compose', '1.3.2')
-            version('coroutines', '1.6.4')
+            version('coroutines', '1.7.2')
             version('dagger', '2.46.1')
             version('errorprone', '2.18.0')
             version('kotlin', '1.7.0')
             version('mockito', '5.3.1')
             version('retrofit', '2.3.0')
             version('androidx-benchmark', '1.1.1')
-            version('androidx-espresso', '3.4.0')
+            version('androidx-espresso', '3.5.1')
             // At least versions 1.5 and later require java 8 desugaring, which Glide can't
             // currently use, so we're stuck on an older version.
             version('androidx-fragment', '1.3.6')


### PR DESCRIPTION
Glide's executor thread notifies the flow in a loop while holding a lock on the resource. When it finishes, it releases the lock.

If the flow wins the race and runs before Glide's executor releases the lock, the resource will not be recycled in the remainder of the test method. If the executor wins the race and releases the lock first, then the resource will be recycled in the rest of the test method.

To fix this race, I've used Espresso's onIdle and idling resources, similar to the compose rule.
