### PR TITLE
Add an experimental rememberGlidePainter API

### DIFF
--- a/benchmark/src/androidTest/java/com/bumptech/glide/benchmark/BenchmarkFromCache.java
+++ b/benchmark/src/androidTest/java/com/bumptech/glide/benchmark/BenchmarkFromCache.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.benchmark;
 
 import android.app.Application;
 import android.graphics.Bitmap;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.annotation.RawRes;
 import androidx.benchmark.BenchmarkState;
@@ -111,17 +112,17 @@ public class BenchmarkFromCache {
                   public boolean onLoadFailed(
                       @Nullable GlideException e,
                       Object model,
-                      Target<Bitmap> target,
+                      @NonNull Target<Bitmap> target,
                       boolean isFirstResource) {
                     return false;
                   }
 
                   @Override
                   public boolean onResourceReady(
-                      Bitmap resource,
-                      Object model,
+                      @NonNull Bitmap resource,
+                      @NonNull Object model,
                       Target<Bitmap> target,
-                      DataSource dataSource,
+                      @NonNull DataSource dataSource,
                       boolean isFirstResource) {
                     dataSourceRef.set(dataSource);
                     return false;

--- a/instrumentation/src/androidTest/java/com/bumptech/glide/MultiRequestTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/MultiRequestTest.java
@@ -68,17 +68,17 @@ public class MultiRequestTest {
                   public boolean onLoadFailed(
                       @Nullable GlideException e,
                       Object model,
-                      Target<Drawable> target,
+                      @NonNull Target<Drawable> target,
                       boolean isFirstResource) {
                     return false;
                   }
 
                   @Override
                   public boolean onResourceReady(
-                      Drawable resource,
-                      Object model,
+                      @NonNull Drawable resource,
+                      @NonNull Object model,
                       Target<Drawable> target,
-                      DataSource dataSource,
+                      @NonNull DataSource dataSource,
                       boolean isFirstResource) {
                     isPrimaryRequestComplete.set(target.getRequest().isComplete());
                     countDownLatch.countDown();
@@ -115,7 +115,7 @@ public class MultiRequestTest {
                   public boolean onLoadFailed(
                       @Nullable GlideException e,
                       Object model,
-                      Target<Drawable> target,
+                      @NonNull Target<Drawable> target,
                       boolean isFirstResource) {
                     Request request = target.getRequest();
                     isNeitherRunningNorComplete.set(!request.isComplete() && !request.isRunning());
@@ -125,10 +125,10 @@ public class MultiRequestTest {
 
                   @Override
                   public boolean onResourceReady(
-                      Drawable resource,
-                      Object model,
+                      @NonNull Drawable resource,
+                      @NonNull Object model,
                       Target<Drawable> target,
-                      DataSource dataSource,
+                      @NonNull DataSource dataSource,
                       boolean isFirstResource) {
                     return false;
                   }

--- a/integration/compose/api/compose.api
+++ b/integration/compose/api/compose.api
@@ -1,3 +1,22 @@
+public final class com/bumptech/glide/integration/compose/AnimationState : java/lang/Enum {
+	public static final field Animate Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static final field Failed Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static final field Loading Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static final field Success Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static fun valueOf (Ljava/lang/String;)Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static fun values ()[Lcom/bumptech/glide/integration/compose/AnimationState;
+}
+
+public final class com/bumptech/glide/integration/compose/AsyncLayoutSize {
+	public static final field $stable I
+	public fun <init> (Lcom/bumptech/glide/integration/ktx/AsyncGlideSize;)V
+	public final fun copy (Lcom/bumptech/glide/integration/ktx/AsyncGlideSize;)Lcom/bumptech/glide/integration/compose/AsyncLayoutSize;
+	public static synthetic fun copy$default (Lcom/bumptech/glide/integration/compose/AsyncLayoutSize;Lcom/bumptech/glide/integration/ktx/AsyncGlideSize;ILjava/lang/Object;)Lcom/bumptech/glide/integration/compose/AsyncLayoutSize;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
 public abstract interface annotation class com/bumptech/glide/integration/compose/ExperimentalGlideComposeApi : java/lang/annotation/Annotation {
 }
 
@@ -6,6 +25,45 @@ public final class com/bumptech/glide/integration/compose/GlideImageKt {
 	public static final fun placeholder (I)Lcom/bumptech/glide/integration/compose/Placeholder;
 	public static final fun placeholder (Landroid/graphics/drawable/Drawable;)Lcom/bumptech/glide/integration/compose/Placeholder;
 	public static final fun placeholder (Lkotlin/jvm/functions/Function2;)Lcom/bumptech/glide/integration/compose/Placeholder;
+}
+
+public abstract class com/bumptech/glide/integration/compose/GlidePainter : androidx/compose/ui/graphics/painter/Painter {
+	public static final field $stable I
+	public fun <init> ()V
+	public abstract fun getState ()Lcom/bumptech/glide/integration/compose/GlidePainter$State;
+}
+
+public abstract class com/bumptech/glide/integration/compose/GlidePainter$State {
+	public static final field $stable I
+}
+
+public final class com/bumptech/glide/integration/compose/GlidePainter$State$Failure : com/bumptech/glide/integration/compose/GlidePainter$State {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/bumptech/glide/integration/compose/GlidePainter$State$Failure;
+}
+
+public final class com/bumptech/glide/integration/compose/GlidePainter$State$Loading : com/bumptech/glide/integration/compose/GlidePainter$State {
+	public static final field $stable I
+	public static final field INSTANCE Lcom/bumptech/glide/integration/compose/GlidePainter$State$Loading;
+}
+
+public final class com/bumptech/glide/integration/compose/GlidePainter$State$Success : com/bumptech/glide/integration/compose/GlidePainter$State {
+	public static final field $stable I
+	public fun <init> (Lcom/bumptech/glide/load/DataSource;)V
+	public final fun component1 ()Lcom/bumptech/glide/load/DataSource;
+	public final fun copy (Lcom/bumptech/glide/load/DataSource;)Lcom/bumptech/glide/integration/compose/GlidePainter$State$Success;
+	public static synthetic fun copy$default (Lcom/bumptech/glide/integration/compose/GlidePainter$State$Success;Lcom/bumptech/glide/load/DataSource;ILjava/lang/Object;)Lcom/bumptech/glide/integration/compose/GlidePainter$State$Success;
+	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSource ()Lcom/bumptech/glide/load/DataSource;
+	public fun hashCode ()I
+	public fun toString ()Ljava/lang/String;
+}
+
+public final class com/bumptech/glide/integration/compose/GlidePainterKt {
+	public static final fun animate (Lcom/bumptech/glide/integration/compose/GlidePainter$State;)Lcom/bumptech/glide/integration/compose/AnimationState;
+	public static final fun rememberGlidePainter (Ljava/lang/Object;Lcom/bumptech/glide/integration/compose/AsyncLayoutSize;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/bumptech/glide/integration/compose/GlidePainter;
+	public static final fun rememberGlidePainter (Ljava/lang/Object;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)Lcom/bumptech/glide/integration/compose/GlidePainter;
+	public static final fun rememberSizeAndModifier (Landroidx/compose/ui/Modifier;Landroidx/compose/runtime/Composer;I)Lkotlin/Pair;
 }
 
 public abstract interface class com/bumptech/glide/integration/compose/GlidePreloadingData {

--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
@@ -295,17 +295,17 @@ class GlideImageTest {
       override fun onLoadFailed(
         e: GlideException?,
         model: Any?,
-        target: Target<Drawable>?,
+        target: Target<Drawable>,
         isFirstResource: Boolean,
       ): Boolean {
         throw UnsupportedOperationException()
       }
 
       override fun onResourceReady(
-        resource: Drawable?,
-        model: Any?,
-        target: Target<Drawable>?,
-        dataSource: DataSource?,
+        resource: Drawable,
+        model: Any,
+        target: Target<Drawable>,
+        dataSource: DataSource,
         isFirstResource: Boolean,
       ): Boolean {
         onResourceReadyCounter.incrementAndGet()

--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlidePainterTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlidePainterTest.kt
@@ -1,0 +1,155 @@
+@file:OptIn(ExperimentalGlideComposeApi::class)
+
+package com.bumptech.glide.integration.compose
+
+import android.content.Context
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.size
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+import androidx.test.core.app.ApplicationProvider
+import com.bumptech.glide.Glide
+import com.bumptech.glide.integration.compose.test.GlideComposeRule
+import com.bumptech.glide.load.DataSource
+import com.google.common.truth.ComparableSubject
+import com.google.common.truth.Truth.assertThat
+import org.junit.Assert.assertThrows
+import org.junit.Rule
+import org.junit.Test
+
+class GlidePainterTest {
+    val context: Context = ApplicationProvider.getApplicationContext()
+
+    @get:Rule
+    val glideComposeRule = GlideComposeRule()
+
+    @Test
+    fun rememberGlidePainter_withoutSize_startsWithStateLoading() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on)
+        }
+        assertThat(painter!!.state).isEqualTo(GlidePainter.State.Loading)
+    }
+
+    @Test
+    fun rememberGlidePainter_withOverrideSize_loadsImage() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on) {
+                it.override(50)
+            }
+        }
+        glideComposeRule.waitForIdle()
+        assertThat(painter!!.state).isInstanceOf(GlidePainter.State.Success::class.java)
+    }
+
+    @Test
+    fun rememberGlidePainter_whenDrawnWithSize_loadsImage() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on)
+            Image(
+                painter = painter!!,
+                contentDescription = "",
+            )
+        }
+        glideComposeRule.waitForIdle()
+        assertThat(painter!!.state).isInstanceOf(GlidePainter.State.Success::class.java)
+    }
+
+    @Test
+    fun rememberGlidePainter_withProvidedSize_andOverrideSize_throws() {
+        assertThrows(IllegalArgumentException::class.java) {
+            glideComposeRule.setContent {
+                val (size, _) = rememberSizeAndModifier(Modifier.size(10.dp))
+                rememberGlidePainter(model = android.R.drawable.star_big_on, size) {
+                    it.override(50)
+                }
+            }
+        }
+    }
+
+    @Test
+    fun rememberGlidePainter_withLayoutSize_startsWithStateLoading() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            val (size, _) = rememberSizeAndModifier(Modifier.size(10.dp))
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on, size)
+        }
+        assertThat(painter!!.state).isEqualTo(GlidePainter.State.Loading)
+    }
+
+    @Test
+    fun rememberGlidePainter_withLayoutSize_appliedToBox_loadsImage() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            val (size, modifier) = rememberSizeAndModifier(Modifier.size(10.dp))
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on, size)
+            Box(modifier)
+        }
+        glideComposeRule.waitForIdle()
+        assertThat(painter!!.state).isInstanceOf(GlidePainter.State.Success::class.java)
+    }
+
+    @Test
+    fun rememberGlidePainter_withOverrideSize_andInvalidImage_setsStateToFailed() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = 1234) {
+                it.override(50)
+            }
+        }
+        glideComposeRule.waitForIdle()
+        assertThat(painter!!.state).isEqualTo(GlidePainter.State.Failure)
+    }
+
+    @Test
+    fun rememberGlidePainter_withLayoutSize_andInvalidImage_setsStateToFailed() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            val (size, modifier) = rememberSizeAndModifier(Modifier.size(10.dp))
+            painter = rememberGlidePainter(model = 1234, size)
+            Box(modifier)
+        }
+        glideComposeRule.waitForIdle()
+        assertThat(painter!!.state).isEqualTo(GlidePainter.State.Failure)
+    }
+
+    @Test
+    fun rememberGlidePainter_onLoadFromSource_setsDataSourceToSource() {
+        var painter: GlidePainter? = null
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = android.R.drawable.star_big_on) {
+                it.override(50)
+            }
+        }
+        glideComposeRule.waitForIdle()
+        assertThatDataSource(painter).isEqualTo(DataSource.LOCAL)
+    }
+
+    @Test
+    fun rememberGlidePainter_onLoadFromMemory_setsDataSourceToMemory() {
+        var painter: GlidePainter? = null
+        val resourceId = android.R.drawable.star_big_on
+        val overrideSize = 50
+        // TODO: Compose always uses the generic paths to load models, so it skips options that are
+        // set by default by Glide's various class specific .load() method overrides.
+        val future = Glide.with(context).load(resourceId as Any).override(overrideSize).submit()
+        glideComposeRule.waitForIdle()
+        future.get()
+        glideComposeRule.setContent {
+            painter = rememberGlidePainter(model = resourceId) {
+                it.override(overrideSize)
+            }
+        }
+
+        glideComposeRule.waitForIdle()
+        assertThatDataSource(painter).isEqualTo(DataSource.MEMORY_CACHE)
+    }
+
+    private fun assertThatDataSource(painter: GlidePainter?): ComparableSubject<DataSource> =
+        assertThat((painter!!.state as GlidePainter.State.Success).dataSource)
+}
+

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlidePainter.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlidePainter.kt
@@ -3,12 +3,16 @@ package com.bumptech.glide.integration.compose
 import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.ColorDrawable
 import android.graphics.drawable.Drawable
