### PR TITLE
Support multiple level inheritance for lib and app modules in case of KSP usage

### DIFF
--- a/annotation/ksp/integrationtest/src/test/java/com/bumptech/glide/annotation/ksp/integrationtest/IntegrationLibraryGlideModuleTests.kt
+++ b/annotation/ksp/integrationtest/src/test/java/com/bumptech/glide/annotation/ksp/integrationtest/IntegrationLibraryGlideModuleTests.kt
@@ -57,6 +57,53 @@ class IntegrationLibraryGlideModuleTests(override val sourceType: SourceType) : 
   }
 
   @Test
+  fun compile_withOnlyAppGlideModuleThroughBaseClass_generatesGeneratedAppGlideModule_thatCallsDependencyLibraryGlideModules() {
+    val kotlinAppModule =
+      KotlinSourceFile(
+        "AppModule.kt",
+        """
+        import com.bumptech.glide.annotation.GlideModule
+        import com.bumptech.glide.module.AppGlideModule
+
+        class BaseAppModule : AppGlideModule()
+        @GlideModule class AppModule : BaseAppModule()
+        """
+      )
+    val javaBaseAppModule =
+      JavaSourceFile(
+        "BaseAppModule.java",
+        """
+        import com.bumptech.glide.module.AppGlideModule;
+
+        public class BaseAppModule extends AppGlideModule {
+          public BaseAppModule() {}
+        }
+        """
+      )
+    val javaAppModule =
+      JavaSourceFile(
+        "AppModule.java",
+        """
+        import com.bumptech.glide.annotation.GlideModule;
+
+        @GlideModule public class AppModule extends BaseAppModule {
+          public AppModule() {}
+        }
+        """
+      )
+
+    compileCurrentSourceType(
+        kotlinAppModule,
+        javaBaseAppModule,
+        javaAppModule,
+    ) {
+      assertThat(it.exitCode).isEqualTo(ExitCode.OK)
+      assertThat(it.generatedAppGlideModuleContents())
+          .hasSourceEqualTo(appGlideModuleWithOnlyDependencyLibraryModules)
+    }
+  }
+
+  @Test
   fun compile_withValidLibraryGlideModule_andAppGlideModule_generatesGeneratedAppGlideModule_thatCallsAllLibraryAndDependencyAndAppGlideModules() {
     val kotlinLibraryModule =
       KotlinSourceFile(
@@ -110,6 +157,85 @@ class IntegrationLibraryGlideModuleTests(override val sourceType: SourceType) : 
       assertThat(it.exitCode).isEqualTo(ExitCode.OK)
       assertThat(it.generatedAppGlideModuleContents())
         .hasSourceEqualTo(appGlideModuleWithLibraryModuleAndDependencyLibraryModules)
+    }
+  }
+
+  @Test
+  fun compile_withValidLibraryGlideModule_andAppGlideModule_ThroughBaseClass_generatesGeneratedAppGlideModule_thatCallsAllLibraryAndDependencyAndAppGlideModules() {
+    val kotlinLibraryModule =
+      KotlinSourceFile(
+        "LibraryModule.kt",
+        """
+        import com.bumptech.glide.annotation.GlideModule
+        import com.bumptech.glide.module.LibraryGlideModule
+
+        class BaseLibraryModule : LibraryGlideModule()
+        @GlideModule class LibraryModule : BaseLibraryModule()
+        """
+      )
+    val kotlinAppModule =
+      KotlinSourceFile(
+        "AppModule.kt",
+        """
+        import com.bumptech.glide.annotation.GlideModule
+        import com.bumptech.glide.module.AppGlideModule
+
+        class BaseAppModule : AppGlideModule()
+        @GlideModule class AppModule : BaseAppModule()
+        """
+      )
+    val javaBaseLibraryModule =
+      JavaSourceFile(
+        "BaseLibraryModule.java",
+        """
+          import com.bumptech.glide.module.LibraryGlideModule;
+
+          public class BaseLibraryModule extends LibraryGlideModule {}
+        """
+      )
+    val javaLibraryModule =
+      JavaSourceFile(
+        "LibraryModule.java",
+        """
+          import com.bumptech.glide.annotation.GlideModule;
+
+          @GlideModule public class LibraryModule extends BaseLibraryModule {}
+        """
+      )
+    val javaBaseAppModule =
+      JavaSourceFile(
+        "BaseAppModule.java",
+        """
+          import com.bumptech.glide.module.AppGlideModule;
+
+          public class BaseAppModule extends AppGlideModule {
+            public BaseAppModule() {}
+          }
+        """
+      )
+    val javaAppModule =
+      JavaSourceFile(
+        "AppModule.java",
+        """
+          import com.bumptech.glide.annotation.GlideModule;
+
+          @GlideModule public class AppModule extends BaseAppModule {
+            public AppModule() {}
+          }
+        """
+      )
+
+    compileCurrentSourceType(
+        kotlinAppModule,
+        kotlinLibraryModule,
+        javaBaseAppModule,
+        javaAppModule,
+        javaBaseLibraryModule,
+        javaLibraryModule
+    ) {
+      assertThat(it.exitCode).isEqualTo(ExitCode.OK)
+      assertThat(it.generatedAppGlideModuleContents())
+          .hasSourceEqualTo(appGlideModuleWithLibraryModuleAndDependencyLibraryModules)
     }
   }
 

