### PR TITLE
fgrep: warning: fgrep is obsolescent; use grep -F

### DIFF
--- a/scripts/update_javadocs.sh
+++ b/scripts/update_javadocs.sh
@@ -9,8 +9,8 @@ set -o pipefail
 TEMP_DIR="/tmp/tmp_glide_javadoc"
 JAVADOC_GH_PAGES_DIR="javadocs"
 
-major_version=$(fgrep VERSION_MAJOR gradle.properties | cut -d '=' -f 2)
-minor_version=$(fgrep VERSION_MINOR gradle.properties | cut -d '=' -f 2)
+major_version=$(grep -F VERSION_MAJOR gradle.properties | cut -d '=' -f 2)
+minor_version=$(grep -F VERSION_MINOR gradle.properties | cut -d '=' -f 2)
 version="${major_version}${minor_version}0"
 
 echo "Updating javadocs for ${version}"


### PR DESCRIPTION
replaces fgrep with grep -F