### PR TITLE
Add a Transition API and a CrossFade Transition for Compose

### DIFF
--- a/integration/compose/api/compose.api
+++ b/integration/compose/api/compose.api
@@ -1,8 +1,21 @@
+public final class com/bumptech/glide/integration/compose/CrossFade : com/bumptech/glide/integration/compose/Transition$Factory {
+	public static final field $stable I
+	public static final field Companion Lcom/bumptech/glide/integration/compose/CrossFade$Companion;
+	public fun <init> (Landroidx/compose/animation/core/AnimationSpec;)V
+	public fun build ()Lcom/bumptech/glide/integration/compose/Transition;
+	public fun equals (Ljava/lang/Object;)Z
+	public fun hashCode ()I
+}
+
+public final class com/bumptech/glide/integration/compose/CrossFade$Companion : com/bumptech/glide/integration/compose/Transition$Factory {
+	public fun build ()Lcom/bumptech/glide/integration/compose/Transition;
+}
+
 public abstract interface annotation class com/bumptech/glide/integration/compose/ExperimentalGlideComposeApi : java/lang/annotation/Annotation {
 }
 
 public final class com/bumptech/glide/integration/compose/GlideImageKt {
-	public static final fun GlideImage (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;Lcom/bumptech/glide/integration/compose/Placeholder;Lcom/bumptech/glide/integration/compose/Placeholder;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;II)V
+	public static final fun GlideImage (Ljava/lang/Object;Ljava/lang/String;Landroidx/compose/ui/Modifier;Landroidx/compose/ui/Alignment;Landroidx/compose/ui/layout/ContentScale;FLandroidx/compose/ui/graphics/ColorFilter;Lcom/bumptech/glide/integration/compose/Placeholder;Lcom/bumptech/glide/integration/compose/Placeholder;Lcom/bumptech/glide/integration/compose/Transition$Factory;Lkotlin/jvm/functions/Function1;Landroidx/compose/runtime/Composer;III)V
 	public static final fun GlideSubcomposition (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun placeholder (I)Lcom/bumptech/glide/integration/compose/Placeholder;
 	public static final fun placeholder (Landroid/graphics/drawable/Drawable;)Lcom/bumptech/glide/integration/compose/Placeholder;
@@ -52,5 +65,16 @@ public final class com/bumptech/glide/integration/compose/RequestState$Success :
 	public final fun getDataSource ()Lcom/bumptech/glide/load/DataSource;
 	public fun hashCode ()I
 	public fun toString ()Ljava/lang/String;
+}
+
+public abstract interface class com/bumptech/glide/integration/compose/Transition {
+	public abstract fun getDrawCurrent ()Lkotlin/jvm/functions/Function5;
+	public abstract fun getDrawPlaceholder ()Lkotlin/jvm/functions/Function5;
+	public abstract fun stop (Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public abstract fun transition (Lkotlin/jvm/functions/Function0;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+}
+
+public abstract interface class com/bumptech/glide/integration/compose/Transition$Factory {
+	public abstract fun build ()Lcom/bumptech/glide/integration/compose/Transition;
 }
 

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Painter.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Painter.kt
@@ -1,0 +1,19 @@
+package com.bumptech.glide.integration.compose
+
+import android.graphics.drawable.BitmapDrawable
+import android.graphics.drawable.ColorDrawable
+import android.graphics.drawable.Drawable
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.asImageBitmap
+import androidx.compose.ui.graphics.painter.BitmapPainter
+import androidx.compose.ui.graphics.painter.ColorPainter
+import androidx.compose.ui.graphics.painter.Painter
+import com.google.accompanist.drawablepainter.DrawablePainter
+
+internal fun Drawable?.toPainter(): Painter =
+  when (this) {
+    is BitmapDrawable -> BitmapPainter(bitmap.asImageBitmap())
+    is ColorDrawable -> ColorPainter(Color(color))
+    null -> ColorPainter(Color.Transparent)
+    else -> DrawablePainter(mutate())
+  }

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Transition.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/Transition.kt
@@ -1,0 +1,164 @@
+package com.bumptech.glide.integration.compose
+
+import android.util.Log
+import androidx.compose.animation.core.Animatable
+import androidx.compose.animation.core.AnimationSpec
+import androidx.compose.animation.core.AnimationVector1D
+import androidx.compose.animation.core.VectorConverter
+import androidx.compose.animation.core.tween
+import androidx.compose.ui.geometry.Size
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.graphics.drawscope.DrawScope
+import androidx.compose.ui.graphics.drawscope.clipRect
+import androidx.compose.ui.graphics.drawscope.translate
+import androidx.compose.ui.graphics.painter.Painter
+
+/**
+ * Transition between a given request's optional placeholder and the resource.
+ */
+public interface Transition {
+  /**
+   * Start the transition, calling [invalidate] each time the transition requires that the image
+   * be re-drawn.
+   */
+  public suspend fun transition(invalidate: () -> Unit)
+
+  /**
+   * Stop the transition
+   */
+  public suspend fun stop()
+
+  /**
+   * Optionally draw the current placeholder. If you want the placeholder to be shown during the
+   * transition, you must implement this method. If you only want to show the placeholder until
+   * the first resource finishes loading, then you can simply return null
+   *
+   * The canvas is prepared so that the image will be drawn in the appropriate location based on
+   * the parameters you provided (e.g. `ContentScale`). The canvas is saved before this method is
+   * called and restored afterward so you do not need to do so manually unless it's required for
+   * your transition.
+   *
+   * This method will only be called if a placeholder is set. If this method is called, it will
+   * always be called before [drawCurrent].
+   */
+  public val drawPlaceholder: DrawPainter?
+
+  /**
+   * Draw the current image. If you do not draw the current image, it will not be shown.
+   *
+   * This method is used before and after the transition finishes, so you need to ensure that you
+   * draw something even if your transition is not currently running, if you want the image to
+   * be displayed.
+   *
+   * The canvas is prepared so that the image will be drawn in the appropriate location based on
+   * the parameters you provided (e.g. `ContentScale`). The canvas is saved before this method is
+   * called and restored afterward so you do not need to do so manually unless it's required for
+   * your transition.
+   *
+   * This method is always called if there is something to draw. If [drawPlaceholder] is also
+   * called, [drawPlaceholder] will be called before this method.
+   */
+  public val drawCurrent: DrawPainter
+
+  /**
+   * Creates a new instance of this [Transition]. Must implement equals/hashcode. The simplest way
+   * of ensuring equals and hashcode are implemented correctly for custom transitions is to use an
+   * Object.
+   */
+  public interface Factory {
+    /**
+     * Create a new stateful [Transition] instance.
+     *
+     * May be called multiple times for a single Composable.
+     */
+    public fun build(): Transition
+  }
+}
+
+public typealias DrawPainter = DrawScope.(Painter, Size, Float, ColorFilter?) -> Unit
+
+internal object DoNotTransition : Transition {
+  object Factory : Transition.Factory {
+    override fun build() = DoNotTransition
+  }
+
+  override suspend fun transition(invalidate: () -> Unit) {}
+  override suspend fun stop() {}
+  override val drawPlaceholder: DrawPainter = { _, _, _, _ -> }
+  override val drawCurrent: DrawPainter = { painter, size, alpha, colorFilter ->
+    with(painter) {
+      draw(size, alpha, colorFilter)
+    }
+  }
+}
+
+/**
+ * A factory for [CrossFade]. If you do not want to modify the [animationSpec], use the companion
+ * object (ie `transition = CrossFade`)
+ */
+public class CrossFade(
+  private val animationSpec: AnimationSpec<Float>
+) : Transition.Factory {
+
+  override fun build(): Transition = CrossFadeImpl(animationSpec)
+
+  /**
+   * A default [CrossFade] with a 250ms duration
+   */
+  public companion object : Transition.Factory {
+    override fun build(): Transition =
+      CrossFadeImpl(animationSpec = tween(250))
+  }
+
+  override fun equals(other: Any?): Boolean {
+    if (other is CrossFade) {
+      return animationSpec == other.animationSpec
+    }
+    return false
+  }
+
+  override fun hashCode(): Int {
+    return animationSpec.hashCode()
+  }
+}
+
+/**
+ * Fades out the placeholder while fading in the resource(s).
+ */
+internal class CrossFadeImpl(
+  private val animationSpec: AnimationSpec<Float>
+) : Transition {
+
+  private companion object {
+    const val OPAQUE_ALPHA = 1f
+  }
+
+  private val animatable: Animatable<Float, AnimationVector1D> =
+    Animatable(0f, Float.VectorConverter, OPAQUE_ALPHA)
+
+  override suspend fun transition(invalidate: () -> Unit) {
+    try {
+      animatable.animateTo(OPAQUE_ALPHA, animationSpec)
+      invalidate()
+    } finally {
+      animatable.snapTo(OPAQUE_ALPHA)
+      invalidate()
+    }
+  }
+
+  override suspend fun stop() {
+    animatable.stop()
+  }
+
+  override val drawPlaceholder: DrawPainter = { painter, size, alpha, colorFilter ->
+    with(painter) {
+      draw(size, (OPAQUE_ALPHA - animatable.value) * alpha, colorFilter)
+    }
+  }
+
+  override val drawCurrent: DrawPainter = { painter, size, alpha, colorFilter ->
+    with(painter) {
+      draw(size, animatable.value * alpha, colorFilter)
+    }
+  }
+}

--- a/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/HorizontalGalleryFragment.kt
+++ b/samples/gallery/src/main/java/com/bumptech/glide/samples/gallery/HorizontalGalleryFragment.kt
@@ -72,7 +72,7 @@ class HorizontalGalleryFragment : Fragment() {
     preloadRequestBuilder: RequestBuilder<Drawable>,
     modifier: Modifier,
   ) =
-    GlideImage(model = item.uri, contentDescription = null, modifier = modifier) {
+    GlideImage(model = item.uri, contentDescription = item.displayName, modifier = modifier) {
       it.thumbnail(preloadRequestBuilder).signature(item.signature())
     }
 


### PR DESCRIPTION
Similar to Glide's existing Transitions, but intended for use with Animatable instead of views. I've started with a simple CrossFade. We probably should add at least a FadeOnTopOf (or something similar) to mimic the existing Crossfade support.