### PR TITLE
Avoid drawing placeholder when it shouldn't be used

### DIFF
--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
@@ -332,10 +332,15 @@ internal class GlideNode : DrawModifierNode, LayoutModifierNode, SemanticsModifi
   override fun ContentDrawScope.draw() {
     if (draw) {
       val drawPlaceholder = transition.drawPlaceholder ?: DoNotTransition.drawPlaceholder
-      placeholder?.let { painter ->
-        drawContext.canvas.withSave {
-          placeholderPositionAndSize = drawOne(painter, placeholderPositionAndSize) { size ->
-            drawPlaceholder.invoke(this, painter, size, alpha, colorFilter)
+      // If we're only showing the placeholder, it should just be drawn as the primary image.
+      // If we've loaded a full image and we have a placeholder, then we should try to draw both so
+      // that the transition can decide what to do.
+      if (placeholder != primary && transition != DoNotTransition) {
+        placeholder?.let { painter ->
+          drawContext.canvas.withSave {
+            placeholderPositionAndSize = drawOne(painter, placeholderPositionAndSize) { size ->
+              drawPlaceholder.invoke(this, painter, size, alpha, colorFilter)
+            }
           }
         }
       }


### PR DESCRIPTION
This isn't a huge deal, but we might as well not try to draw the placeholder if we can tell it's not going to be used. In particular this might fix an issue where a custom transition would draw the placeholder twice before or after the transition was supposed to have run. 