### PR TITLE
Add @RequiresPermission to NotificationTarget

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
+++ b/library/src/main/java/com/bumptech/glide/request/target/NotificationTarget.java
@@ -1,5 +1,7 @@
 package com.bumptech.glide.request.target;
 
+import android.Manifest;
+import android.annotation.SuppressLint;
 import android.app.Notification;
 import android.app.NotificationManager;
 import android.content.Context;
@@ -8,6 +10,7 @@ import android.graphics.drawable.Drawable;
 import android.widget.RemoteViews;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import androidx.annotation.RequiresPermission;
 import com.bumptech.glide.request.transition.Transition;
 import com.bumptech.glide.util.Preconditions;
 
@@ -39,6 +42,9 @@ public class NotificationTarget extends CustomTarget<Bitmap> {
    * @param notification The Notification object that we want to update.
    * @param notificationId The notificationId of the Notification that we want to load the Bitmap.
    */
+  @SuppressLint("InlinedApi")
+  // Alert users of Glide to have this permission.
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   public NotificationTarget(
       Context context,
       int viewId,
@@ -61,6 +67,9 @@ public class NotificationTarget extends CustomTarget<Bitmap> {
    * @param notificationTag The notificationTag of the Notification that we want to load the Bitmap.
    *     May be {@code null}.
    */
+  @SuppressLint("InlinedApi")
+  // Alert users of Glide to have this permission.
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   public NotificationTarget(
       Context context,
       int viewId,
@@ -95,6 +104,9 @@ public class NotificationTarget extends CustomTarget<Bitmap> {
    * @param notificationTag The notificationTag of the Notification that we want to load the Bitmap.
    *     May be {@code null}.
    */
+  @SuppressLint("InlinedApi")
+  // Alert users of Glide to have this permission.
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   public NotificationTarget(
       Context context,
       int width,
@@ -116,6 +128,9 @@ public class NotificationTarget extends CustomTarget<Bitmap> {
   }
 
   /** Updates the Notification after the Bitmap resource is loaded. */
+  @SuppressLint("InlinedApi")
+  // Help tools to recognize that this method requires a permission, because it posts a notification.
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   private void update() {
     NotificationManager manager =
         (NotificationManager) this.context.getSystemService(Context.NOTIFICATION_SERVICE);
@@ -123,17 +138,26 @@ public class NotificationTarget extends CustomTarget<Bitmap> {
         .notify(this.notificationTag, this.notificationId, this.notification);
   }
 
+  @SuppressLint("InlinedApi")
+  // Help tools to recognize that this method requires a permission, because it calls setBitmap().
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   @Override
   public void onResourceReady(
       @NonNull Bitmap resource, @Nullable Transition<? super Bitmap> transition) {
     setBitmap(resource);
   }
 
+  @SuppressLint("InlinedApi")
+  // Help tools to recognize that this method requires a permission, because it calls setBitmap().
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   @Override
   public void onLoadCleared(@Nullable Drawable placeholder) {
     setBitmap(null);
   }
 
+  @SuppressLint("InlinedApi")
+  // Help tools to recognize that this method requires a permission, because it calls update().
+  @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)
   private void setBitmap(@Nullable Bitmap bitmap) {
     this.remoteViews.setImageViewBitmap(this.viewId, bitmap);
     this.update();


### PR DESCRIPTION
## Description
Add `RequiresPermission` to help users and tools recognize that this class needs permissions. Ideally it would be just one `@RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)` on the class, but `androidx.annotation.RequiresPermission` is not applicable there (even though lint checks for it 😕). I checked androidx.annotation 1.6.0.

`InlinedApi` suppression is necessary because minSdk=14, compileSdk=33. The constant is new. Could inline it instead, but I personally don't like hard-coded copy-pasted constants when there's a named one.

## Motivation and Context
Motivation is this lint error:
![image](https://github.com/bumptech/glide/assets/2906988/5ea978a5-4556-424c-8cf9-564cf994b0e0)

It alerts when Glide is on the classpath, even if this class is not used. Noticed on AGP 8.

I read the code of `NotificationPermissionDetector` and noticed that it wouldn't alert if the class asked for the permission, that's why I decided it might be a good solution to add it, and fix everyone's lint at once :)