--- a/annotation/ksp/src/main/kotlin/com/bumptech/glide/annotation/ksp/ModuleParser.kt
+++ b/annotation/ksp/src/main/kotlin/com/bumptech/glide/annotation/ksp/ModuleParser.kt
@@ -14,7 +14,7 @@ object ModuleParser {
     val appAndLibraryModuleNames = listOf(APP_MODULE_QUALIFIED_NAME, LIBRARY_MODULE_QUALIFIED_NAME)
     val modulesBySuperType: Map<String?, List<KSClassDeclaration>> =
       annotatedModules.filterIsInstance<KSClassDeclaration>().groupBy { classDeclaration ->
-        appAndLibraryModuleNames.singleOrNull { classDeclaration.hasSuperType(it) }
+        appAndLibraryModuleNames.firstOrNull { classDeclaration.hasSuperType(it) }
       }
 
     val (appModules, libraryModules) =
@@ -22,10 +22,19 @@ object ModuleParser {
     return GlideModules(appModules, libraryModules)
   }
 
-  private fun KSClassDeclaration.hasSuperType(superTypeQualifiedName: String) =
-    superTypes
-      .map { superType -> superType.resolve().declaration.qualifiedName!!.asString() }
-      .contains(superTypeQualifiedName)
+  private fun KSClassDeclaration.hasSuperType(superTypeQualifiedName: String): Boolean {
+    val superDeclarations = superTypes
+            .map { superType -> superType.resolve().declaration }
+    val hasInDirectParent = superDeclarations
+            .map { it.qualifiedName!!.asString() }
+            .contains(superTypeQualifiedName)
+    return if (hasInDirectParent) {
+      true
+    } else {
+      superDeclarations.filterIsInstance(KSClassDeclaration::class.java)
+              .any { it.hasSuperType(superTypeQualifiedName) }
+    }
+  }
 
   private const val APP_MODULE_QUALIFIED_NAME = "com.bumptech.glide.module.AppGlideModule"
   private const val LIBRARY_MODULE_QUALIFIED_NAME = "com.bumptech.glide.module.LibraryGlideModule"

--- a/annotation/ksp/test/src/test/kotlin/com/bumptech/glide/annotation/ksp/test/LibraryGlideModuleTests.kt
+++ b/annotation/ksp/test/src/test/kotlin/com/bumptech/glide/annotation/ksp/test/LibraryGlideModuleTests.kt
@@ -109,6 +109,86 @@ class LibraryGlideModuleTests(override val sourceType: SourceType) : PerSourceTy
   }
 
   @Test