+import androidx.compose.runtime.Composable
 import androidx.compose.runtime.MutableState
 import androidx.compose.runtime.RememberObserver
 import androidx.compose.runtime.Stable
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
 import androidx.compose.ui.geometry.Size
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
@@ -18,7 +22,12 @@ import androidx.compose.ui.graphics.drawscope.DrawScope
 import androidx.compose.ui.graphics.painter.BitmapPainter
 import androidx.compose.ui.graphics.painter.ColorPainter
 import androidx.compose.ui.graphics.painter.Painter
+import androidx.compose.ui.layout.layout
+import androidx.compose.ui.platform.LocalContext
+import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
+import com.bumptech.glide.RequestManager
+import com.bumptech.glide.integration.compose.GlidePainter.State
 import com.bumptech.glide.integration.ktx.AsyncGlideSize
 import com.bumptech.glide.integration.ktx.ExperimentGlideFlows
 import com.bumptech.glide.integration.ktx.ImmediateGlideSize
@@ -28,6 +37,7 @@ import com.bumptech.glide.integration.ktx.ResolvableGlideSize
 import com.bumptech.glide.integration.ktx.Resource
 import com.bumptech.glide.integration.ktx.Status
 import com.bumptech.glide.integration.ktx.flowResolvable
+import com.bumptech.glide.load.DataSource
 import com.google.accompanist.drawablepainter.DrawablePainter
 import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.Dispatchers
