### PR TITLE
Add a Painter variant of the placeholder APIs

### DIFF
--- a/integration/compose/api/compose.api
+++ b/integration/compose/api/compose.api
@@ -19,6 +19,7 @@ public final class com/bumptech/glide/integration/compose/GlideImageKt {
 	public static final fun GlideSubcomposition (Ljava/lang/Object;Landroidx/compose/ui/Modifier;Lkotlin/jvm/functions/Function1;Lkotlin/jvm/functions/Function3;Landroidx/compose/runtime/Composer;II)V
 	public static final fun placeholder (I)Lcom/bumptech/glide/integration/compose/Placeholder;
 	public static final fun placeholder (Landroid/graphics/drawable/Drawable;)Lcom/bumptech/glide/integration/compose/Placeholder;
+	public static final fun placeholder (Landroidx/compose/ui/graphics/painter/Painter;)Lcom/bumptech/glide/integration/compose/Placeholder;
 	public static final fun placeholder (Lkotlin/jvm/functions/Function2;)Lcom/bumptech/glide/integration/compose/Placeholder;
 }
 

--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageErrorTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageErrorTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.core.app.ApplicationProvider
 import com.bumptech.glide.integration.compose.test.GlideComposeRule
 import com.bumptech.glide.integration.compose.test.expectDisplayedDrawable
+import com.bumptech.glide.integration.compose.test.expectDisplayedPainter
 import com.bumptech.glide.integration.compose.test.expectDisplayedResource
 import com.bumptech.glide.integration.compose.test.expectNoDrawable
 import org.junit.Rule
@@ -141,6 +142,25 @@ class GlideImageErrorTest {
     glideComposeRule
       .onNodeWithContentDescription(description)
       .assert(expectDisplayedResource(failureResourceId))
+  }
+
+  @Test
+  fun failure_setViaFailureParameterWithPainter_andRequestBuilderTransform_prefersFailurePainter() {
+    val description = "test"
+    val failurePainter = context.getDrawable(android.R.drawable.star_big_off).toPainter()
+    glideComposeRule.setContent {
+      GlideImage(
+        model = null,
+        contentDescription = description,
+        failure = placeholder(failurePainter),
+      ) {
+        it.error(android.R.drawable.btn_star)
+      }
+    }
+
+    glideComposeRule
+      .onNodeWithContentDescription(description)
+      .assert(expectDisplayedPainter(failurePainter))
   }
 
   @Test

--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImagePlaceholderTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImagePlaceholderTest.kt
@@ -7,6 +7,7 @@ import androidx.compose.ui.test.junit4.createComposeRule
 import androidx.compose.ui.test.onNodeWithContentDescription
 import androidx.test.core.app.ApplicationProvider
 import com.bumptech.glide.integration.compose.test.expectDisplayedDrawable
+import com.bumptech.glide.integration.compose.test.expectDisplayedPainter
 import com.bumptech.glide.integration.compose.test.expectDisplayedResource
 import com.bumptech.glide.integration.compose.test.expectNoDrawable
 import com.bumptech.glide.testutil.TearDownGlide
@@ -179,6 +180,27 @@ class GlideImagePlaceholderTest {
     composeRule
       .onNodeWithContentDescription(description)
       .assert(expectDisplayedDrawable(placeholderDrawable))
+  }
+
+  @Test
+  fun loading_setViaLoadingParameterWithPainter_andRequestBuilderTransform_prefersLoadingParameter() {
+    val description = "test"
+    val waitModel = waitModelLoaderRule.waitOn(android.R.drawable.star_big_on)
+    val placeholderDrawable = context.getDrawable(android.R.drawable.star_big_off)
+    val placeholderPainter = placeholderDrawable.toPainter()
+    composeRule.setContent {
+      GlideImage(
+        model = waitModel,
+        contentDescription = description,
+        loading = placeholder(placeholderPainter),
+      ) {
+        it.placeholder(android.R.drawable.btn_star)
+      }
+    }
+
+    composeRule
+      .onNodeWithContentDescription(description)
+      .assert(expectDisplayedPainter(placeholderPainter))
   }
 
   @Test

--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/test/expectations.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/test/expectations.kt
@@ -10,10 +10,12 @@ import android.graphics.drawable.BitmapDrawable
 import android.graphics.drawable.Drawable
 import android.util.TypedValue
 import androidx.compose.runtime.MutableState
+import androidx.compose.ui.graphics.painter.Painter
 import androidx.compose.ui.semantics.SemanticsPropertyKey
 import androidx.compose.ui.test.SemanticsMatcher
 import androidx.test.core.app.ApplicationProvider
 import com.bumptech.glide.integration.compose.DisplayedDrawableKey
+import com.bumptech.glide.integration.compose.DisplayedPainterKey
 import com.bumptech.glide.integration.ktx.InternalGlideApi
 import com.bumptech.glide.integration.ktx.Size
 import kotlin.math.roundToInt
@@ -43,10 +45,10 @@ fun expectDisplayedDrawableSize(expectedSize: Size): SemanticsMatcher =
 fun expectDisplayedDrawable(expectedValue: Drawable?): SemanticsMatcher =
   expectDisplayedDrawable(expectedValue.bitmapOrThrow(), ::compareBitmaps) { it.bitmapOrThrow() }
 
-fun expectAnimatingDrawable(): SemanticsMatcher =
-  expectDisplayedDrawable(true) {
-    (it as Animatable).isRunning
-  }
+fun expectDisplayedPainter(expectedValue: Painter?): SemanticsMatcher =
+  expectStateValue(
+    DisplayedPainterKey, expectedValue, {first, second -> first == second}, {value -> value}
+  )
 
 fun expectNoDrawable(): SemanticsMatcher = expectDisplayedDrawable(null)
 


### PR DESCRIPTION
Fixes #5224

We could go further and remove the drawable / resource id variants entirely, but it won't lead to a huge simplification internally because we still have to deal with those types from RequestBuilder.