### PR TITLE
Compose Bugfix: When requestBuilder not changed, GlideImage reset to display nothing or loadingPainter

### DIFF
--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideImage.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideImage.kt
@@ -235,15 +235,15 @@ public fun GlideSubcomposition(
     }
 
   val requestState: MutableState<RequestState> =
-    remember(model, requestManager, requestBuilderTransform) {
+    remember(requestBuilder) {
       mutableStateOf(RequestState.Loading)
     }
-  val painter: MutableState<Painter?> = remember(model, requestManager, requestBuilderTransform) {
+  val painter: MutableState<Painter?> = remember(requestBuilder) {
     mutableStateOf(null)
   }
 
   val requestListener: StateTrackingListener =
-    remember(model, requestManager, requestBuilderTransform) {
+    remember(requestBuilder) {
       StateTrackingListener(
         requestState,
         painter


### PR DESCRIPTION
Compose Bugfix: If requestBuilder has not changed, the requestState, painter(State) and requestListener should not change either. Otherwise, the GlideImage will display nothing or loadingPainter. Since requestState will be reset to RequestState.Loading and GlideNode.launchRequest will not run due to requestBuilder not changed.

This may happen when the request model has not changed but the requestBuilderTransform has changed, and the change of requestBuilderTransform has not been detected in RequestBuilder.equals(). So requestBuilder is considered to have no change.

e.g:
```kotlin
    val transform1: RequestBuilderTransform<Drawable> = {
        val unused = "transform1"
        it
    }

    val transform2: RequestBuilderTransform<Drawable> = {
        val unused = "transform2"
        it
    }

    val switch = Random.nextBoolean()

    GlideImage(
        model = url,
        contentDescription = url,
        loading = placeholder(loadingPainter),
        modifier = modifier
            .fillMaxWidth()
            .aspectRatio(1f),
        requestBuilderTransform = if (switch) transform1 else transform2
    )
```
