### PR TITLE
Fix java.lang.IllegalStateException Had two simultaneous

### DIFF
--- a/third_party/disklrucache/src/main/java/com/bumptech/glide/disklrucache/DiskLruCache.java
+++ b/third_party/disklrucache/src/main/java/com/bumptech/glide/disklrucache/DiskLruCache.java
@@ -846,7 +846,9 @@ public final class DiskLruCache implements Closeable {
       if (!committed) {
         try {
           abort();
-        } catch (IOException ignored) {
+        } catch (IOException exception) {
+            lruEntries.remove(entry.key);
+            entry.currentEditor = null;
         }
       }
     }


### PR DESCRIPTION
Fix java.lang.IllegalStateException Had two simultaneous when abort exception.
For example, when the phone storage is insufficient, and the dirty file fails to write, an exception occurs when deleting.
![image](https://github.com/bumptech/glide/assets/8597839/d3819db0-26a1-4d66-a329-2ff29e04140e)
