### PR TITLE
GifDrawable: Call stop before notifying end to listeners

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/gif/GifDrawable.java
@@ -345,8 +345,8 @@ public class GifDrawable extends Drawable
     }
 
     if (maxLoopCount != LOOP_FOREVER && loopCount >= maxLoopCount) {
-      notifyAnimationEndToListeners();
       stop();
+      notifyAnimationEndToListeners();
     }
   }
 


### PR DESCRIPTION
In the current code, `GifDrawable` calls the `onAnimationEnd` callback first and then invokes `stop()` to end the animation.

This behavior prevents the following use-case: An app wants to schedule another loop of the `GifDrawable` when the current loop ends (i.e.) calls `start()` from within the
`onAnimationEnd()` callback. This doesn't work because `stop()` is called right after the onAnimationEnd() callback is complete.

Reversing the order of these two calls to enable this use-case.