+  fun compile_withValidLibraryGlideModule_andAppGlideModule_ThroughBaseClass_generatesGeneratedAppGlideModule_andCallsBothLibraryAndAppGlideModules() {
+    val kotlinLibraryModule =
+      KotlinSourceFile(
+        "LibraryModule.kt",
+        """
+        import com.bumptech.glide.annotation.GlideModule
+        import com.bumptech.glide.module.LibraryGlideModule
+
+        class BaseLibraryModule : LibraryGlideModule()
+        @GlideModule class LibraryModule : BaseLibraryModule()
+        """
+      )
+    val kotlinAppModule =
+      KotlinSourceFile(
+        "AppModule.kt",
+        """
+        import com.bumptech.glide.annotation.GlideModule
+        import com.bumptech.glide.module.AppGlideModule
+
+        class BaseAppModule : AppGlideModule()
+        @GlideModule class AppModule : BaseAppModule()
+        """
+      )
+    val javaBaseLibraryModule =
+      JavaSourceFile(
+        "BaseLibraryModule.java",
+        """
+          import com.bumptech.glide.module.LibraryGlideModule;
+
+          public class BaseLibraryModule extends LibraryGlideModule {}
+        """
+      )
+    val javaLibraryModule =
+      JavaSourceFile(
+        "LibraryModule.java",
+        """
+          import com.bumptech.glide.annotation.GlideModule;
+
+          @GlideModule public class LibraryModule extends BaseLibraryModule {}
+        """
+      )
+    val javaBaseAppModule =
+      JavaSourceFile(
+        "BaseAppModule.java",
+        """
+          import com.bumptech.glide.module.AppGlideModule;
+
+          public class BaseAppModule extends AppGlideModule {
+            public BaseAppModule() {}
+          }
+        """
+      )
+    val javaAppModule =
+      JavaSourceFile(
+        "AppModule.java",
+        """
+          import com.bumptech.glide.annotation.GlideModule;
+
+          @GlideModule public class AppModule extends BaseAppModule {
+            public AppModule() {}
+          }
+        """
+      )
+
+    compileCurrentSourceType(
+        kotlinAppModule,
+        kotlinLibraryModule,
+        javaBaseAppModule,
+        javaAppModule,
+        javaBaseLibraryModule,
+        javaLibraryModule
+    ) {
+      assertThat(it.messages).doesNotContainMatch("[we]: \\[ksp] .*")
+      assertThat(it.exitCode).isEqualTo(ExitCode.OK)
+      assertThat(it.generatedAppGlideModuleContents())
+          .hasSourceEqualTo(appGlideModuleWithLibraryModule)
+    }
+  }
+
+  @Test
   fun compile_withMultipleLibraryGlideModules_andAppGlideModule_callsAllLibraryGlideModulesFromGeneratedAppGlideModule() {
     val kotlinLibraryModule1 =
       KotlinSourceFile(

--- a/annotation/ksp/test/src/test/kotlin/com/bumptech/glide/annotation/ksp/test/OnlyAppGlideModuleTests.kt
+++ b/annotation/ksp/test/src/test/kotlin/com/bumptech/glide/annotation/ksp/test/OnlyAppGlideModuleTests.kt
@@ -80,6 +80,46 @@ class OnlyAppGlideModuleTests(override val sourceType: SourceType) : PerSourceTy
   }
 
   @Test
+  fun compile_withGlideModuleOnValidAppGlideModuleThroughBaseClass_generatedGeneratedAppGlideModule() {
+    val kotlinModule =
+      KotlinSourceFile(
+        "AppModule.kt",
+        """
+      import com.bumptech.glide.annotation.GlideModule
+      import com.bumptech.glide.module.AppGlideModule
+      class BaseAppModule : AppGlideModule()
+        @GlideModule class AppModule : BaseAppModule()
+        """
+      )
+    val javaBaseAppModule =
+      JavaSourceFile(
+        "BaseAppModule.java",
+        """
+          import com.bumptech.glide.module.AppGlideModule;
+
+          public class BaseAppModule extends AppGlideModule {}
+        """
+                .trimIndent()
+      )
+    val javaModule =
+      JavaSourceFile(
+        "AppModule.java",
+        """
+          import com.bumptech.glide.annotation.GlideModule;
+
+          @GlideModule public class AppModule extends BaseAppModule {}
+        """
+                .trimIndent()
+      )
+
+    compileCurrentSourceType(kotlinModule, javaBaseAppModule, javaModule) {
+      assertThat(it.generatedAppGlideModuleContents())
+          .hasSourceEqualTo(CommonSources.simpleAppGlideModule)
+      assertThat(it.exitCode).isEqualTo(KotlinCompilation.ExitCode.OK)
+    }
+  }
+
+  @Test
   fun compile_withAppGlideModuleConstructorAcceptingOnlyContext_generatesGeneratedAppGlideModule() {
     val kotlinModule =
       KotlinSourceFile(
@@ -179,7 +219,7 @@ class OnlyAppGlideModuleTests(override val sourceType: SourceType) : PerSourceTy
 
   // This is quite weird, we could probably pretty reasonably just assert that this doesn't happen.
   @Test
-  fun compile_withAppGlideModuleWithOneEmptyrConstructor_andOneContextOnlyConstructor_usesTheContextOnlyConstructor() {
+  fun compile_withAppGlideModuleWithOneEmptyConstructor_andOneContextOnlyConstructor_usesTheContextOnlyConstructor() {
     val kotlinModule =
       KotlinSourceFile(
         "AppModule.kt",
@@ -217,7 +257,7 @@ class OnlyAppGlideModuleTests(override val sourceType: SourceType) : PerSourceTy
   }
 
   @Test
-  fun copmile_withMultipleAppGlideModules_failes() {
+  fun compile_withMultipleAppGlideModules_fails() {
     val firstKtModule =
       KotlinSourceFile(
         "Module1.kt",


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
In Datadog we [have instrumentation](https://github.com/DataDog/dd-sdk-android/blob/ab6f38f5b8ddf8d9f500d4043ef8ac77b2cf8ca1/integrations/dd-sdk-android-glide/src/main/kotlin/com/datadog/android/glide/DatadogGlideModule.kt) for Glide by the means of creating `DatadogGlideModule` which inherits from `AppGlideModule`. Customers can extend `DatadogGlideModule` instead of `AppGlideModule` and get their Glide calls instrumented with Datadog.

This worked fine for KAPT, but doesn't work for KSP, because in case of KSP usage compilation with some class which inherits `DatadogGlideModule` instead of `AppGlideModule` directly gives the same error as in https://github.com/bumptech/glide/issues/5328.

This happens because `supertypes` call [here](https://github.com/bumptech/glide/blob/e77562a432352da19741d93b8c1f6599b558676a/annotation/ksp/src/main/kotlin/com/bumptech/glide/annotation/ksp/ModuleParser.kt#L26) checks only types at declaration site and doesn't go through the whole inheritance chain up.

This PR fixes that issue by traversing the whole inheritance chain, so that functionality is aligned with KAPT compiler (which permits such inheritance chains).

**NB**: Since we have to traverse the whole inheritance chain and `AppGlideModule` extends actually `LibraryGlideModule`, it may be tricky to not register app module as library module as well, but since this PR is using `first` item in the supertype match, app module will be still registered as app module and not as both.

<!-- ## Motivation and Context -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->