### PR TITLE
Add workaround for AOSP bug with decoding single channel hardware gai…

### DIFF
--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -500,6 +500,17 @@ public final class GlideBuilder {
   }
 
   /**
+   * Fixes decoding of hardware gainmaps from Ultra HDR images on Android U.
+   *
+   * <p>Without this flag on, gainmaps may be dropped when decoding Ultra HDR on Android U devices
+   * using skiagl for hwui as described in https://github.com/bumptech/glide/issues/5362.
+   */
+  public GlideBuilder setEnableHardwareGainmapFixOnU(boolean isEnabled) {
+    glideExperimentsBuilder.update(new EnableHardwareGainmapFixOnU(), isEnabled);
+    return this;
+  }
+
+  /**
    * @deprecated This method does nothing. It will be hard coded and removed in a future release
    *     without further warning.
    */
@@ -617,6 +628,9 @@ public final class GlideBuilder {
    * {@link com.bumptech.glide.load.resource.bitmap.TransformationUtils}.
    */
   static final class PreserveGainmapAndColorSpaceForTransformations implements Experiment {}
+
+  /** Fixes decoding of hardware gainmaps from Ultra HDR images on Android U. */
+  static final class EnableHardwareGainmapFixOnU implements Experiment {}
 
   static final class EnableImageDecoderForBitmaps implements Experiment {}
 

--- a/library/src/main/java/com/bumptech/glide/RegistryFactory.java
+++ b/library/src/main/java/com/bumptech/glide/RegistryFactory.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
 import androidx.tracing.Trace;
+import com.bumptech.glide.GlideBuilder.EnableHardwareGainmapFixOnU;
 import com.bumptech.glide.GlideBuilder.EnableImageDecoderForBitmaps;
 import com.bumptech.glide.GlideBuilder.PreserveGainmapAndColorSpaceForTransformations;
 import com.bumptech.glide.gifdecoder.GifDecoder;
@@ -160,7 +161,8 @@ final class RegistryFactory {
             resources.getDisplayMetrics(),
             bitmapPool,
             arrayPool,
-            experiments.isEnabled(PreserveGainmapAndColorSpaceForTransformations.class));
+            experiments.isEnabled(PreserveGainmapAndColorSpaceForTransformations.class),
+            experiments.isEnabled(EnableHardwareGainmapFixOnU.class));
 
     ResourceDecoder<ByteBuffer, Bitmap> byteBufferBitmapDecoder;
     ResourceDecoder<InputStream, Bitmap> streamBitmapDecoder;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