@@ -36,97 +46,447 @@ import kotlinx.coroutines.SupervisorJob
 import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
+import java.lang.IllegalStateException
+
+/**
+ * Exposes a [Painter] and the painter's [State] so that they can be composed with other
+ * Composables like [androidx.compose.foundation.Image].
+ *
+ * [GlideImage] is easier to use than this method and should be preferred unless you have a use case
+ * that requires [State].
+ *
+ * See also the other variant of [rememberGlidePainter] and [rememberSizeAndModifier].
+ *
+ * You can use this class to display custom placeholders and/or animations. For example to crossfade
+ * from a placeholder to a real image, you might do something like this:
+ *
+ * ```
+ * val painter = rememberGlidePainter(model = item.uri) {
+ *   it.override(targetImageSize)
+ * }
+ * when (painter.state.animate()) {
+ *  AnimationState.Loading, AnimationState.Animate -> {
+ *    Crossfade(painter.state == AnimationState.Loading) {
+ *      if (it) {
+ *        Image(
+ *          painterResource(android.R.drawable.star_big_on),
+ *          contentDescription,
+ *          modifier,
+ *        )
+ *      } else {
+ *        Image(painter, contentDescription, modifier)
+ *      }
+ *    }
+ *  }
+ *  AnimationState.Success -> {
+ *    Image(painter, contentDescription, modifier)
+ *  }
+ *  AnimationState.Failed -> {
+ *    Image(
+ *      painterResource(android.R.drawable.star_big_off),
+ *      contentDescription,
+ *      modifier,
+ *    )
+ *  }
+ * }
+ * ```
+ *
+ * [animate] is a helper that uses [AnimationState.Animate] to indicate that an
+ * animation should be performed because the [DataSource] is not [DataSource.MEMORY_CACHE], or
+ * [AnimationState.Success] to indicate that the animation should be skipped. It's derived from
+ * [State] so you can implement your own version if your requirements differ, or skip it
+ * entirely.
+ *
+ * Unlike [GlideImage], the painter cannot automatically determine its size. If no override size
+ * (by calling [RequestBuilder.override] in [requestBuilderTransform]) is provided, the painter will
+ * wait until it is drawn to start the image load. This can lead to the image load never starting.
+ * To ensure the painter is always able to determine a size and start the image load:
+ *
+ * 1. Use the other variant of [rememberGlidePainter] along with [rememberSizeAndModifier] to
+ * resolve the size from layout.
+ * 2. Ensure that the painter is always drawn (unlike in the example above) in another Composable
+ * (e.g. [androidx.compose.foundation.Image] with a reasonable [Modifier].
+ * 3. Using [requestBuilderTransform] to apply a specific [RequestBuilder.override] size to the
+ * Glide request directly. If you choose this option, try to pick an override size based on the area
+ * you want to display the image in or at least the screen size rather than using
+ * [com.bumptech.glide.request.target.Target.SIZE_ORIGINAL].
+ */
+@ExperimentalGlideComposeApi
+@OptIn(InternalGlideApi::class)
+@Composable
+public fun rememberGlidePainter(
+    model: Any?,
+    requestBuilderTransform: RequestBuilderTransform<Drawable> = { it },
+): GlidePainter {
+    val requestManager: RequestManager =
+        LocalContext.current.let { remember(it) { Glide.with(it) } }
+
+    val requestBuilder = remember(model, requestManager, requestBuilderTransform) {
+        requestBuilderTransform(requestManager.load(model))
+    }
+
+    val overrideSize = requestBuilder.overrideSize()
+    val size = rememberResolvableSize(overrideSize)
+    return rememberGlidePainter(
+        requestBuilder = requestBuilder,
+        size = size,
+        resolveSize = true,
+    )
+}
+
+/**
+ * A size associated with a [Modifier] that will be resolved during layout.
+ */
+@OptIn(InternalGlideApi::class)
+public data class AsyncLayoutSize(internal val size: AsyncGlideSize)
+
+/**
+ * Similar to the other variant of [rememberGlidePainter] except that this method uses the given
+ * [size] to determine the size for the image load.
+ *
+ * [GlideImage] is easier to use than this method and should be preferred unless you have a use case
+ * that requires [State].
+ *
+ * Using this method and [rememberSizeAndModifier] together looks like this:
+ *
+ * ```
+ * val (size, updatedModifier) = rememberSizeAndModifier(modifier)
+ * val painter = rememberGlidePainter(model = item.uri, size)
+ * when (painter.state.animate()) {
+ *  AnimationState.Loading, AnimationState.Animate -> {
+ *    Crossfade(painter.state == AnimationState.Loading) {
+ *      if (it) {
+ *        Image(
+ *          painterResource(android.R.drawable.star_big_on),
+ *          contentDescription,
+ *          updatedModifier,
+ *        )
+ *      } else {
+ *        Image(painter, contentDescription, updatedModifier)
+ *      }
+ *    }
+ *  }
+ *  AnimationState.Success -> {
+ *    Image(painter, contentDescription, updatedModifier)
+ *  }
+ *  AnimationState.Failed -> {
+ *    Image(
+ *      painterResource(android.R.drawable.star_big_off),
+ *      contentDescription,
+ *      updatedModifier,
+ *    )
+ *  }
+ * }
+ * ```
+ *
+ * If you're using fixed size buckets across the app, or have some other reason to use
+ * [RequestBuilder.override], then this method is not helpful and you should use the other
+ * [rememberGlidePainter] variant instead. If an override size is set, this method will throw.
+ *
+ * Otherwise, using this method can improve efficiency by ensuring you load an image whose size
+ * matches the layout it's displayed in. In addition, this variant will always resolve a size and
+ * be able to start an image load if the given [size] is resolved via its associated [Modifier].
+ * See [rememberSizeAndModifier].
+ *
+ * @throws IllegalArgumentException if [requestBuilderTransform] sets an [RequestBuilder.override]
+ * size.
+ */
+@ExperimentalGlideComposeApi
+@OptIn(InternalGlideApi::class)
+@Composable
+public fun rememberGlidePainter(
+    model: Any?,
+    size: AsyncLayoutSize,
+    requestBuilderTransform: RequestBuilderTransform<Drawable> = { it },
+): GlidePainter {
+    val requestManager: RequestManager =
+        LocalContext.current.let { remember(it) { Glide.with(it) } }
+
+    val requestBuilder = remember(model, requestManager, requestBuilderTransform) {
+        requestBuilderTransform(requestManager.load(model))
+    }
+    if (requestBuilder.overrideSize() != null) {
+        throw IllegalArgumentException(
+            "Using rememberGlidePainterAndSize with a fixed override size " +
+                    "(${requestBuilder.overrideSize()}) is redundant, use rememberGlidePainter instead"
+        )
+    }
+
+    return rememberGlidePainter(
+        requestBuilder = requestBuilder,
+        size = size.size,
+        // Let the Modifier resolve the size
+        resolveSize = false,
+    )
+}
+
+/**
+ * Returns a [AsyncLayoutSize] that can be provided to [rememberGlidePainter] and an updated
+ * copy of the given [Modifier]. The returned modifier must be applied to some other Composable
+ * whose layout size is the size of the image you want.
+ *
+ * Using this method along with [rememberGlidePainter] allows you to avoid specifying an override
+ * size, saving memory and speeding up future image loads.
+ */
+@OptIn(InternalGlideApi::class)
+@ExperimentalGlideComposeApi
+@Composable
+public fun rememberSizeAndModifier(
+    modifier: Modifier,
+): Pair<AsyncLayoutSize, Modifier> =
+    remember(modifier) {
+        val size = AsyncGlideSize()
+        Pair(
+            AsyncLayoutSize(size),
+            modifier.sizeObservingModifier(size)
+        )
+    }
+
+@OptIn(InternalGlideApi::class)
+private fun Modifier.sizeObservingModifier(size: AsyncGlideSize): Modifier =
+    this.layout { measurable, constraints ->
+        val inferredSize = constraints.inferredGlideSize()
+        if (inferredSize != null) {
+            size.setSize(inferredSize)
+        }
+        val placeable = measurable.measure(constraints)
+        layout(placeable.width, placeable.height) { placeable.place(0, 0) }
+    }
+
+@OptIn(InternalGlideApi::class, ExperimentalGlideComposeApi::class)
+@Composable
+internal fun rememberGlidePainter(
+    requestBuilder: RequestBuilder<Drawable>,
+    size: ResolvableGlideSize,
+    resolveSize: Boolean,
+): GlidePainterImpl {
+    val scope = rememberCoroutineScope()
+    val result = remember(requestBuilder, size) {
+        GlidePainterImpl(
+            requestBuilder,
+            size,
+            resolveSize,
+            scope
+        )
+    }
+    result.onRemembered()
+    return result
+}
+
+/**
+ * A helper enum that translates [State] into something easier to use with custom
+ * animations. See [animate].
+ */
+@ExperimentalGlideComposeApi
+public enum class AnimationState {
+    Loading,
+
+    /**
+     * The request has finished successfully and should animate.
+     */
+    Animate,
+
+    /**
+     * The request has finished successfully but should not animate because it was loaded from
+     * [DataSource.MEMORY_CACHE].
+     */
+    Success,
+    Failed;
+}
+
+/**
+ * An optional helper that simplifies writing animations with [State] by using
+ * [AnimationState.Animate] and [AnimationState.Success] to distinguish when an animation should
+ * occur.
+ *
+ * If you use thumbnails, this API will return [AnimationState.Animate] or [AnimationState.Success]
+ * based on the data source of the first image to be loaded. If the first image to be loaded is
+ * from the memory cache, this method will always return [AnimationState.Animate]. Otherwise it will
+ * always return [AnimationState.Success]. This behavior is based on [State.Success].
+ */
+@ExperimentalGlideComposeApi
+public fun State.animate(): AnimationState =
+    when (this) {
+        is State.Failure -> AnimationState.Failed
+        is State.Loading -> AnimationState.Loading
+        is State.Success ->
+            if (dataSource != DataSource.MEMORY_CACHE) {
+                AnimationState.Animate
+            } else {
+                AnimationState.Success
+            }
+    }
+
+
+/**
+ * Paints images from Glide, see [rememberGlidePainter] for details.
+ */
+@ExperimentalGlideComposeApi
+public abstract class GlidePainter : Painter() {
+    /**
+     * The current [State] of the painter and its corresponding image load(s).
+     *
+     * See [rememberGlidePainter] for details and examples
+     */
+    public abstract var state: State
+        internal set
+
+    /**
+     * The current state of a request associated with a Glide painter.
+     *
+     * This state is a bit of a simplification over Glide's real state. In particular [Success] is
+     * used in any case where we have an image, even if that image is the thumbnail of a full request
+     * where the full request has failed. From the point of view of the UI this is usually reasonable
+     * and a significant simplification of this API.
+     */
+    @ExperimentalGlideComposeApi
+    public sealed class State {
+
+        @ExperimentalGlideComposeApi
+        public object Loading : State()
+
+        /**
+         * Indicates the load finished successfully (or at least one thumbnail was loaded, see the details
+         * on [State]).
+         *
+         * @param dataSource The data source the latest image was loaded from. If your request uses one
+         * or more thumbnails this value may change as each successive thumbnail is loaded.
+         */
+        @ExperimentalGlideComposeApi
+        public data class Success(
+            val dataSource: DataSource,
+        ) : State()
+
+        @ExperimentalGlideComposeApi
+        public object Failure : State()
+    }
+}
 
 // This class is inspired by a similar implementation in the excellent Coil library
 // (https://github.com/coil-kt/coil), specifically:
 // https://github.com/coil-kt/coil/blob/main/coil-compose-base/src/main/java/coil/compose/AsyncImagePainter.kt
 @Stable
