### PR TITLE
Introduce a constant for Robolectric tests using sdk = 18.

### DIFF
--- a/library/test/src/test/java/com/bumptech/glide/GlideTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/GlideTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.request.RequestOptions.decodeTypeOf;
 import static com.bumptech.glide.request.RequestOptions.errorOf;
 import static com.bumptech.glide.request.RequestOptions.placeholderOf;
@@ -94,7 +95,7 @@ import org.robolectric.shadow.api.Shadow;
 @LooperMode(LEGACY)
 @RunWith(RobolectricTestRunner.class)
 @Config(
-    sdk = 18,
+    sdk = ROBOLECTRIC_SDK,
     shadows = {
       GlideTest.ShadowFileDescriptorContentResolver.class,
       GlideTest.ShadowMediaMetadataRetriever.class,

--- a/library/test/src/test/java/com/bumptech/glide/ListPreloaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/ListPreloaderTest.java
@@ -30,7 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK)
 public class ListPreloaderTest {
 
   @Mock private RequestBuilder<Object> request;

--- a/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/RequestBuilderTest.java
@@ -40,7 +40,7 @@ import org.robolectric.annotation.Config;
 
 @SuppressWarnings("unchecked")
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK)
 public class RequestBuilderTest {
   @Rule public TearDownGlide tearDownGlide = new TearDownGlide();
 

--- a/library/test/src/test/java/com/bumptech/glide/RequestManagerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/RequestManagerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.BackgroundUtil.testInBackground;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -42,7 +43,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class RequestManagerTest {
   @Rule public TearDownGlide tearDownGlide = new TearDownGlide();
 

--- a/library/test/src/test/java/com/bumptech/glide/RobolectricConstants.java
+++ b/library/test/src/test/java/com/bumptech/glide/RobolectricConstants.java
@@ -1,0 +1,6 @@
+package com.bumptech.glide;
+
+public class RobolectricConstants {
+  /** The default SDK used for Robolectric tests */
+  public static final int ROBOLECTRIC_SDK = 18;
+}

--- a/library/test/src/test/java/com/bumptech/glide/load/OptionsTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/OptionsTest.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.load;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
+
 import androidx.annotation.NonNull;
 import com.bumptech.glide.load.Option.CacheKeyUpdater;
 import com.bumptech.glide.tests.KeyTester;
@@ -12,7 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class OptionsTest {
   @Rule public final KeyTester keyTester = new KeyTester();
 

--- a/library/test/src/test/java/com/bumptech/glide/load/data/ExifOrientationStreamTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/ExifOrientationStreamTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
@@ -15,7 +16,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ExifOrientationStreamTest {
   private ArrayPool byteArrayPool;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/data/FileDescriptorAssetPathFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/FileDescriptorAssetPathFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class FileDescriptorAssetPathFetcherTest {
 
   @Mock private AssetManager assetManager;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/HttpUrlFetcherServerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/HttpUrlFetcherServerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -36,7 +37,7 @@ import org.robolectric.annotation.Config;
  * com.bumptech.glide.load.data.HttpUrlFetcherTest}, response handling should go here.
  */
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 18)
+@Config(manifest = Config.NONE, sdk = ROBOLECTRIC_SDK)
 public class HttpUrlFetcherServerTest {
   private static final String DEFAULT_PATH = "/fakepath";
   private static final int TIMEOUT_TIME_MS = 300;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/HttpUrlFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/HttpUrlFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doThrow;
@@ -30,7 +31,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class HttpUrlFetcherTest {
   @Mock private HttpURLConnection urlConnection;
   @Mock private HttpUrlFetcher.HttpUrlConnectionFactory connectionFactory;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/LocalUriFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/LocalUriFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -23,7 +24,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class LocalUriFetcherTest {
   private TestLocalUriFetcher fetcher;
   @Mock private DataFetcher.DataCallback<Closeable> callback;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/StreamAssetPathFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/StreamAssetPathFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class StreamAssetPathFetcherTest {
   @Mock private AssetManager assetManager;
   @Mock private InputStream expected;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtilTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtilTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data.mediastore;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.net.Uri;
@@ -10,7 +11,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class MediaStoreUtilTest {
 
   @Test

--- a/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data.mediastore;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -19,7 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ThumbFetcherTest {
 
   @Mock private ThumbnailStreamOpener opener;

--- a/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbnailStreamOpenerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/mediastore/ThumbnailStreamOpenerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data.mediastore;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -36,7 +37,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.fakes.RoboCursor;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ThumbnailStreamOpenerTest {
   private Harness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/data/resource/FileDescriptorLocalUriFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/resource/FileDescriptorLocalUriFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data.resource;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.mock;
@@ -28,7 +29,7 @@ import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(
-    sdk = 18,
+    sdk = ROBOLECTRIC_SDK,
     shadows = {ContentResolverShadow.class})
 public class FileDescriptorLocalUriFetcherTest {
 

--- a/library/test/src/test/java/com/bumptech/glide/load/data/resource/StreamLocalUriFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/resource/StreamLocalUriFetcherTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.data.resource;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.Mockito.verify;
 
@@ -26,7 +27,7 @@ import org.robolectric.shadow.api.Shadow;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(
-    sdk = 18,
+    sdk = ROBOLECTRIC_SDK,
     shadows = {ContentResolverShadow.class})
 public class StreamLocalUriFetcherTest {
   @Mock private DataFetcher.DataCallback<InputStream> callback;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/EngineJobTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.anyResource;
 import static com.bumptech.glide.tests.Util.isADataSource;
 import static com.bumptech.glide.tests.Util.mockResource;
@@ -41,7 +42,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class EngineJobTest {
   private EngineJobHarness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/EngineKeyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/EngineKeyTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertThrows;
 
 import androidx.annotation.NonNull;
@@ -23,7 +24,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class EngineKeyTest {
   @Mock private Transformation<Object> transformation;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/EngineResourceTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/EngineResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class EngineResourceTest {
   private EngineResource<Object> engineResource;
   @Mock private EngineResource.ResourceListener listener;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/EngineTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.anyResource;
 import static com.bumptech.glide.tests.Util.isADataSource;
 import static com.bumptech.glide.tests.Util.mockResource;
@@ -44,7 +45,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 @SuppressWarnings("unchecked")
 public class EngineTest {
   private EngineTestHarness harness;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/ResourceRecyclerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/ResourceRecyclerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.never;
@@ -16,7 +17,7 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ResourceRecyclerTest {
 
   private ResourceRecycler recycler;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/AttributeStrategyKeyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/AttributeStrategyKeyTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -16,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class AttributeStrategyKeyTest {
 
   private AttributeStrategy.KeyPool keyPool;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/AttributeStrategyTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/AttributeStrategyTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 
@@ -11,7 +12,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class AttributeStrategyTest {
 
   private AttributeStrategy strategy;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/GroupedLinkedMapTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/GroupedLinkedMapTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.bitmap_recycle;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNull;
 
@@ -10,7 +11,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GroupedLinkedMapTest {
 
   private GroupedLinkedMap<Key, Object> map;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/bitmap_recycle/LruArrayPoolTest.java
@@ -4,6 +4,7 @@ import static android.content.ComponentCallbacks2.TRIM_MEMORY_BACKGROUND;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_COMPLETE;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_RUNNING_CRITICAL;
 import static android.content.ComponentCallbacks2.TRIM_MEMORY_UI_HIDDEN;
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
@@ -19,7 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class LruArrayPoolTest {
   private static final int MAX_SIZE = 10;
   private static final int MAX_PUT_SIZE = MAX_SIZE / 2;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapperTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/cache/DiskLruCacheWrapperTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.cache;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DiskLruCacheWrapperTest {
   private DiskCache cache;
   private byte[] data;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/cache/SafeKeyGeneratorTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/cache/SafeKeyGeneratorTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.cache;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertTrue;
 
 import androidx.annotation.NonNull;
@@ -14,7 +15,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class SafeKeyGeneratorTest {
   private SafeKeyGenerator keyGenerator;
   private int nextId;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/executor/GlideExecutorTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/executor/GlideExecutorTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.executor;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import androidx.annotation.NonNull;
@@ -14,7 +15,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GlideExecutorTest {
 
   @Test

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillRunnerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.prefill;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.anyResource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotEquals;
@@ -43,7 +44,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLog;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapPreFillRunnerTest {
   @Mock private BitmapPreFillRunner.Clock clock;
   @Mock private BitmapPool pool;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillerTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/BitmapPreFillerTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.prefill;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
@@ -30,7 +31,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapPreFillerTest {
   private static final int DEFAULT_BITMAP_WIDTH = 100;
   private static final int DEFAULT_BITMAP_HEIGHT = 50;

--- a/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/PreFillTypeTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/engine/prefill/PreFillTypeTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.engine.prefill;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 
 import android.graphics.Bitmap;
@@ -10,7 +11,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class PreFillTypeTest {
 
   @Test(expected = IllegalArgumentException.class)

--- a/library/test/src/test/java/com/bumptech/glide/load/model/AssetUriLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/AssetUriLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class AssetUriLoaderTest {
   private static final int IMAGE_SIDE = 10;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/model/DataUrlLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/DataUrlLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -26,7 +27,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for the {@link DataUrlLoader} class. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DataUrlLoaderTest {
 
   // A valid base64-encoded PNG (a small "Google" logo).

--- a/library/test/src/test/java/com/bumptech/glide/load/model/GlideUrlTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/GlideUrlTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
@@ -13,7 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GlideUrlTest {
 
   @Test(expected = NullPointerException.class)

--- a/library/test/src/test/java/com/bumptech/glide/load/model/LazyHeadersTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/LazyHeadersTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -16,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class LazyHeadersTest {
   private static final String DEFAULT_USER_AGENT = "default_user_agent";
   private static final String DEFAULT_USER_AGENT_PROPERTY = "http.agent";

--- a/library/test/src/test/java/com/bumptech/glide/load/model/MultiModelLoaderFactoryTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/MultiModelLoaderFactoryTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertThrows;
 import static org.mockito.ArgumentMatchers.eq;
@@ -26,7 +27,7 @@ import org.robolectric.annotation.Config;
 // containsExactly produces a spurious warning.
 @SuppressWarnings("ResultOfMethodCallIgnored")
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class MultiModelLoaderFactoryTest {
   @Mock private ModelLoaderFactory<String, String> firstFactory;
   @Mock private ModelLoader<String, String> firstModelLoader;

--- a/library/test/src/test/java/com/bumptech/glide/load/model/ResourceLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/ResourceLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +27,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for the {@link com.bumptech.glide.load.model.ResourceLoader} class. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ResourceLoaderTest {
 
   @Mock private ModelLoader<Uri, Object> uriLoader;

--- a/library/test/src/test/java/com/bumptech/glide/load/model/StreamEncoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/StreamEncoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 
 import androidx.test.core.app.ApplicationProvider;
@@ -17,7 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class StreamEncoderTest {
   private StreamEncoder encoder;
   private File file;

--- a/library/test/src/test/java/com/bumptech/glide/load/model/StringLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/StringLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -26,7 +27,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for the {@link com.bumptech.glide.load.model.StringLoader} class. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class StringLoaderTest {
   // Not a magic number, just an arbitrary non zero value.
   private static final int IMAGE_SIDE = 100;

--- a/library/test/src/test/java/com/bumptech/glide/load/model/UriLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/UriLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
@@ -21,7 +22,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for the {@link UriLoader} class. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class UriLoaderTest {
   // Not a magic number, just arbitrary non zero.
   private static final int IMAGE_SIDE = 120;

--- a/library/test/src/test/java/com/bumptech/glide/load/model/UrlUriLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/UrlUriLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -17,7 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class UrlUriLoaderTest {
   private static final int IMAGE_SIDE = 100;
   private static final Options OPTIONS = new Options();

--- a/library/test/src/test/java/com/bumptech/glide/load/model/stream/BaseGlideUrlLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/stream/BaseGlideUrlLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.model.stream;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.ArgumentMatchers.any;
@@ -29,7 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BaseGlideUrlLoaderTest {
 
   @Mock private ModelCache<Object, GlideUrl> modelCache;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableResourceTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.mockito.ArgumentMatchers.eq;
@@ -17,7 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapDrawableResourceTest {
   private BitmapDrawableResourceHarness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapDrawableTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.anyContext;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -37,7 +38,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 @SuppressWarnings("deprecation")
 public class BitmapDrawableTransformationTest {
   @Rule public final KeyTester keyTester = new KeyTester();

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapEncoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -26,7 +27,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapEncoderTest {
   private EncoderHarness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapResourceTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,7 @@ import org.robolectric.annotation.Config;
 
 // TODO: add a test for bitmap size using getAllocationByteSize when robolectric supports kitkat.
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapResourceTest {
   private int currentBuildVersion;
   private BitmapResourceHarness harness;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/BitmapTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -26,7 +27,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapTransformationTest {
 
   @Mock private BitmapPool bitmapPool;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterInsideTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/CenterInsideTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.ArgumentMatchers.any;
@@ -32,7 +33,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class CenterInsideTest {
   @Rule public final KeyTester keyTester = new KeyTester();
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParserTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParserTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -23,7 +24,7 @@ import org.robolectric.annotation.Config;
 import org.robolectric.util.Util;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DefaultImageHeaderParserTest {
 
   private static final byte[] PNG_HEADER_WITH_IHDR_CHUNK =

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DrawableTransformationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DrawableTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -39,7 +40,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DrawableTransformationTest {
   @Rule public final KeyTester keyTester = new KeyTester();
   @Mock private Transformation<Bitmap> bitmapTransformation;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/FitCenterTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/FitCenterTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doAnswer;
@@ -31,7 +32,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class FitCenterTest {
   @Rule public final KeyTester keyTester = new KeyTester();
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStreamTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/RecyclableBufferedInputStreamTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.bitmap;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.doThrow;
@@ -22,7 +23,7 @@ import org.robolectric.annotation.Config;
 // Not required in tests.
 @SuppressWarnings("ResultOfMethodCallIgnored")
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class RecyclableBufferedInputStreamTest {
 
   private static final int DATA_SIZE = 30;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/drawable/DrawableResourceTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/drawable/DrawableResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.drawable;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNotEquals;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DrawableResourceTest {
   private TestDrawable drawable;
   private DrawableResource<TestDrawable> resource;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/ByteBufferGifDecoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
@@ -32,7 +33,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ByteBufferGifDecoderTest {
   private static final byte[] GIF_HEADER = new byte[] {0x47, 0x49, 0x46};
   private static final int ARRAY_POOL_SIZE_BYTES = 4 * 1024 * 1024;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableResourceTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableResourceTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
@@ -13,7 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GifDrawableResourceTest {
   private GifDrawable drawable;
   private GifDrawableResource resource;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -48,7 +49,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowCanvas;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GifDrawableTest {
   @Rule public final TearDownGlide tearDownGlide = new TearDownGlide();
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifDrawableTransformationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -34,7 +35,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GifDrawableTransformationTest {
   @Rule public final KeyTester keyTester = new KeyTester();
   @Mock private Transformation<Bitmap> wrapped;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameLoaderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -46,7 +47,7 @@ import org.robolectric.annotation.LooperMode;
 
 @LooperMode(LEGACY)
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GifFrameLoaderTest {
   @Rule public TearDownGlide tearDownGlide = new TearDownGlide();
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameResourceDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/GifFrameResourceDecoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class GifFrameResourceDecoderTest {
   private GifDecoder gifDecoder;
   private GifFrameResourceDecoder resourceDecoder;

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/gif/StreamGifDecoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/gif/StreamGifDecoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.gif;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import com.bumptech.glide.load.ImageHeaderParser;
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class StreamGifDecoderTest {
   private static final byte[] GIF_HEADER = new byte[] {0x47, 0x49, 0x46};
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapBytesTranscoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapBytesTranscoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.verify;
@@ -17,7 +18,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapBytesTranscoderTest {
   private BitmapBytesTranscoderHarness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapDrawableTranscoderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/transcode/BitmapDrawableTranscoderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.load.resource.transcode;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.when;
@@ -16,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapDrawableTranscoderTest {
   private BitmapDrawableTranscoder transcoder;
 

--- a/library/test/src/test/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactoryTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/manager/DefaultConnectivityMonitorFactoryTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.manager;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.Mockito.mock;
 import static org.robolectric.Shadows.shadowOf;
@@ -13,7 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DefaultConnectivityMonitorFactoryTest {
   private ConnectivityMonitorFactory factory;
 

--- a/library/test/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/manager/RequestManagerRetrieverTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.manager;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.BackgroundUtil.testInBackground;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
@@ -43,7 +44,7 @@ import org.robolectric.shadows.ShadowLooper;
 
 @LooperMode(LEGACY)
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class RequestManagerRetrieverTest {
   @Rule public TearDownGlide tearDownGlide = new TearDownGlide();
 

--- a/library/test/src/test/java/com/bumptech/glide/module/ManifestParserTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/module/ManifestParserTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.module;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyString;
@@ -27,7 +28,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 @SuppressWarnings("deprecation")
 public class ManifestParserTest {
   private static final String MODULE_VALUE = "GlideModule";

--- a/library/test/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/RequestFutureTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -27,7 +28,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class RequestFutureTargetTest {
   private int width;
   private int height;

--- a/library/test/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/SingleRequestTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.bumptech.glide.tests.Util.isADataSource;
 import static com.bumptech.glide.tests.Util.mockResource;
 import static com.google.common.truth.Truth.assertThat;
@@ -59,7 +60,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 @SuppressWarnings("rawtypes")
 public class SingleRequestTest {
 

--- a/library/test/src/test/java/com/bumptech/glide/request/target/AppWidgetTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/AppWidgetTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
@@ -22,7 +23,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowAppWidgetManager;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18, shadows = AppWidgetTargetTest.UpdateShadowAppWidgetManager.class)
+@Config(sdk = ROBOLECTRIC_SDK, shadows = AppWidgetTargetTest.UpdateShadowAppWidgetManager.class)
 public class AppWidgetTargetTest {
   private UpdateShadowAppWidgetManager shadowManager;
   private RemoteViews views;

--- a/library/test/src/test/java/com/bumptech/glide/request/target/BitmapImageViewTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/BitmapImageViewTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 
 import android.graphics.Bitmap;
@@ -13,7 +14,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class BitmapImageViewTargetTest {
 
   private ImageView view;

--- a/library/test/src/test/java/com/bumptech/glide/request/target/ImageViewTargetFactoryTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/ImageViewTargetFactoryTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import android.graphics.Bitmap;
@@ -16,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ImageViewTargetFactoryTest {
   private ImageViewTargetFactory factory;
   private ImageView view;

--- a/library/test/src/test/java/com/bumptech/glide/request/target/ImageViewTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/ImageViewTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -29,7 +30,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ImageViewTargetTest {
 
   @Mock private AnimatedDrawable animatedDrawable;

--- a/library/test/src/test/java/com/bumptech/glide/request/target/NotificationTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/NotificationTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -22,7 +23,7 @@ import org.robolectric.shadow.api.Shadow;
 import org.robolectric.shadows.ShadowNotificationManager;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18, shadows = NotificationTargetTest.UpdateShadowNotificationManager.class)
+@Config(sdk = ROBOLECTRIC_SDK, shadows = NotificationTargetTest.UpdateShadowNotificationManager.class)
 public class NotificationTargetTest {
   private UpdateShadowNotificationManager shadowManager;
   private RemoteViews remoteViews;

--- a/library/test/src/test/java/com/bumptech/glide/request/target/PreloadTargetTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/target/PreloadTargetTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.target;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
@@ -19,7 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class PreloadTargetTest {
 
   @Mock private RequestManager requestManager;

--- a/library/test/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeFactoryTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeFactoryTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.transition;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
 
@@ -12,7 +13,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DrawableCrossFadeFactoryTest {
 
   private DrawableCrossFadeFactory factory;

--- a/library/test/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeViewAnimationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/transition/DrawableCrossFadeViewAnimationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.transition;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class DrawableCrossFadeViewAnimationTest {
   private CrossFadeHarness harness;
 

--- a/library/test/src/test/java/com/bumptech/glide/request/transition/ViewAnimationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/transition/ViewAnimationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.transition;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ViewAnimationTest {
   private ViewTransition<Object> viewAnimation;
   private ViewAdapter adapter;

--- a/library/test/src/test/java/com/bumptech/glide/request/transition/ViewPropertyAnimationTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/request/transition/ViewPropertyAnimationTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.request.transition;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
@@ -19,7 +20,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ViewPropertyAnimationTest {
   private ViewPropertyTransition.Animator animator;
   private ViewPropertyTransition<Object> animation;

--- a/library/test/src/test/java/com/bumptech/glide/resize/load/ExifTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/resize/load/ExifTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.resize.load;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.assertEquals;
 
@@ -16,7 +17,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ExifTest {
 
   private ArrayPool byteArrayPool;

--- a/library/test/src/test/java/com/bumptech/glide/signature/ApplicationVersionSignatureTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/signature/ApplicationVersionSignatureTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.signature;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -21,7 +22,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ApplicationVersionSignatureTest {
   @Rule public final KeyTester keyTester = new KeyTester();
   private Context context;

--- a/library/test/src/test/java/com/bumptech/glide/util/ByteBufferUtilTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/util/ByteBufferUtilTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.util;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static org.junit.Assert.assertEquals;
 
 import java.io.ByteArrayInputStream;
@@ -12,7 +13,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ByteBufferUtilTest {
   private static final int BUFFER_SIZE = 16384;
 

--- a/library/test/src/test/java/com/bumptech/glide/util/ContentLengthInputStreamTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/util/ContentLengthInputStreamTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.util;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,7 +19,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class ContentLengthInputStreamTest {
   @Mock private InputStream wrapped;
 

--- a/library/test/src/test/java/com/bumptech/glide/util/FixedPreloadSizeProviderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/util/FixedPreloadSizeProviderTest.java
@@ -1,5 +1,6 @@
 package com.bumptech.glide.util;
 
+import static com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK;
 import static com.google.common.truth.Truth.assertThat;
 
 import org.junit.Test;
@@ -8,7 +9,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = ROBOLECTRIC_SDK)
 public class FixedPreloadSizeProviderTest {
 
   // containsExactly doesn't need a return value check.

--- a/library/test/src/test/java/com/bumptech/glide/util/ViewPreloadSizeProviderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/util/ViewPreloadSizeProviderTest.java
@@ -13,7 +13,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = com.bumptech.glide.RobolectricConstants.ROBOLECTRIC_SDK)
 public class ViewPreloadSizeProviderTest {
 
   private View view;


### PR DESCRIPTION
This commit replaces hardcoded instances of 'Config(sdk = 18') with a constant. The intent is to make it easier to update the value in the future when Robolectric stops supporting sdk 18.

Tested via gradle test testDebugUnitTest.
