### PR TITLE
Increment ROBOLECTRIC_SDK to 19 from 18.

### DIFF
--- a/library/test/src/test/java/com/bumptech/glide/RobolectricConstants.java
+++ b/library/test/src/test/java/com/bumptech/glide/RobolectricConstants.java
@@ -2,5 +2,5 @@ package com.bumptech.glide;
 
 public class RobolectricConstants {
   /** The default SDK used for Robolectric tests */
-  public static final int ROBOLECTRIC_SDK = 18;
+  public static final int ROBOLECTRIC_SDK = 19;
 }


### PR DESCRIPTION
A future version of Robolectric will drop support for SDK 18.

Tested via gradle test testDebugUnitTest.
