### PR TITLE
Update incorrect import in migration guide

### DIFF
--- a/_posts/2017-04-17-generatedapi.md
+++ b/_posts/2017-04-17-generatedapi.md
@@ -18,7 +18,7 @@ Specifically:
 1. You should not add new [`Extensions`][6] as described on this page
 2. You should not use generated classes. Use the equivalent non-generated classes instead:
 
-    *  Instead of `GlideApp`, use `com.bumptech.Glide`
+    *  Instead of `GlideApp`, use `com.bumptech.glide.Glide`
     *  Instead of `GlideRequests`, use `com.bumptech.glide.RequestManager`
     *  Instead of `GlideRequest`, use `com.bumptech.glide.RequestBuilder`
     *  Instead of `GlideOptions`, use `com.bumptech.glide.request.RequestOptions`


### PR DESCRIPTION
## Description
The import for the new API was incorrect there : https://bumptech.github.io/glide/doc/generatedapi.html