### PR TITLE
Clean up setEnableHardwareGainmapFixOnU flag

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
@@ -444,8 +444,7 @@ public class DownsamplerEmulatorTest {
       int expectedWidth,
       int expectedHeight)
       throws IOException {
-    Downsampler downsampler =
-        hasGainmap ? buildDownsamplerWithGainmapBugFixes() : buildDownsampler();
+    Downsampler downsampler = buildDownsampler();
 
     InputStream is =
         openBitmapStream(format, initialWidth, initialHeight, exifOrientation, hasGainmap);
@@ -551,18 +550,6 @@ public class DownsamplerEmulatorTest {
     BitmapPool bitmapPool = new BitmapPoolAdapter();
     ArrayPool arrayPool = new LruArrayPool();
     return new Downsampler(parsers, displayMetrics, bitmapPool, arrayPool);
-  }
-
-  private static Downsampler buildDownsamplerWithGainmapBugFixes() {
-    List<ImageHeaderParser> parsers =
-        Collections.<ImageHeaderParser>singletonList(new DefaultImageHeaderParser());
-    DisplayMetrics displayMetrics = new DisplayMetrics();
-    // XHDPI.
-    displayMetrics.densityDpi = 320;
-    BitmapPool bitmapPool = new BitmapPoolAdapter();
-    ArrayPool arrayPool = new LruArrayPool();
-    return new Downsampler(
-        parsers, displayMetrics, bitmapPool, arrayPool, /* enableHardwareGainmapFixOnU= */ true);
   }
 
   private static InputStream openBitmapStream(

--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -497,13 +497,11 @@ public final class GlideBuilder {
   }
 
   /**
-   * Fixes decoding of hardware gainmaps from Ultra HDR images on Android U.
-   *
-   * <p>Without this flag on, gainmaps may be dropped when decoding Ultra HDR on Android U devices
-   * using skiagl for hwui as described in https://github.com/bumptech/glide/issues/5362.
+   * @deprecated This method does nothing. It will be hard coded and removed in a future release
+   *     without further warning.
    */
+  @Deprecated
   public GlideBuilder setEnableHardwareGainmapFixOnU(boolean isEnabled) {
-    glideExperimentsBuilder.update(new EnableHardwareGainmapFixOnU(), isEnabled);
     return this;
   }
 
@@ -619,9 +617,6 @@ public final class GlideBuilder {
       this.fdCount = fdCount;
     }
   }
-
-  /** Fixes decoding of hardware gainmaps from Ultra HDR images on Android U. */
-  static final class EnableHardwareGainmapFixOnU implements Experiment {}
 
   static final class EnableImageDecoderForBitmaps implements Experiment {}
 

--- a/library/src/main/java/com/bumptech/glide/RegistryFactory.java
+++ b/library/src/main/java/com/bumptech/glide/RegistryFactory.java
@@ -12,7 +12,6 @@ import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
 import androidx.tracing.Trace;
-import com.bumptech.glide.GlideBuilder.EnableHardwareGainmapFixOnU;
 import com.bumptech.glide.GlideBuilder.EnableImageDecoderForBitmaps;
 import com.bumptech.glide.gifdecoder.GifDecoder;
 import com.bumptech.glide.load.ImageHeaderParser;
@@ -159,8 +158,7 @@ final class RegistryFactory {
             registry.getImageHeaderParsers(),
             resources.getDisplayMetrics(),
             bitmapPool,
-            arrayPool,
-            experiments.isEnabled(EnableHardwareGainmapFixOnU.class));
+            arrayPool);
 
     ResourceDecoder<ByteBuffer, Bitmap> byteBufferBitmapDecoder;
     ResourceDecoder<InputStream, Bitmap> streamBitmapDecoder;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -141,35 +141,16 @@ public final class Downsampler {
   private final ArrayPool byteArrayPool;
   private final List<ImageHeaderParser> parsers;
   private final HardwareConfigState hardwareConfigState = HardwareConfigState.getInstance();
-  private final boolean enableHardwareGainmapFixOnU;
 
   public Downsampler(
       List<ImageHeaderParser> parsers,
       DisplayMetrics displayMetrics,
       BitmapPool bitmapPool,
       ArrayPool byteArrayPool) {
-    this(
-        parsers,
-        displayMetrics,
-        bitmapPool,
-        byteArrayPool,
-        /* enableHardwareGainmapFixOnU= */ false);
-  }
-
-  /**
-   * @param enableHardwareGainmapFixOnU Fixes issues with hardware gainmaps on U.
-   */
-  public Downsampler(
-      List<ImageHeaderParser> parsers,
-      DisplayMetrics displayMetrics,
-      BitmapPool bitmapPool,
-      ArrayPool byteArrayPool,
-      boolean enableHardwareGainmapFixOnU) {
     this.parsers = parsers;
     this.displayMetrics = Preconditions.checkNotNull(displayMetrics);
     this.bitmapPool = Preconditions.checkNotNull(bitmapPool);
     this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
-    this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
   }
 
   public boolean handles(@SuppressWarnings("unused") InputStream is) {
@@ -206,8 +187,7 @@ public final class Downsampler {
       ByteBuffer buffer, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     return decode(
-        new ImageReader.ByteBufferReader(
-            buffer, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
+        new ImageReader.ByteBufferReader(buffer, parsers, byteArrayPool),
         requestedWidth,
         requestedHeight,
         options,
@@ -242,8 +222,7 @@ public final class Downsampler {
       DecodeCallbacks callbacks)
       throws IOException {
     return decode(
-        new ImageReader.InputStreamImageReader(
-            is, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
+        new ImageReader.InputStreamImageReader(is, parsers, byteArrayPool),
         requestedWidth,
         requestedHeight,
         options,
@@ -254,7 +233,7 @@ public final class Downsampler {
   void decode(byte[] bytes, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     decode(
-        new ImageReader.ByteArrayReader(bytes, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
+        new ImageReader.ByteArrayReader(bytes, parsers, byteArrayPool),
         requestedWidth,
         requestedHeight,
         options,
@@ -265,7 +244,7 @@ public final class Downsampler {
   void decode(File file, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     decode(
-        new ImageReader.FileReader(file, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
+        new ImageReader.FileReader(file, parsers, byteArrayPool),
         requestedWidth,
         requestedHeight,
         options,
@@ -278,7 +257,7 @@ public final class Downsampler {
       throws IOException {
     return decode(
         new ImageReader.ParcelFileDescriptorImageReader(
-            parcelFileDescriptor, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
+            parcelFileDescriptor, parsers, byteArrayPool),
         outWidth,
         outHeight,
         options,

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
@@ -249,8 +249,8 @@ final class GlideBitmapFactory {
     private static Bitmap copyAlpha8ToOpaqueArgb888(Bitmap bitmap) {
       Preconditions.checkArgument(bitmap.getConfig() == Config.ALPHA_8);
       // We have to use a canvas operation with an opaque alpha filter to draw the gainmap. We can't
-      // use bitmap.copy(Config.ARGB_8888, /* isMutable= */ false) because the output bitmap will
-      // have zero values for alpha.
+      // use bitmap.copy(Config.ARGB_8888, /* isMutable= */ false) because copying from A8 to RBGA
+      // will result in zero-valued RGB values.
       Bitmap newContents =
           Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Config.ARGB_8888);
       Canvas canvas = new Canvas(newContents);

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/ImageReader.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/ImageReader.java
@@ -43,25 +43,17 @@ interface ImageReader {
     private final byte[] bytes;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
-    private final boolean enableHardwareGainmapFixOnU;
 
-    ByteArrayReader(
-        byte[] bytes,
-        List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool,
-        boolean enableHardwareGainmapFixOnU) {
+    ByteArrayReader(byte[] bytes, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
       this.bytes = bytes;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
-      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(Options options) {
-      return enableHardwareGainmapFixOnU
-          ? GlideBitmapFactory.decodeByteArray(bytes, options)
-          : BitmapFactory.decodeByteArray(bytes, /* offset= */ 0, bytes.length, options);
+      return GlideBitmapFactory.decodeByteArray(bytes, options);
     }
 
     @Override
@@ -76,7 +68,6 @@ interface ImageReader {
 
     @Override
     public void stopGrowingBuffers() {}
-
   }
 
   final class FileReader implements ImageReader {
@@ -84,17 +75,11 @@ interface ImageReader {
     private final File file;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
-    private final boolean enableHardwareGainmapFixOnU;
 
-    FileReader(
-        File file,
-        List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool,
-        boolean enableHardwareGainmapFixOnU) {
+    FileReader(File file, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
       this.file = file;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
-      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
@@ -103,9 +88,7 @@ interface ImageReader {
       InputStream is = null;
       try {
         is = new RecyclableBufferedInputStream(new FileInputStream(file), byteArrayPool);
-        return enableHardwareGainmapFixOnU
-            ? GlideBitmapFactory.decodeStream(is, options)
-            : BitmapFactory.decodeStream(is, /* outPadding= */ null, options);
+        return GlideBitmapFactory.decodeStream(is, options);
       } finally {
         if (is != null) {
           try {
@@ -160,26 +143,18 @@ interface ImageReader {
     private final ByteBuffer buffer;
     private final List<ImageHeaderParser> parsers;
     private final ArrayPool byteArrayPool;
-    private final boolean enableHardwareGainmapFixOnU;
 
-    ByteBufferReader(
-        ByteBuffer buffer,
-        List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool,
-        boolean enableHardwareGainmapFixOnU) {
+    ByteBufferReader(ByteBuffer buffer, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
       this.buffer = buffer;
       this.parsers = parsers;
       this.byteArrayPool = byteArrayPool;
-      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(Options options) {
       InputStream inputStream = stream();
-      return enableHardwareGainmapFixOnU
-          ? GlideBitmapFactory.decodeStream(inputStream, options)
-          : BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
+      return GlideBitmapFactory.decodeStream(inputStream, options);
     }
 
     @Override
@@ -205,27 +180,20 @@ interface ImageReader {
     private final InputStreamRewinder dataRewinder;
     private final ArrayPool byteArrayPool;
     private final List<ImageHeaderParser> parsers;
-    private final boolean enableHardwareGainmapFixOnU;
 
     InputStreamImageReader(
-        InputStream is,
-        List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool,
-        boolean enableHardwareGainmapFixOnU) {
+        InputStream is, List<ImageHeaderParser> parsers, ArrayPool byteArrayPool) {
       this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
       this.parsers = Preconditions.checkNotNull(parsers);
 
       dataRewinder = new InputStreamRewinder(is, byteArrayPool);
-      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
     @Override
     public Bitmap decodeBitmap(BitmapFactory.Options options) throws IOException {
       InputStream inputStream = dataRewinder.rewindAndGet();
-      return enableHardwareGainmapFixOnU
-          ? GlideBitmapFactory.decodeStream(inputStream, options)
-          : BitmapFactory.decodeStream(inputStream, /* outPadding= */ null, options);
+      return GlideBitmapFactory.decodeStream(inputStream, options);
     }
 
     @Override
@@ -249,18 +217,15 @@ interface ImageReader {
     private final ArrayPool byteArrayPool;
     private final List<ImageHeaderParser> parsers;
     private final ParcelFileDescriptorRewinder dataRewinder;
-    private final boolean enableHardwareGainmapFixOnU;
 
     ParcelFileDescriptorImageReader(
         ParcelFileDescriptor parcelFileDescriptor,
         List<ImageHeaderParser> parsers,
-        ArrayPool byteArrayPool,
-        boolean enableHardwareGainmapFixOnU) {
+        ArrayPool byteArrayPool) {
       this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
       this.parsers = Preconditions.checkNotNull(parsers);
 
       dataRewinder = new ParcelFileDescriptorRewinder(parcelFileDescriptor);
-      this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
     }
 
     @Nullable
@@ -268,10 +233,7 @@ interface ImageReader {
     public Bitmap decodeBitmap(BitmapFactory.Options options) throws IOException {
       ParcelFileDescriptor parcelFileDescriptor = dataRewinder.rewindAndGet();
       FileDescriptor fileDescriptor = parcelFileDescriptor.getFileDescriptor();
-      return enableHardwareGainmapFixOnU
-          ? GlideBitmapFactory.decodeFileDescriptor(fileDescriptor, options)
-          : BitmapFactory.decodeFileDescriptor(
-              parcelFileDescriptor.getFileDescriptor(), /* outPadding= */ null, options);
+      return GlideBitmapFactory.decodeFileDescriptor(fileDescriptor, options);
     }
 
     @Override


### PR DESCRIPTION
## Description
Clean up the setEnableHardwareGainmapFixOnU flag, baking in the changes.
Also fix a related comment about why we can't use bitmap.copy for A8 -> RGBA copies.

## Motivation and Context
Allows the fix for https://github.com/bumptech/glide/issues/5362 to be available to all Glide clients without needing to enable the flag.