### PR TITLE
Fix logging time in JournaledLruDiskCache.java

### DIFF
--- a/integration/sqljournaldiskcache/src/main/java/com/bumptech/glide/integration/sqljournaldiskcache/JournaledLruDiskCache.java
+++ b/integration/sqljournaldiskcache/src/main/java/com/bumptech/glide/integration/sqljournaldiskcache/JournaledLruDiskCache.java
@@ -3,7 +3,6 @@ package com.bumptech.glide.integration.sqljournaldiskcache;
 import android.os.HandlerThread;
 import android.os.Looper;
 import android.os.Process;
-import android.os.SystemClock;
 import android.util.Log;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
@@ -461,7 +460,7 @@ final class JournaledLruDiskCache {
   }
 
   private static long getLogTime() {
-    return SystemClock.currentThreadTimeMillis();
+    return System.currentTimeMillis();
   }
 
   private static long getElapsedTime(long startTime) {


### PR DESCRIPTION
currentThreadTimeMillis() returns how long the current thread has been executing, not the current time.

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->