### PR TITLE
Fix ResourceID validation check expression

### DIFF
--- a/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
+++ b/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java
@@ -1364,8 +1364,18 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
   }
 
   @SuppressWarnings("WeakerAccess")
+  public final boolean hasErrorId() {
+    return isSet(ERROR_ID);
+  }
+
+  @SuppressWarnings("WeakerAccess")
   public final int getPlaceholderId() {
     return placeholderId;
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public final boolean hasPlaceholderId() {
+    return isSet(PLACEHOLDER_ID);
   }
 
   @SuppressWarnings("WeakerAccess")
@@ -1377,6 +1387,11 @@ public abstract class BaseRequestOptions<T extends BaseRequestOptions<T>> implem
   @SuppressWarnings("WeakerAccess")
   public final int getFallbackId() {
     return fallbackId;
+  }
+
+  @SuppressWarnings("WeakerAccess")
+  public final boolean hasFallbackId() {
+    return isSet(FALLBACK_ID);
   }
 
   @SuppressWarnings("WeakerAccess")

--- a/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
+++ b/library/src/main/java/com/bumptech/glide/request/SingleRequest.java
@@ -387,7 +387,7 @@ public final class SingleRequest<R> implements Request, SizeReadyCallback, Resou
   private Drawable getErrorDrawable() {
     if (errorDrawable == null) {
       errorDrawable = requestOptions.getErrorPlaceholder();
-      if (errorDrawable == null && requestOptions.getErrorId() > 0) {
+      if (errorDrawable == null && requestOptions.hasErrorId()) {
         errorDrawable = loadDrawable(requestOptions.getErrorId());
       }
     }
@@ -398,7 +398,7 @@ public final class SingleRequest<R> implements Request, SizeReadyCallback, Resou
   private Drawable getPlaceholderDrawable() {
     if (placeholderDrawable == null) {
       placeholderDrawable = requestOptions.getPlaceholderDrawable();
-      if (placeholderDrawable == null && requestOptions.getPlaceholderId() > 0) {
+      if (placeholderDrawable == null && requestOptions.hasPlaceholderId()) {
         placeholderDrawable = loadDrawable(requestOptions.getPlaceholderId());
       }
     }
@@ -409,7 +409,7 @@ public final class SingleRequest<R> implements Request, SizeReadyCallback, Resou
   private Drawable getFallbackDrawable() {
     if (fallbackDrawable == null) {
       fallbackDrawable = requestOptions.getFallbackDrawable();
-      if (fallbackDrawable == null && requestOptions.getFallbackId() > 0) {
+      if (fallbackDrawable == null && requestOptions.hasFallbackId()) {
         fallbackDrawable = loadDrawable(requestOptions.getFallbackId());
       }
     }


### PR DESCRIPTION
## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
related issue : #5404
 I changed three methods which have wrong expression
- getFallbackDrawable()
- getErrorDrawable()
- getPlaceholderDrawable()
Resource IDs can be negative, but the functions were treating such IDs as invalid. Therefore, I improved the if statement logic to allow valid resource IDs that have negative values to pass through.

## Motivation and Context
According to the [referenced documentation](https://android.googlesource.com/platform/frameworks/base/+/HEAD/core/java/android/content/res/ResourceId.java), resource IDs can be negative, and while some legacy code assumes -1 to be an invalid resource ID, this is incorrect. The issue #5404 involves a method malfunctioning when using an image with a specific negative value as its resource ID, which was identified as a validation issue related to resourceID. The original code incorrectly assumed any negative value to be an invalid resource ID. However, I have refactored it using the correct validation logic as outlined in the android.content.res package.