### PR TITLE
Update TransformationUtils#rotateImageExif to preserve gainmap and co…

### DIFF
--- a/integration/gifencoder/src/test/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoderTest.java
+++ b/integration/gifencoder/src/test/java/com/bumptech/glide/integration/gifencoder/ReEncodingGifResourceEncoderTest.java
@@ -44,7 +44,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link com.bumptech.glide.integration.gifencoder.ReEncodingGifResourceEncoder}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(manifest = Config.NONE, sdk = 18)
+@Config(manifest = Config.NONE, sdk = 19)
 public class ReEncodingGifResourceEncoderTest {
   @Mock private Resource<GifDrawable> resource;
   @Mock private GifDecoder decoder;

--- a/integration/volley/src/test/java/com/bumptech/glide/integration/volley/VolleyStreamFetcherServerTest.java
+++ b/integration/volley/src/test/java/com/bumptech/glide/integration/volley/VolleyStreamFetcherServerTest.java
@@ -47,7 +47,7 @@ import org.robolectric.shadows.ShadowSystemClock;
 @RunWith(RobolectricTestRunner.class)
 @Config(
     manifest = Config.NONE,
-    sdk = 18,
+    sdk = 19,
     shadows = VolleyStreamFetcherServerTest.FakeSystemClock.class)
 public class VolleyStreamFetcherServerTest {
   private static final String DEFAULT_PATH = "/fakepath";

--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -488,6 +488,18 @@ public final class GlideBuilder {
   }
 
   /**
+   * Preserves gainmap and color spaces while {@link Bitmap}s undergo transformation, i.e., in
+   * {@link com.bumptech.glide.load.resource.bitmap.TransformationUtils}.
+   *
+   * <p>Without this flag on, gainmap and color space information may be dropped in transformations,
+   * leading to unexpected behavior when transforming wide gamut images or Ultra HDR images.
+   */
+  public GlideBuilder setPreserveGainmapAndColorSpaceForTransformations(boolean isEnabled) {
+    glideExperimentsBuilder.update(new PreserveGainmapAndColorSpaceForTransformations(), isEnabled);
+    return this;
+  }
+
+  /**
    * @deprecated This method does nothing. It will be hard coded and removed in a future release
    *     without further warning.
    */
@@ -599,6 +611,12 @@ public final class GlideBuilder {
       this.fdCount = fdCount;
     }
   }
+
+  /**
+   * Preserves gainmap and color spaces while {@link Bitmap}s undergo transformation, i.e., in
+   * {@link com.bumptech.glide.load.resource.bitmap.TransformationUtils}.
+   */
+  static final class PreserveGainmapAndColorSpaceForTransformations implements Experiment {}
 
   static final class EnableImageDecoderForBitmaps implements Experiment {}
 

--- a/library/src/main/java/com/bumptech/glide/RegistryFactory.java
+++ b/library/src/main/java/com/bumptech/glide/RegistryFactory.java
@@ -13,6 +13,7 @@ import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
 import androidx.tracing.Trace;
 import com.bumptech.glide.GlideBuilder.EnableImageDecoderForBitmaps;
+import com.bumptech.glide.GlideBuilder.PreserveGainmapAndColorSpaceForTransformations;
 import com.bumptech.glide.gifdecoder.GifDecoder;
 import com.bumptech.glide.load.ImageHeaderParser;
 import com.bumptech.glide.load.ResourceDecoder;
@@ -155,7 +156,11 @@ final class RegistryFactory {
     // TODO(judds): Make ParcelFileDescriptorBitmapDecoder work with ImageDecoder.
     Downsampler downsampler =
         new Downsampler(
-            registry.getImageHeaderParsers(), resources.getDisplayMetrics(), bitmapPool, arrayPool);
+            registry.getImageHeaderParsers(),
+            resources.getDisplayMetrics(),
+            bitmapPool,
+            arrayPool,
+            experiments.isEnabled(PreserveGainmapAndColorSpaceForTransformations.class));
 
     ResourceDecoder<ByteBuffer, Bitmap> byteBufferBitmapDecoder;
     ResourceDecoder<InputStream, Bitmap> streamBitmapDecoder;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -304,6 +304,9 @@ public final class TransformationUtils {
   /**
    * Rotate and/or flip the image to match the given exif orientation.
    *
+   * <p>Note that this method will not preserve the image's color gamut and gainmap. Use {@link
+   * #rotateImageExif(BitmapPool, Bitmap, int, boolean)} to enable that functionality.
+   *
    * @param pool A pool that may or may not contain an image of the necessary dimensions.
    * @param inBitmap The bitmap to rotate/flip.
    * @param exifOrientation the exif orientation [1-8].
@@ -311,6 +314,25 @@ public final class TransformationUtils {
    */
   public static Bitmap rotateImageExif(
       @NonNull BitmapPool pool, @NonNull Bitmap inBitmap, int exifOrientation) {
+    return rotateImageExif(
+        pool, inBitmap, exifOrientation, /* preserveGainmapAndColorSpace= */ false);
+  }
+
+  /**
+   * Rotate and/or flip the image to match the given exif orientation.
+   *
+   * @param pool A pool that may or may not contain an image of the necessary dimensions.
+   * @param inBitmap The bitmap to rotate/flip.
+   * @param exifOrientation the exif orientation [1-8].
+   * @param preserveGainmapAndColorSpace whether to preserve gainmap and color space information
+   *     post-transformation.
+   * @return The rotated and/or flipped image or inBitmap if no rotation or flip was necessary.
+   */
+  public static Bitmap rotateImageExif(
+      @NonNull BitmapPool pool,
+      @NonNull Bitmap inBitmap,
+      int exifOrientation,
+      boolean preserveGainmapAndColorSpace) {
     if (!isExifOrientationRequired(exifOrientation)) {
       return inBitmap;
     }
@@ -318,21 +340,36 @@ public final class TransformationUtils {
     final Matrix matrix = new Matrix();
     initializeMatrixForRotation(exifOrientation, matrix);
 
-    // From Bitmap.createBitmap.
-    final RectF newRect = new RectF(0, 0, inBitmap.getWidth(), inBitmap.getHeight());
-    matrix.mapRect(newRect);
+    Bitmap result;
+    if (preserveGainmapAndColorSpace) {
+      // BitmapPool doesn't preserve gainmaps and color space, so use Bitmap.create to apply the
+      // matrix.
+      result =
+          Bitmap.createBitmap(
+              inBitmap,
+              /* x= */ 0,
+              /* y= */ 0,
+              inBitmap.getWidth(),
+              inBitmap.getHeight(),
+              matrix,
+              /* filter= */ true);
+    } else {
+      // From Bitmap.createBitmap.
+      final RectF newRect = new RectF(0, 0, inBitmap.getWidth(), inBitmap.getHeight());
+      matrix.mapRect(newRect);
 
-    final int newWidth = Math.round(newRect.width());
-    final int newHeight = Math.round(newRect.height());
+      final int newWidth = Math.round(newRect.width());
+      final int newHeight = Math.round(newRect.height());
 
-    Bitmap.Config config = getNonNullConfig(inBitmap);
-    Bitmap result = pool.get(newWidth, newHeight, config);
+      Bitmap.Config config = getNonNullConfig(inBitmap);
+      result = pool.get(newWidth, newHeight, config);
 
-    matrix.postTranslate(-newRect.left, -newRect.top);
+      matrix.postTranslate(-newRect.left, -newRect.top);
 
-    result.setHasAlpha(inBitmap.hasAlpha());
+      result.setHasAlpha(inBitmap.hasAlpha());
 
-    applyMatrix(inBitmap, result, matrix);
+      applyMatrix(inBitmap, result, matrix);
+    }
     return result;
   }
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
@@ -14,7 +14,10 @@ import static org.mockito.Mockito.when;
 
 import android.graphics.Bitmap;
 import android.graphics.Color;
+import android.graphics.ColorSpace;
+import android.graphics.ColorSpace.Named;
 import android.graphics.Matrix;
+import android.os.Build.VERSION_CODES;
 import androidx.exifinterface.media.ExifInterface;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.tests.Util;
@@ -408,6 +411,40 @@ public class TransformationUtilsTest {
             bitmapPool, toRotate, ExifInterface.ORIENTATION_ROTATE_180);
     assertEquals(Bitmap.Config.ARGB_8888, rotated.getConfig());
   }
+
+  @Test
+  @Config(sdk = VERSION_CODES.UPSIDE_DOWN_CAKE)
+  public void rotateImageExif_flagOff_doesNotPreserveColorSpace() {
+    Bitmap toRotate = Bitmap.createBitmap(200, 100, Bitmap.Config.ARGB_8888);
+    toRotate.setColorSpace(ColorSpace.get(ColorSpace.Named.DISPLAY_P3));
+
+    Bitmap rotated =
+        TransformationUtils.rotateImageExif(
+            bitmapPool,
+            toRotate,
+            ExifInterface.ORIENTATION_ROTATE_90,
+            /* preserveGainmapAndColorSpace= */ false);
+
+    assertEquals(ColorSpace.get(Named.SRGB), rotated.getColorSpace());
+  }
+
+  @Test
+  @Config(sdk = VERSION_CODES.UPSIDE_DOWN_CAKE)
+  public void rotateImageExif_flagOm_preservesColorSpace() {
+    Bitmap toRotate = Bitmap.createBitmap(200, 100, Bitmap.Config.ARGB_8888);
+    toRotate.setColorSpace(ColorSpace.get(ColorSpace.Named.DISPLAY_P3));
+
+    Bitmap rotated =
+        TransformationUtils.rotateImageExif(
+            bitmapPool,
+            toRotate,
+            ExifInterface.ORIENTATION_ROTATE_90,
+            /* preserveGainmapAndColorSpace= */ true);
+
+    assertEquals(ColorSpace.get(ColorSpace.Named.DISPLAY_P3), rotated.getColorSpace());
+  }
+
+  // TODO: Add gainmap-based tests once Robolectric has sufficient support.
 
   @Test
   public void testInitializeMatrixSetsScaleIfFlipHorizontal() {

--- a/settings.gradle
+++ b/settings.gradle
@@ -138,7 +138,7 @@ dependencyResolutionManagement {
             library('retrofit', 'com.squareup.retrofit2', 'retrofit').versionRef('retrofit')
             library('retrofit-gson', 'com.squareup.retrofit2', 'converter-gson').versionRef('retrofit')
             library('retrofit-rxjava', 'com.squareup.retrofit2', 'adapter-rxjava').versionRef('retrofit')
-            library('robolectric', 'org.robolectric:robolectric:4.8.1')
+            library('robolectric', 'org.robolectric:robolectric:4.11.1')
             library('rx-android', 'io.reactivex:rxandroid:1.2.1')
             library('rx-java', 'io.reactivex:rxjava:1.3.8')
             library('svg', 'com.caverock:androidsvg:1.2.1')

--- a/third_party/gif_decoder/src/test/java/com/bumptech/glide/gifdecoder/GifDecoderTest.java
+++ b/third_party/gif_decoder/src/test/java/com/bumptech/glide/gifdecoder/GifDecoderTest.java
@@ -17,7 +17,7 @@ import org.robolectric.annotation.Config;
 
 /** Tests for {@link com.bumptech.glide.gifdecoder.GifDecoder}. */
 @RunWith(RobolectricTestRunner.class)
-@Config(sdk = 18)
+@Config(sdk = 19)
 public class GifDecoderTest {
 
   private MockProvider provider;
@@ -206,6 +206,5 @@ public class GifDecoderTest {
     public void release(@NonNull int[] array) {
       // Do Nothing
     }
-
   }
 }


### PR DESCRIPTION
…lorspace on Android U+

This is only done on Android U+ to minimize risk with not using BitmapPool anymore when an image is rotated due to an EXIF orientation metadata.

I was going to add a unit test for gainmaps too, but unfortunately, there needs to be one more change to Robolectric's ShadowGainmap that will allow us to exercise the flows on Android U. My own testing with the required change in Robolectric shows that this change will preserve gainmaps.

fix #5333 