-internal class GlidePainter
+@ExperimentalGlideComposeApi
+internal class GlidePainterImpl
 @OptIn(InternalGlideApi::class)
 constructor(
-  private val requestBuilder: RequestBuilder<Drawable>,
-  private val resolvableSize: ResolvableGlideSize,
-  scope: CoroutineScope,
-) : Painter(), RememberObserver {
-  @OptIn(ExperimentGlideFlows::class) internal var status: Status by mutableStateOf(Status.CLEARED)
-  internal val currentDrawable: MutableState<Drawable?> = mutableStateOf(null)
-  private var alpha: Float by mutableStateOf(DefaultAlpha)
-  private var colorFilter: ColorFilter? by mutableStateOf(null)
-  private var delegate: Painter? by mutableStateOf(null)
-  private val scope =
-    scope + SupervisorJob(parent = scope.coroutineContext.job) + Dispatchers.Main.immediate
-  private var currentJob: Job? = null
-
-  override val intrinsicSize: Size
-    get() = delegate?.intrinsicSize ?: Size.Unspecified
-
-  @OptIn(InternalGlideApi::class)
-  override fun DrawScope.onDraw() {
-    when (resolvableSize) {
-      is AsyncGlideSize -> {
-        size.toGlideSize()?.let { resolvableSize.setSize(it) }
-      }
-      // Do nothing.
-      is ImmediateGlideSize -> {}
-    }
-    delegate?.apply { draw(size, alpha, colorFilter) }
-  }
-
-  override fun onAbandoned() {
-    (delegate as? RememberObserver)?.onAbandoned()
-  }
-
-  override fun onForgotten() {
-    (delegate as? RememberObserver)?.onForgotten()
-    currentJob?.cancel()
-    currentJob = null
-  }
-
-  override fun onRemembered() {
-    (delegate as? RememberObserver)?.onRemembered()
-    if (currentJob == null) {
-      currentJob = launchRequest()
-    }
-  }
-
-  @OptIn(ExperimentGlideFlows::class, InternalGlideApi::class)
-  private fun launchRequest() = this.scope.launch {
-    requestBuilder.flowResolvable(resolvableSize).collect {
-      updateDelegate(
-        when (it) {
-          is Resource -> it.resource
-          is Placeholder -> it.placeholder
+    private val requestBuilder: RequestBuilder<Drawable>,
+    private val resolvableSize: ResolvableGlideSize,
+    private val resolveSize: Boolean,
+    scope: CoroutineScope,
+) : GlidePainter(), RememberObserver {
+    private var _state: State = State.Loading
+        set(value) {
+            field = value
+            state = value
         }
-      )
-      status = it.status
+    private var _painter: Painter? = null
+        set(value) {
+            field = value
+            painter = value
+        }
+    public override var state: State by mutableStateOf(State.Loading)
+    private var painter: Painter? by mutableStateOf(null)
+    internal val currentDrawable: MutableState<Drawable?> = mutableStateOf(null)
+
+    private var alpha: Float by mutableStateOf(DefaultAlpha)
+    private var colorFilter: ColorFilter? by mutableStateOf(null)
+    private val scope =
+        scope + SupervisorJob(parent = scope.coroutineContext.job) + Dispatchers.Main.immediate
+    private var currentJob: Job? = null
+
+    override val intrinsicSize: Size
+        get() = _painter?.intrinsicSize ?: Size.Unspecified
+
+    @OptIn(InternalGlideApi::class)
+    override fun DrawScope.onDraw() {
+        if (resolveSize) {
+            when (resolvableSize) {
+                is AsyncGlideSize -> {
+                    size.toGlideSize()?.let { resolvableSize.setSize(it) }
+                }
+                // Do nothing.
+                is ImmediateGlideSize -> {}
+            }
+        }
+        painter?.apply { draw(size, alpha, colorFilter) }
     }
-  }
 
-  private fun Drawable.toPainter() =
-    when (this) {
-      is BitmapDrawable -> BitmapPainter(bitmap.asImageBitmap())
-      is ColorDrawable -> ColorPainter(Color(color))
-      else -> DrawablePainter(mutate())
+    override fun onAbandoned() {
+        (_painter as? RememberObserver)?.onAbandoned()
     }
 
-  private fun updateDelegate(drawable: Drawable?) {
-    val newDelegate = drawable?.toPainter()
-    val oldDelegate = delegate
-    if (newDelegate !== oldDelegate) {
-      (oldDelegate as? RememberObserver)?.onForgotten()
-      (newDelegate as? RememberObserver)?.onRemembered()
-      currentDrawable.value = drawable
-      delegate = newDelegate
+    override fun onForgotten() {
+        (_painter as? RememberObserver)?.onForgotten()
+        currentJob?.cancel()
+        currentJob = null
     }
-  }
 
-  override fun applyAlpha(alpha: Float): Boolean {
-    this.alpha = alpha
-    return true
-  }
+    override fun onRemembered() {
+        (_painter as? RememberObserver)?.onRemembered()
+        if (currentJob == null) {
+            currentJob = launchRequest()
+        }
+    }
 
-  override fun applyColorFilter(colorFilter: ColorFilter?): Boolean {
-    this.colorFilter = colorFilter
-    return true
-  }
+    @OptIn(ExperimentGlideFlows::class, InternalGlideApi::class)
+    private fun launchRequest() = this.scope.launch {
+        requestBuilder.flowResolvable(resolvableSize).collect {
+            val (glidePainterState, painter) = when (it) {
+                is Resource -> {
+                    currentDrawable.value = it.resource
+                    Pair(State.Success(it.dataSource), it.resource.toPainter())
+                }
+
+                is Placeholder -> {
+                    currentDrawable.value = it.placeholder
+                    val painter = it.placeholder?.toPainter()
+                    when (it.status) {
+                        Status.CLEARED -> Pair(State.Loading, painter)
+                        Status.RUNNING -> Pair(State.Loading, painter)
+                        Status.FAILED -> Pair(State.Failure, painter)
+                        Status.SUCCEEDED -> throw IllegalStateException()
+                    }
+                }
+            }
+            updateState(glidePainterState, painter)
+        }
+    }
+
+    private fun Drawable.toPainter() =
+        when (this) {
+            is BitmapDrawable -> BitmapPainter(bitmap.asImageBitmap())
+            is ColorDrawable -> ColorPainter(Color(color))
+            else -> DrawablePainter(mutate())
+        }
+
+    private fun updateState(glidePainterState: State, painter: Painter?) {
+        val previous = _painter
+
+        if (previous !== painter) {
+            (previous as? RememberObserver)?.onForgotten()
+            (painter as? RememberObserver)?.onRemembered()
+        }
+        _painter = painter
+
+        // Avoid updating the DataSource for multiple successful Glide loads (ie when using thumbnails).
+        // This makes the API a bit less flexible, but avoids recompositions when only the data source
+        // changes.
+        if (glidePainterState is State.Success && _state is State.Success) {
+            return
+        }
+        if (glidePainterState != _state) {
+            _state = glidePainterState
+        }
+    }
+
+    override fun applyAlpha(alpha: Float): Boolean {
+        this.alpha = alpha
+        return true
+    }
+
+    override fun applyColorFilter(colorFilter: ColorFilter?): Boolean {
+        this.colorFilter = colorFilter
+        return true
+    }
 }

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Sizes.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Sizes.kt
@@ -2,6 +2,7 @@
 
 package com.bumptech.glide.integration.compose
 
+import androidx.compose.ui.unit.Constraints
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.integration.ktx.InternalGlideApi
 import com.bumptech.glide.integration.ktx.Size
@@ -38,4 +39,23 @@ internal fun androidx.compose.ui.geometry.Size.toGlideSize(): Size? {
     return null;
   }
   return Size(width, height);
+}
+
+internal fun Constraints.inferredGlideSize(): Size? {
+  val width =
+    if (hasBoundedWidth) {
+      maxWidth
+    } else {
+      com.bumptech.glide.request.target.Target.SIZE_ORIGINAL
+    }
+  val height =
+    if (hasBoundedHeight) {
+      maxHeight
+    } else {
+      com.bumptech.glide.request.target.Target.SIZE_ORIGINAL
+    }
+  if (!width.isValidGlideDimension() || !height.isValidGlideDimension()) {
+    return null
+  }
+  return Size(width, height)
 }

--- a/integration/concurrent/src/main/java/com/bumptech/glide/integration/concurrent/GlideFutures.java
+++ b/integration/concurrent/src/main/java/com/bumptech/glide/integration/concurrent/GlideFutures.java
@@ -181,14 +181,14 @@ public final class GlideFutures {
 
     @Override
     public boolean onLoadFailed(
-        @Nullable GlideException e, Object model, Target<T> target, boolean isFirst) {
+        @Nullable GlideException e, Object model, @NonNull Target<T> target, boolean isFirst) {
       completer.setException(e != null ? e : new RuntimeException("Unknown error"));
       return true;
     }
 
     @Override
     public boolean onResourceReady(
-        T resource, Object model, Target<T> target, DataSource dataSource, boolean isFirst) {
+        @NonNull T resource, @NonNull Object model, Target<T> target, @NonNull DataSource dataSource, boolean isFirst) {
       try {
         completer.set(new TargetAndResult<>(target, resource));
       } catch (Throwable t) {

--- a/integration/ktx/api/ktx.api
+++ b/integration/ktx/api/ktx.api
@@ -28,15 +28,20 @@ public final class com/bumptech/glide/integration/ktx/Placeholder : com/bumptech
 }
 
 public final class com/bumptech/glide/integration/ktx/Resource : com/bumptech/glide/integration/ktx/GlideFlowInstant {
-	public fun <init> (Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;)V
+	public fun <init> (Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;ZLcom/bumptech/glide/load/DataSource;)V
+	public final fun asFailure ()Lcom/bumptech/glide/integration/ktx/Resource;
 	public final fun component1 ()Lcom/bumptech/glide/integration/ktx/Status;
 	public final fun component2 ()Ljava/lang/Object;
-	public final fun copy (Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;)Lcom/bumptech/glide/integration/ktx/Resource;
-	public static synthetic fun copy$default (Lcom/bumptech/glide/integration/ktx/Resource;Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;ILjava/lang/Object;)Lcom/bumptech/glide/integration/ktx/Resource;
+	public final fun component3 ()Z
+	public final fun component4 ()Lcom/bumptech/glide/load/DataSource;
+	public final fun copy (Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;ZLcom/bumptech/glide/load/DataSource;)Lcom/bumptech/glide/integration/ktx/Resource;
+	public static synthetic fun copy$default (Lcom/bumptech/glide/integration/ktx/Resource;Lcom/bumptech/glide/integration/ktx/Status;Ljava/lang/Object;ZLcom/bumptech/glide/load/DataSource;ILjava/lang/Object;)Lcom/bumptech/glide/integration/ktx/Resource;
 	public fun equals (Ljava/lang/Object;)Z
+	public final fun getDataSource ()Lcom/bumptech/glide/load/DataSource;
 	public final fun getResource ()Ljava/lang/Object;
 	public fun getStatus ()Lcom/bumptech/glide/integration/ktx/Status;
 	public fun hashCode ()I
+	public final fun isFirstResource ()Z
 	public fun toString ()Ljava/lang/String;
 }
 

--- a/integration/ktx/src/test/java/com/bumptech/glide/integration/ktx/FlowsTest.kt
+++ b/integration/ktx/src/test/java/com/bumptech/glide/integration/ktx/FlowsTest.kt
@@ -646,22 +646,22 @@ private fun atMostOnce(function: () -> Unit): () -> Unit {
   }
 }
 
-private fun <ResourceT> onSuccess(onSuccess: () -> Unit) =
+private fun <ResourceT : Any> onSuccess(onSuccess: () -> Unit) =
   simpleRequestListener<ResourceT>(onSuccess) {}
 
-private fun <ResourceT> onFailure(onFailure: () -> Unit) =
+private fun <ResourceT : Any> onFailure(onFailure: () -> Unit) =
   simpleRequestListener<ResourceT>({}, onFailure)
 
-private fun <ResourceT> simpleRequestListener(
+private fun <ResourceT : Any> simpleRequestListener(
   onSuccess: () -> Unit,
   onFailure: () -> Unit
 ): RequestListener<ResourceT> =
   object : RequestListener<ResourceT> {
     override fun onResourceReady(
-      resource: ResourceT?,
-      model: Any?,
-      target: Target<ResourceT>?,
-      dataSource: DataSource?,
+      resource: ResourceT,
+      model: Any,
+      target: Target<ResourceT>,
+      dataSource: DataSource,
       isFirstResource: Boolean,
     ): Boolean {
       onSuccess()
@@ -671,7 +671,7 @@ private fun <ResourceT> simpleRequestListener(
     override fun onLoadFailed(
       e: GlideException?,
       model: Any?,
-      target: Target<ResourceT>?,
+      target: Target<ResourceT>,
       isFirstResource: Boolean,
     ): Boolean {
       onFailure()

--- a/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestFutureTarget.java
@@ -241,7 +241,7 @@ public class RequestFutureTarget<R> implements FutureTarget<R>, RequestListener<
 
   @Override
   public synchronized boolean onLoadFailed(
-      @Nullable GlideException e, Object model, Target<R> target, boolean isFirstResource) {
+      @Nullable GlideException e, Object model, @NonNull Target<R> target, boolean isFirstResource) {
     loadFailed = true;
     exception = e;
     waiter.notifyAll(this);
@@ -250,7 +250,7 @@ public class RequestFutureTarget<R> implements FutureTarget<R>, RequestListener<
 
   @Override
   public synchronized boolean onResourceReady(
-      R resource, Object model, Target<R> target, DataSource dataSource, boolean isFirstResource) {
+      @NonNull R resource, @NonNull Object model, Target<R> target, @NonNull DataSource dataSource, boolean isFirstResource) {
     // We might get a null result.
     resultReceived = true;
     this.resource = resource;

--- a/library/src/main/java/com/bumptech/glide/request/RequestListener.java
+++ b/library/src/main/java/com/bumptech/glide/request/RequestListener.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.request;
 
 import android.graphics.drawable.Drawable;
 import android.widget.ImageView;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.DataSource;
@@ -60,7 +61,10 @@ public interface RequestListener<R> {
    *     Target#onLoadFailed(Drawable)} to be called on {@code target}.
    */
   boolean onLoadFailed(
-      @Nullable GlideException e, Object model, Target<R> target, boolean isFirstResource);
+      @Nullable GlideException e,
+      @Nullable Object model,
+      @NonNull Target<R> target,
+      boolean isFirstResource);
 
   /**
    * Called when a load completes successfully, immediately before {@link
@@ -68,8 +72,12 @@ public interface RequestListener<R> {
    *
    * <p>For threading guarantees, see the class comment.
    *
-   * @param resource The resource that was loaded for the target.
-   * @param model The specific model that was used to load the image.
+   * @param resource The resource that was loaded for the target. Non-null because a null resource
+   *     will result in a call to {@link #onLoadFailed(GlideException, Object, Target, boolean)}
+   *     instead of this method.
+   * @param model The specific model that was used to load the image. Non-null because a null model
+   *     will result in a call to {@link #onLoadFailed(GlideException, Object, Target, boolean)}
+   *     instead of this method.
    * @param target The target the model was loaded into.
    * @param dataSource The {@link DataSource} the resource was loaded from.
    * @param isFirstResource {@code true} if this is the first resource to in this load to be loaded
@@ -81,5 +89,9 @@ public interface RequestListener<R> {
    *     Target#onResourceReady(Object, Transition)} to be called on {@code target}.
    */
   boolean onResourceReady(
-      R resource, Object model, Target<R> target, DataSource dataSource, boolean isFirstResource);
+      @NonNull R resource,
+      @NonNull Object model,
+      Target<R> target,
+      @NonNull DataSource dataSource,
+      boolean isFirstResource);
 }

--- a/library/test/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/GlideTest.java
@@ -424,17 +424,17 @@ public class GlideTest {
               public boolean onLoadFailed(
                   GlideException e,
                   Object model,
-                  Target<Drawable> target,
+                  @NonNull Target<Drawable> target,
                   boolean isFirstResource) {
                 throw new RuntimeException("Load failed");
               }
 
               @Override
               public boolean onResourceReady(
-                  Drawable resource,
-                  Object model,
+                  @NonNull Drawable resource,
+                  @NonNull Object model,
                   Target<Drawable> target,
-                  DataSource dataSource,
+                  @NonNull DataSource dataSource,
                   boolean isFirstResource) {
                 return false;
               }

--- a/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
@@ -13,6 +13,7 @@ import static org.mockito.Mockito.when;
 import android.app.Application;
 import android.net.Uri;
 import android.widget.ImageView;
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import androidx.test.core.app.ApplicationProvider;
 import com.bumptech.glide.load.DataSource;
@@ -174,17 +175,17 @@ public class RequestBuilderTest {
           public boolean onLoadFailed(
               @Nullable GlideException e,
               Object model,
-              Target<Object> target,
+              @NonNull Target<Object> target,
               boolean isFirstResource) {
             return false;
           }
 
           @Override
           public boolean onResourceReady(
-              Object resource,
-              Object model,
+              @NonNull Object resource,
+              @NonNull Object model,
               Target<Object> target,
-              DataSource dataSource,
+              @NonNull DataSource dataSource,
               boolean isFirstResource) {
             return false;
           }
@@ -195,17 +196,17 @@ public class RequestBuilderTest {
           public boolean onLoadFailed(
               @Nullable GlideException e,
               Object model,
-              Target<Object> target,
+              @NonNull Target<Object> target,
               boolean isFirstResource) {
             return false;
           }
 
           @Override
           public boolean onResourceReady(
-              Object resource,
-              Object model,
+              @NonNull Object resource,
+              @NonNull Object model,
               Target<Object> target,
-              DataSource dataSource,
+              @NonNull DataSource dataSource,
               boolean isFirstResource) {
             return false;
           }

--- a/library/test/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
@@ -696,17 +696,17 @@ public class SingleRequestTest {
                   public boolean onLoadFailed(
                       @Nullable GlideException e,
                       Object model,
-                      Target<List> target,
+                      @NonNull Target<List> target,
                       boolean isFirstResource) {
                     return false;
                   }
 
                   @Override
                   public boolean onResourceReady(
-                      List resource,
-                      Object model,
+                      @NonNull List resource,
+                      @NonNull Object model,
                       Target<List> target,
-                      DataSource dataSource,
+                      @NonNull DataSource dataSource,
                       boolean isFirstResource) {
                     verify(builder.requestCoordinator).onRequestSuccess(target.getRequest());
                     isRequestCoordinatorVerified.set(true);
@@ -733,7 +733,7 @@ public class SingleRequestTest {
                   public boolean onLoadFailed(
                       @Nullable GlideException e,
                       Object model,
-                      Target<List> target,
+                      @NonNull Target<List> target,
                       boolean isFirstResource) {
                     verify(builder.requestCoordinator).onRequestFailed(target.getRequest());
                     isRequestCoordinatorVerified.set(true);
@@ -742,10 +742,10 @@ public class SingleRequestTest {
 
                   @Override
                   public boolean onResourceReady(
-                      List resource,
-                      Object model,
+                      @NonNull List resource,
+                      @NonNull Object model,
                       Target<List> target,
-                      DataSource dataSource,
+                      @NonNull DataSource dataSource,
                       boolean isFirstResource) {
                     return false;
                   }

--- a/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/FullscreenActivity.java
+++ b/samples/giphy/src/main/java/com/bumptech/glide/samples/giphy/FullscreenActivity.java
@@ -10,6 +10,7 @@ import android.graphics.drawable.Drawable;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.ImageView;
+import androidx.annotation.NonNull;
 import com.bumptech.glide.RequestBuilder;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
@@ -70,17 +71,17 @@ public class FullscreenActivity extends Activity {
               public boolean onLoadFailed(
                   GlideException e,
                   Object model,
-                  Target<Drawable> target,
+                  @NonNull Target<Drawable> target,
                   boolean isFirstResource) {
                 return false;
               }
 
               @Override
               public boolean onResourceReady(
-                  Drawable resource,
-                  Object model,
+                  @NonNull Drawable resource,
+                  @NonNull Object model,
                   Target<Drawable> target,
-                  DataSource dataSource,
+                  @NonNull DataSource dataSource,
                   boolean isFirstResource) {
                 if (resource instanceof GifDrawable) {
                   gifDrawable = (GifDrawable) resource;

--- a/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgSoftwareLayerSetter.java
+++ b/samples/svg/src/main/java/com/bumptech/glide/samples/svg/SvgSoftwareLayerSetter.java
@@ -2,6 +2,7 @@ package com.bumptech.glide.samples.svg;
 
 import android.graphics.drawable.PictureDrawable;
 import android.widget.ImageView;
+import androidx.annotation.NonNull;
 import com.bumptech.glide.load.DataSource;
 import com.bumptech.glide.load.engine.GlideException;
 import com.bumptech.glide.request.RequestListener;
@@ -17,7 +18,7 @@ public class SvgSoftwareLayerSetter implements RequestListener<PictureDrawable> 
 
   @Override
   public boolean onLoadFailed(
-      GlideException e, Object model, Target<PictureDrawable> target, boolean isFirstResource) {
+      GlideException e, Object model, @NonNull Target<PictureDrawable> target, boolean isFirstResource) {
     ImageView view = ((ImageViewTarget<?>) target).getView();
     view.setLayerType(ImageView.LAYER_TYPE_NONE, null);
     return false;
@@ -25,10 +26,10 @@ public class SvgSoftwareLayerSetter implements RequestListener<PictureDrawable> 
 
   @Override
   public boolean onResourceReady(
-      PictureDrawable resource,
-      Object model,
+      @NonNull PictureDrawable resource,
+      @NonNull Object model,
       Target<PictureDrawable> target,
-      DataSource dataSource,
+      @NonNull DataSource dataSource,
       boolean isFirstResource) {
     ImageView view = ((ImageViewTarget<?>) target).getView();
     view.setLayerType(ImageView.LAYER_TYPE_SOFTWARE, null);


### PR DESCRIPTION
A separate painter can be used outside of GlideImage with other composables. It can also be used for crossfades or custom animations. 

This is very similar in concept to Coil's implementation but the details are a bit different. 