### PR TITLE
Avoid referencing resource names within Resource Loader

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/model/ResourceLoader.java
+++ b/library/src/main/java/com/bumptech/glide/load/model/ResourceLoader.java
@@ -52,9 +52,7 @@ public class ResourceLoader<Data> implements ModelLoader<Integer, Data> {
               + "://"
               + resources.getResourcePackageName(model)
               + '/'
-              + resources.getResourceTypeName(model)
-              + '/'
-              + resources.getResourceEntryName(model));
+              + model);
     } catch (Resources.NotFoundException e) {
       if (Log.isLoggable(TAG, Log.WARN)) {
         Log.w(TAG, "Received invalid resource id: " + model, e);

--- a/library/test/src/test/java/com/bumptech/glide/load/model/ResourceLoaderTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/model/ResourceLoaderTest.java
@@ -49,7 +49,7 @@ public class ResourceLoaderTest {
   @Test
   public void testCanHandleId() {
     int id = android.R.drawable.star_off;
-    Uri contentUri = Uri.parse("android.resource://android/drawable/star_off");
+    Uri contentUri = Uri.parse("android.resource://android/" + String.valueOf(id));
     when(uriLoader.buildLoadData(eq(contentUri), anyInt(), anyInt(), any(Options.class)))
         .thenReturn(new ModelLoader.LoadData<>(key, fetcher));
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
We are working on enabling the collapse names optimization of `aapt2` that removes the resource names from the Resource Table as an app size optimization. However, once enabled, we ran into issues loading resources.

One requirement of removing resource names from the Resource Table is ensuring that resources are not referenced by resource name when loaded. If they are referenced by resource name, they must be explicitly kept with keep rules. ([ref](https://developer.android.com/build/shrink-code#keep-resources)).



## Motivation and Context

ResourceLoader is using the `android.resource://<package_name>/<resource_type>/<resource_name>` content URI to resolve Drawable resources, which is incompatible with collapse names optimization.

Fortunately, the ContentResolver for resources has another URI scheme that enables loading resources without referencing the name: `android.resource://<package_name>/<resource_id>`, which can be used instead ([ref](https://developer.android.com/reference/android/content/ContentResolver#the-android.resource-scheme_android_resource-scheme)).

## Test Plan
Pre-merge passes (TODO: still building locally and verifying)