### PR TITLE
Add a isEquivalentTo method to correctly check equality

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -1209,31 +1209,42 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
     return selfOrThrowIfLocked();
   }
 
+  /**
+   * Returns {@code true} if this {@link BaseRequestOptions} is equivalent to the given
+   * {@link BaseRequestOptions} (has all of the same options and sizes).
+   *
+   * <p>This method is identical to {@link #equals(Object)}, but this can not be overridden. We need
+   * to use this method instead of {@link #equals(Object)}, because child classes may have additional
+   * fields, such as listeners and models, that should not be considered when checking for equality.
+   */
+  public final boolean isEquivalentTo(BaseRequestOptions<?> other) {
+    return Float.compare(other.sizeMultiplier, sizeMultiplier) == 0
+        && errorId == other.errorId
+        && Util.bothNullOrEqual(errorPlaceholder, other.errorPlaceholder)
+        && placeholderId == other.placeholderId
+        && Util.bothNullOrEqual(placeholderDrawable, other.placeholderDrawable)
+        && fallbackId == other.fallbackId
+        && Util.bothNullOrEqual(fallbackDrawable, other.fallbackDrawable)
+        && isCacheable == other.isCacheable
+        && overrideHeight == other.overrideHeight
+        && overrideWidth == other.overrideWidth
+        && isTransformationRequired == other.isTransformationRequired
+        && isTransformationAllowed == other.isTransformationAllowed
+        && useUnlimitedSourceGeneratorsPool == other.useUnlimitedSourceGeneratorsPool
+        && onlyRetrieveFromCache == other.onlyRetrieveFromCache
+        && diskCacheStrategy.equals(other.diskCacheStrategy)
+        && priority == other.priority
+        && options.equals(other.options)
+        && transformations.equals(other.transformations)
+        && resourceClass.equals(other.resourceClass)
+        && Util.bothNullOrEqual(signature, other.signature)
+        && Util.bothNullOrEqual(theme, other.theme);
+  }
+
   @Override
   public boolean equals(Object o) {
     if (o instanceof BaseRequestOptions<?>) {
-      BaseRequestOptions<?> other = (BaseRequestOptions<?>) o;
-      return Float.compare(other.sizeMultiplier, sizeMultiplier) == 0
-          && errorId == other.errorId
-          && Util.bothNullOrEqual(errorPlaceholder, other.errorPlaceholder)
-          && placeholderId == other.placeholderId
-          && Util.bothNullOrEqual(placeholderDrawable, other.placeholderDrawable)
-          && fallbackId == other.fallbackId
-          && Util.bothNullOrEqual(fallbackDrawable, other.fallbackDrawable)
-          && isCacheable == other.isCacheable
-          && overrideHeight == other.overrideHeight
-          && overrideWidth == other.overrideWidth
-          && isTransformationRequired == other.isTransformationRequired
-          && isTransformationAllowed == other.isTransformationAllowed
-          && useUnlimitedSourceGeneratorsPool == other.useUnlimitedSourceGeneratorsPool
-          && onlyRetrieveFromCache == other.onlyRetrieveFromCache
-          && diskCacheStrategy.equals(other.diskCacheStrategy)
-          && priority == other.priority
-          && options.equals(other.options)
-          && transformations.equals(other.transformations)
-          && resourceClass.equals(other.resourceClass)
-          && Util.bothNullOrEqual(signature, other.signature)
-          && Util.bothNullOrEqual(theme, other.theme);
+      return isEquivalentTo((BaseRequestOptions<?>) o);
     }
     return false;
   }

--- a/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
+++ b/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
@@ -778,7 +778,7 @@ public final class SingleRequest<R> implements Request, SizeReadyCallback, Resou
         && localOverrideHeight == otherLocalOverrideHeight
         && Util.bothModelsNullEquivalentOrEquals(localModel, otherLocalModel)
         && localTranscodeClass.equals(otherLocalTranscodeClass)
-        && localRequestOptions.equals(otherLocalRequestOptions)
+        && Util.bothBaseRequestOptionsNullEquivalentOrEquals(localRequestOptions, otherLocalRequestOptions)
         && localPriority == otherLocalPriority
         // We do not want to require that RequestListeners implement equals/hashcode, so we
         // don't compare them using equals(). We can however, at least assert that the same

--- a/library/src/main/java/com/bumptech/glide/util/Util.java
+++ b/library/src/main/java/com/bumptech/glide/util/Util.java
@@ -8,6 +8,7 @@ import android.os.Looper;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import com.bumptech.glide.load.model.Model;
+import com.bumptech.glide.request.BaseRequestOptions;
 import com.bumptech.glide.request.target.Target;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
@@ -238,6 +239,16 @@ public final class Util {
       return ((Model) a).isEquivalentTo(b);
     }
     return a.equals(b);
+  }
+
+  public static boolean bothBaseRequestOptionsNullEquivalentOrEquals(
+      @Nullable BaseRequestOptions<?> a,
+      @Nullable BaseRequestOptions<?> b
+  ) {
+    if (a == null) {
+      return b == null;
+    }
+    return a.isEquivalentTo(b);
   }
 
   public static int hashCode(int value) {


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
There was a change in equals method on Glide 4.14.2 (f3d6ff7).
After that, the cache doesn't work in several cases.
This PR fixes the bug by adding a `isEquivalentTo` method.

close #4958

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

See [my comment](https://github.com/bumptech/glide/issues/4958#issuecomment-1630408035) in the Issue.

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->