@@ -1,0 +1,327 @@
+package com.bumptech.glide.load.resource.bitmap;
+
+import android.graphics.Bitmap;
+import android.graphics.Bitmap.Config;
+import android.graphics.BitmapFactory;
+import android.graphics.BitmapFactory.Options;
+import android.graphics.Canvas;
+import android.graphics.ColorMatrixColorFilter;
+import android.graphics.Gainmap;
+import android.graphics.Paint;
+import android.graphics.Rect;
+import android.os.Build.VERSION;
+import android.os.Build.VERSION_CODES;
+import android.util.Log;
+import androidx.annotation.Nullable;
+import androidx.annotation.RequiresApi;
+import com.bumptech.glide.util.GlideSuppliers;
+import com.bumptech.glide.util.GlideSuppliers.GlideSupplier;
+import com.bumptech.glide.util.Preconditions;
+import java.io.FileDescriptor;
+import java.io.InputStream;
+
+/**
+ * Wrapper around {@link BitmapFactory} to work around known issues with {@link BitmapFactory}
+ * across Android SDK levels.
+ *
+ * <p>In particular, this class works around these known issues:
+ *
+ * <ul>
+ *   <li>Ultra HDR image single-channel gainmaps not being decoded on Android U when hardware
+ *       bitmaps are enabled. This issue is further described in
+ *       https://github.com/bumptech/glide/issues/5362.
+ * </ul>
+ *
+ * <p>New usages of {@link BitmapFactory} APIs within Glide should be added here rather than called
+ * directly.
+ */
+final class GlideBitmapFactory {
+
+  private GlideBitmapFactory() {}
+
+  /** Wrapper for {@link BitmapFactory#decodeStream}. */
+  @Nullable
+  public static Bitmap decodeStream(InputStream inputStream, BitmapFactory.Options options) {
+    if (VERSION.SDK_INT == VERSION_CODES.UPSIDE_DOWN_CAKE
+        && GainmapDecoderWorkaroundStateCalculator.needsGainmapDecodeWorkaround(options)) {
+      return safeDecodeHardwareBitmapWithGainmap(inputStream, options);
+    }
+    return BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
+  }
+
+  /** Wrapper for {@link BitmapFactory#decodeByteArray}. */
+  @Nullable
+  public static Bitmap decodeByteArray(byte[] bytes, BitmapFactory.Options options) {
+    if (VERSION.SDK_INT == VERSION_CODES.UPSIDE_DOWN_CAKE
+        && GainmapDecoderWorkaroundStateCalculator.needsGainmapDecodeWorkaround(options)) {
+      return safeDecodeHardwareBitmapWithGainmap(bytes, options);
+    }
+    return BitmapFactory.decodeByteArray(bytes, /* offset= */ 0, bytes.length, options);
+  }
+
+  /** Wrapper for {@link BitmapFactory#decodeFileDescriptor}. */
+  @Nullable
+  public static Bitmap decodeFileDescriptor(
+      FileDescriptor fileDescriptor, BitmapFactory.Options options) {
+    if (VERSION.SDK_INT == VERSION_CODES.UPSIDE_DOWN_CAKE
+        && GainmapDecoderWorkaroundStateCalculator.needsGainmapDecodeWorkaround(options)) {
+      return safeDecodeHardwareBitmapWithGainmap(fileDescriptor, options);
+    }
+    return BitmapFactory.decodeFileDescriptor(fileDescriptor, /* outPadding= */ null, options);
+  }
+
+  /**
+   * Returns a decoded bitmap for the input stream, ensuring that any associated gainmap is decoded
+   * without errors on Android U if it is a valid gainamp.
+   *
+   * <p>This method safely wraps BitmapFactory#decodeStream(InputStream, Rect, Options)} on Android
+   * U.
+   *
+   * @param inputStream for the bitmap to be decoded.
+   * @param options to be applied in the {@link BitmapFactory#decodeStream} call.
+   */
+  @RequiresApi(VERSION_CODES.UPSIDE_DOWN_CAKE)
+  @Nullable
+  private static Bitmap safeDecodeHardwareBitmapWithGainmap(
+      InputStream inputStream, Options options) {
+    Preconditions.checkArgument(options.inPreferredConfig == Config.HARDWARE);
+    Bitmap softwareBitmap = null;
+    options.inPreferredConfig = Config.ARGB_8888;
+    try {
+      softwareBitmap = BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
+      if (softwareBitmap == null) {
+        return null;
+      }
+      return safeDecodeBitmapWithGainmap(softwareBitmap);
+    } finally {
+      if (softwareBitmap != null) {
+        softwareBitmap.recycle();
+      }
+      options.inPreferredConfig = Config.HARDWARE;
+    }
+  }
+
+  /**
+   * Returns a decoded bitmap for the input byte array, ensuring that any associated gainmap is
+   * decoded without errors on Android U if it is a valid gainmap.
+   *
+   * <p>This method safely wraps BitmapFactory#decodeByteArray(byte[], int, int)} on Android U.
+   *
+   * @param bytes for the bitmap to be decoded.
+   * @param options to be applied in the {@link BitmapFactory#decodeByteArray} call. This must be
+   *     set to {@link Config#HARDWARE}.
+   * @throws IllegalArgumentException if {@link Options#inPreferredConfig} is set to any state other
+   *     than {@link Config#HARDWARE}.
+   */
+  @RequiresApi(VERSION_CODES.UPSIDE_DOWN_CAKE)
+  @Nullable
+  private static Bitmap safeDecodeHardwareBitmapWithGainmap(byte[] bytes, Options options) {
+    Preconditions.checkArgument(options.inPreferredConfig == Config.HARDWARE);
+    Bitmap softwareBitmap = null;
+    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+    try {
+      softwareBitmap = BitmapFactory.decodeByteArray(bytes, /* offset= */ 0, bytes.length, options);
+      if (softwareBitmap == null) {
+        return null;
+      }
+      return GlideBitmapFactory.safeDecodeBitmapWithGainmap(softwareBitmap);
+    } finally {
+      if (softwareBitmap != null) {
+        softwareBitmap.recycle();
+      }
+      options.inPreferredConfig = Config.HARDWARE;
+    }
+  }
+
+  /**
+   * Returns a decoded bitmap for the input file descriptor, ensuring that any associated gainmap is
+   * decoded without errors on Android U if it is a valid gainmap.
+   *
+   * <p>This method safely wraps {@link BitmapFactory#decodeFileDescriptor(FileDescriptor, Rect,
+   * Options)} on Android U.
+   *
+   * @param fileDescriptor from which the bitmap will be decoded.
+   * @param options to be applied in the {@link BitmapFactory#decodeFileDescriptor} call. This must
+   *     be set to {@link Config#HARDWARE}.
+   * @throws IllegalArgumentException if {@link Options#inPreferredConfig} is set to any state other
+   *     than {@link Config#HARDWARE}.
+   */
+  @RequiresApi(VERSION_CODES.UPSIDE_DOWN_CAKE)
+  @Nullable
+  private static Bitmap safeDecodeHardwareBitmapWithGainmap(
+      FileDescriptor fileDescriptor, Options options) {
+    Preconditions.checkArgument(options.inPreferredConfig == Config.HARDWARE);
+    Bitmap softwareBitmap = null;
+    options.inPreferredConfig = Bitmap.Config.ARGB_8888;
+    try {
+      softwareBitmap =
+          BitmapFactory.decodeFileDescriptor(fileDescriptor, /* outPadding= */ null, options);
+      if (softwareBitmap == null) {
+        return null;
+      }
+      return GlideBitmapFactory.safeDecodeBitmapWithGainmap(softwareBitmap);
+    } finally {
+      if (softwareBitmap != null) {
+        softwareBitmap.recycle();
+      }
+      options.inPreferredConfig = Config.HARDWARE;
+    }
+  }
+
+  /**
+   * Returns a decoded bitmap for the input software bitmap, ensuring that any associated gainmap is
+   * decoded without errors on Android U if it is a valid gainmap.
+   *
+   * @param softwareBitmap The bitmap to be decoded. Must not be a hardware bitmap.
+   * @throws IllegalArgumentException if {@link Options#inPreferredConfig} is set to any state other
+   *     than {@link Config#HARDWARE}.
+   */
+  @RequiresApi(VERSION_CODES.UPSIDE_DOWN_CAKE)
+  @Nullable
+  private static Bitmap safeDecodeBitmapWithGainmap(Bitmap softwareBitmap) {
+    try {
+      Gainmap gainmap = softwareBitmap.getGainmap();
+      if (gainmap != null) {
+        Bitmap gainmapContents = gainmap.getGainmapContents();
+        if (gainmapContents.getConfig() == Config.ALPHA_8) {
+          softwareBitmap.setGainmap(
+              GainmapCopier.convertSingleChannelGainmapToTripleChannelGainmap(gainmap));
+        }
+      }
+      return softwareBitmap.copy(Config.HARDWARE, /* isMutable= */ false);
+    } finally {
+      softwareBitmap.recycle();
+    }
+  }
+
+  /** Utils to copy gainmaps. */
+  @RequiresApi(VERSION_CODES.UPSIDE_DOWN_CAKE)
+  private static final class GainmapCopier {
+
+    /** Transforms a bitmap so that the output alpha is opaque. */
+    private static final ColorMatrixColorFilter OPAQUE_FILTER =
+        new ColorMatrixColorFilter(
+            new float[] {
+              0f, 0f, 0f, 1f, 0f,
+              0f, 0f, 0f, 1f, 0f,
+              0f, 0f, 0f, 1f, 0f,
+              0f, 0f, 0f, 0f, 255f
+            });
+
+    private GainmapCopier() {}
+
+    /**
+     * Converts single channel gainmap to triple channel, where a single channel gainmap is defined
+     * as a gainmap with a bitmap config of {@link Config#ALPHA_8}.
+     *
+     * <p>If the input gainmap is not single channel or the copy operation fails, then this method
+     * will just return the original gainmap.
+     */
+    public static Gainmap convertSingleChannelGainmapToTripleChannelGainmap(Gainmap gainmap) {
+      Bitmap gainmapContents = gainmap.getGainmapContents();
+      if (gainmapContents.getConfig() != Config.ALPHA_8) {
+        return gainmap;
+      }
+      Bitmap newContents = copyAlpha8ToOpaqueArgb888(gainmapContents);
+      Gainmap newGainmap = new Gainmap(newContents);
+      float[] tempFloatArray = gainmap.getRatioMin();
+      newGainmap.setRatioMin(tempFloatArray[0], tempFloatArray[1], tempFloatArray[2]);
+      tempFloatArray = gainmap.getRatioMax();
+      newGainmap.setRatioMax(tempFloatArray[0], tempFloatArray[1], tempFloatArray[2]);
+      tempFloatArray = gainmap.getGamma();
+      newGainmap.setGamma(tempFloatArray[0], tempFloatArray[1], tempFloatArray[2]);
+      tempFloatArray = gainmap.getEpsilonSdr();
+      newGainmap.setEpsilonSdr(tempFloatArray[0], tempFloatArray[1], tempFloatArray[2]);
+      tempFloatArray = gainmap.getEpsilonHdr();
+      newGainmap.setEpsilonHdr(tempFloatArray[0], tempFloatArray[1], tempFloatArray[2]);
+      newGainmap.setDisplayRatioForFullHdr(gainmap.getDisplayRatioForFullHdr());
+      newGainmap.setMinDisplayRatioForHdrTransition(gainmap.getMinDisplayRatioForHdrTransition());
+      return newGainmap;
+    }
+
+    /**
+     * Converts an {@link Config#ALPHA_8} bitmap to a {@link Config#ARGB_8888} bitmap with the alpha
+     * channel set to unity so that the output bitmap is opaque.
+     *
+     * @throws IllegalArgumentException if called with a bitmap with a config that is not {@link
+     *     Config#ALPHA_8}
+     */
+    private static Bitmap copyAlpha8ToOpaqueArgb888(Bitmap bitmap) {
+      Preconditions.checkArgument(bitmap.getConfig() == Config.ALPHA_8);
+      // We have to use a canvas operation with an opaque alpha filter to draw the gainmap. We can't
+      // use bitmap.copy(Config.ARGB_8888, /* isMutable= */ false) because the output bitmap will
+      // have zero values for alpha.
+      Bitmap newContents =
+          Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Config.ARGB_8888);
+      Canvas canvas = new Canvas(newContents);
+      Paint paint = new Paint();
+      paint.setColorFilter(OPAQUE_FILTER);
+      canvas.drawBitmap(bitmap, /* left= */ 0f, /* top= */ 0f, paint);
+      canvas.setBitmap(null);
+      return newContents;
+    }
+  }
+
+  /**
+   * Determines if a gainmap decoding workaround is required to mitigate an Android U bug with
+   * decoding bitmaps with gainmaps. When the following conditions are present, Android U will not
+   * be able to decode a gainmap, with hardware bitmap operation failing for the gainmap:
+   *
+   * <ul>
+   *   <li>The HWUI is configured to use skiagl.
+   *   <li>The gainmap is single channel.
+   *   <li>The bitmap owning the bitmap is a hardware bitmap.
+   * </ul>
+   *
+   * <p>Callers should use this class to determine whether to apply a workaround, e.g., modifying
+   * the gainmap to be triple channel and software decode it.
+   */
+  public static final class GainmapDecoderWorkaroundStateCalculator {
+    private static final String TAG = "GainmapWorkaroundCalc";
+
+    /** Meomizes result of test to see if the device is susceptible to the gainmap decoding bug. */
+    private static final GlideSupplier<Boolean> REQUIRES_GAIN_MAP_FIX =
+        GlideSuppliers.memorize(() -> calculateNeedsGainmapDecodeWorkaround());
+
+    private GainmapDecoderWorkaroundStateCalculator() {}
+
+    /**
+     * Returns true if a gainmap decoding workaround is required to mitigate an Android U bug. This
+     * method tests for the presence of the bug, which only affects hardware bitmaps, and caches the
+     * result in memory.
+     *
+     * <p>This method is thread-safe.
+     *
+     * @param options which will be used to decode the gainmap.
+     */
+    private static boolean needsGainmapDecodeWorkaround(Options options) {
+      if (VERSION.SDK_INT != VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return false;
+      }
+      if (options.inPreferredConfig != Config.HARDWARE) {
+        return false;
+      }
+      return REQUIRES_GAIN_MAP_FIX.get();
+    }
+
+    private static boolean calculateNeedsGainmapDecodeWorkaround() {
+      if (VERSION.SDK_INT != VERSION_CODES.UPSIDE_DOWN_CAKE) {
+        return false;
+      }
+      // Create a 1x1 single channel, A8 bitmap and attempt to copy to a hardware bitmap. If the
+      // copy operation fails, then the device requires a workaround to decode hardware
+      // gainmaps.
+      Bitmap a8Source = Bitmap.createBitmap(/* width= */ 1, /* height= */ 1, Config.ALPHA_8);
+      Bitmap a8HardwareBitmap = a8Source.copy(Config.HARDWARE, /* isMutable= */ false);
+      a8Source.recycle();
+      boolean needsGainmapDecodeWorkaround = a8HardwareBitmap == null;
+      if (Log.isLoggable(TAG, Log.DEBUG)) {
+        Log.d(TAG, "calculateNeedsGainmapDecodeWorkaround=" + needsGainmapDecodeWorkaround);
+      }
+      if (a8HardwareBitmap != null) {
+        a8HardwareBitmap.recycle();
+      }
+      return needsGainmapDecodeWorkaround;
+    }
+  }
+}

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/ImageReader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/ImageReader.java
@@ -3,10 +3,8 @@ package com.bumptech.glide.load.resource.bitmap;
 import android.graphics.Bitmap;
 import android.graphics.BitmapFactory;
 import android.graphics.BitmapFactory.Options;
