### PR TITLE
Help Renovate understand the repo regarding semantic commits

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -3,6 +3,7 @@
   "extends": [
     "config:recommended"
   ],
+  "semanticCommits": "disabled",
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Motivation and Context
Default value is "auto" which looks at commits on base branch. https://github.com/bumptech/glide/commit/3bbc3908edd8432f55ccfae3257bad533c1bf7d1 in considered as a "semantic commit" and therefore https://github.com/bumptech/glide/pull/5299 also uses a semantic name. This change explicitly disables this, as we don't want it to consider something that's not the case.

It seems all future commits/PRs will be semantic too:
https://github.com/bumptech/glide/issues/5187
![image](https://github.com/bumptech/glide/assets/2906988/897c9e9c-7816-4353-832e-f13c817f6b4d)
