### PR TITLE
Fix BitmapPoolAdapter outdated JavaDoc

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPoolAdapter.java
+++ b/library/src/main/java/com/bumptech/glide/load/engine/bitmap_recycle/BitmapPoolAdapter.java
@@ -5,8 +5,8 @@ import androidx.annotation.NonNull;
 
 /**
  * An {@link com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool BitmapPool} implementation
- * that rejects all {@link android.graphics.Bitmap Bitmap}s added to it and always returns {@code
- * null} from get.
+ * that rejects all {@link android.graphics.Bitmap Bitmap}s added to it and always returns a new
+ * {@link android.graphics.Bitmap Bitmap} from {@link #get}.
  */
 public class BitmapPoolAdapter implements BitmapPool {
   @Override


### PR DESCRIPTION
Behavior changed in https://github.com/bumptech/glide/commit/57cdba301532357d55668871321b47d23197349a#diff-83548f809862333be02579b6321a79d3db926c965f468c51fdbb0560e85a4694