-import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
-import androidx.annotation.RequiresApi;
 import com.bumptech.glide.load.ImageHeaderParser;
 import com.bumptech.glide.load.ImageHeaderParser.ImageType;
 import com.bumptech.glide.load.ImageHeaderParserUtils;
@@ -17,6 +15,7 @@ import com.bumptech.glide.load.engine.bitmap_recycle.ArrayPool;
 import com.bumptech.glide.util.ByteBufferUtil;
 import com.bumptech.glide.util.Preconditions;
 import java.io.File;
+import java.io.FileDescriptor;
 import java.io.FileInputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -29,6 +28,7 @@ import java.util.List;
  * type wrapped into a {@link DataRewinder}.
  */
 interface ImageReader {
+
   @Nullable
   Bitmap decodeBitmap(BitmapFactory.Options options) throws IOException;
 
@@ -43,17 +43,25 @@ interface ImageReader {
     private final byte[] bytes;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
+    private final boolean enableHardwareGainmapFixOnU;
 
-    ByteArrayReader(byte[] bytes, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
+    ByteArrayReader(
+        byte[] bytes,
+        List<ImageHeaderParser> parsers,
+        ArrayPool byteArrayPool,
+        boolean enableHardwareGainmapFixOnU) {
       this.bytes = bytes;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
+      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(Options options) {
-      return BitmapFactory.decodeByteArray(bytes, /* offset= */ 0, bytes.length, options);
+      return enableHardwareGainmapFixOnU
+          ? GlideBitmapFactory.decodeByteArray(bytes, options)
+          : BitmapFactory.decodeByteArray(bytes, /* offset= */ 0, bytes.length, options);
     }
 
     @Override
@@ -68,6 +76,7 @@ interface ImageReader {
 
     @Override
     public void stopGrowingBuffers() {}
+
   }
 
   final class FileReader implements ImageReader {
@@ -75,11 +84,17 @@ interface ImageReader {
     private final File file;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
+    private final boolean enableHardwareGainmapFixOnU;
 
-    FileReader(File file, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
+    FileReader(
+        File file,
+        List<ImageHeaderParser> parsers,
+        ArrayPool byteArrayPool,
+        boolean enableHardwareGainmapFixOnU) {
       this.file = file;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
+      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
@@ -88,7 +103,9 @@ interface ImageReader {
       InputStream is = null;
       try {
         is = new RecyclableBufferedInputStream(new FileInputStream(file), byteArrayPool);
-        return BitmapFactory.decodeStream(is, /* outPadding= */ null, options);
+        return enableHardwareGainmapFixOnU
+            ? GlideBitmapFactory.decodeStream(is, options)
+            : BitmapFactory.decodeStream(is, /* outPadding= */ null, options);
       } finally {
         if (is != null) {
           try {
@@ -143,17 +160,26 @@ interface ImageReader {
     private final ByteBuffer buffer;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
+    private final boolean enableHardwareGainmapFixOnU;
 
-    ByteBufferReader(ByteBuffer buffer, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
+    ByteBufferReader(
+        ByteBuffer buffer,
+        List<ImageHeaderParser> parsers,
+        ArrayPool byteArrayPool,
+        boolean enableHardwareGainmapFixOnU) {
       this.buffer = buffer;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
+      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(Options options) {
-      return BitmapFactory.decodeStream(stream(), /* outPadding= */ null, options);
+      InputStream inputStream = stream();
+      return enableHardwareGainmapFixOnU
+          ? GlideBitmapFactory.decodeStream(inputStream, options)
+          : BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
     }
 
     @Override
@@ -179,19 +205,27 @@ interface ImageReader {
     private final InputStreamRewinder dataRewinder;
     private final ArrayPool byteArrayPool;
     private final List<ImageHeaderParser> parsers;
+    private final boolean enableHardwareGainmapFixOnU;
 
     InputStreamImageReader(
-        InputStream is, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
+        InputStream is,
+        List<ImageHeaderParser> parsers,
+        ArrayPool byteArrayPool,
+        boolean enableHardwareGainmapFixOnU) {
       this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
       this.parsers = Preconditions.checkNotNull(parsers);
 
       dataRewinder = new InputStreamRewinder(is, byteArrayPool);
+      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(BitmapFactory.Options options) throws IOException {
-      return BitmapFactory.decodeStream(dataRewinder.rewindAndGet(), null, options);
+      InputStream inputStream = dataRewinder.rewindAndGet();
+      return enableHardwareGainmapFixOnU
+          ? GlideBitmapFactory.decodeStream(inputStream, options)
+          : BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
     }
 
     @Override
@@ -211,27 +245,33 @@ interface ImageReader {
     }
   }
 
-  @RequiresApi(Build.VERSION_CODES.LOLLIPOP)
   final class ParcelFileDescriptorImageReader implements ImageReader {
     private final ArrayPool byteArrayPool;
     private final List<ImageHeaderParser> parsers;
     private final ParcelFileDescriptorRewinder dataRewinder;
+    private final boolean enableHardwareGainmapFixOnU;
 
     ParcelFileDescriptorImageReader(
         ParcelFileDescriptor parcelFileDescriptor,
         List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool) {
+        ArrayPool byteArrayPool,
+        boolean enableHardwareGainmapFixOnU) {
       this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
       this.parsers = Preconditions.checkNotNull(parsers);
 
       dataRewinder = new ParcelFileDescriptorRewinder(parcelFileDescriptor);
+      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(BitmapFactory.Options options) throws IOException {
-      return BitmapFactory.decodeFileDescriptor(
-          dataRewinder.rewindAndGet().getFileDescriptor(), null, options);
+      ParcelFileDescriptor parcelFileDescriptor = dataRewinder.rewindAndGet();
+      FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
+      return enableHardwareGainmapFixOnU
+          ? GlideBitmapFactory.decodeFileDescriptor(fileDescriptor, options)
+          : BitmapFactory.decodeFileDescriptor(
+              parcelFileDescriptor.getFileDescriptor(), /* outPadding= */ null, options);
     }
 
     @Override

--- a/scripts/run_instrumentation_tests.sh
+++ b/scripts/run_instrumentation_tests.sh
@@ -16,5 +16,6 @@ gcloud firebase test android run \
   --device model=Nexus6P,version=23,locale=en,orientation=portrait \
   --device model=Nexus6,version=22,locale=en,orientation=portrait \
   --device model=Nexus5,version=19,locale=en,orientation=portrait \
+  --device model=MediumPhone.arm,version=34,locale=en,orientation=portrait \
   --project android-glide \
   --no-auto-google-login \


### PR DESCRIPTION
…nmaps using BitmapFactory.

Android U devices that use skiagl for hwui renderering (currently the vast majority) have a bug where uplading single channel bitmaps to hardware bitmaps fails. This bug essentially breaks single channel gainmap rendering using hardware bitmaps, which is a common use case on devices that have Ultra HDR as the default capture format.

The workaround is as follows:
1. Detect the presence of the bug by attempting to copy a 1x1 single channel bitmap to hardware.
2. Memoize the result
3. For BitmapFactory.decode* calls, if the input bitmap has a gainmap, copy it to a three-channel gainmap. This step seems wasteful, but in practice, the Android OS already does some copying when creating hardware bitmaps. Also, more importantly, there is an AOSP fix for this bug, and as devices are updated with this fix, this flow will no longer be exercised.