### PR TITLE
Reverts Clean up preserveGainmapAndColorSpaceForTransformations flag #5386

### DIFF
--- a/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
+++ b/instrumentation/src/androidTest/java/com/bumptech/glide/load/resource/bitmap/DownsamplerEmulatorTest.java
@@ -444,7 +444,8 @@ public class DownsamplerEmulatorTest {
       int expectedWidth,
       int expectedHeight)
       throws IOException {
-    Downsampler downsampler = buildDownsampler();
+    Downsampler downsampler =
+        hasGainmap ? buildDownsamplerWithGainmapBugFixes() : buildDownsampler();
 
     InputStream is =
         openBitmapStream(format, initialWidth, initialHeight, exifOrientation, hasGainmap);
@@ -550,6 +551,18 @@ public class DownsamplerEmulatorTest {
     BitmapPool bitmapPool = new BitmapPoolAdapter();
     ArrayPool arrayPool = new LruArrayPool();
     return new Downsampler(parsers, displayMetrics, bitmapPool, arrayPool);
+  }
+
+  private static Downsampler buildDownsamplerWithGainmapBugFixes() {
+    List<ImageHeaderParser> parsers =
+        Collections.<ImageHeaderParser>singletonList(new DefaultImageHeaderParser());
+    DisplayMetrics displayMetrics = new DisplayMetrics();
+    // XHDPI.
+    displayMetrics.densityDpi = 320;
+    BitmapPool bitmapPool = new BitmapPoolAdapter();
+    ArrayPool arrayPool = new LruArrayPool();
+    return new Downsampler(
+        parsers, displayMetrics, bitmapPool, arrayPool, /* enableHardwareGainmapFixOnU= */ true);
   }
 
   private static InputStream openBitmapStream(

--- a/library/src/main/java/com/bumptech/glide/GlideBuilder.java
+++ b/library/src/main/java/com/bumptech/glide/GlideBuilder.java
@@ -497,11 +497,13 @@ public final class GlideBuilder {
   }
 
   /**
-   * @deprecated This method does nothing. It will be hard coded and removed in a future release
-   *     without further warning.
+   * Fixes decoding of hardware gainmaps from Ultra HDR images on Android U.
+   *
+   * <p>Without this flag on, gainmaps may be dropped when decoding Ultra HDR on Android U devices
+   * using skiagl for hwui as described in https://github.com/bumptech/glide/issues/5362.
    */
-  @Deprecated
   public GlideBuilder setEnableHardwareGainmapFixOnU(boolean isEnabled) {
+    glideExperimentsBuilder.update(new EnableHardwareGainmapFixOnU(), isEnabled);
     return this;
   }
 
@@ -617,6 +619,9 @@ public final class GlideBuilder {
       this.fdCount = fdCount;
     }
   }
+
+  /** Fixes decoding of hardware gainmaps from Ultra HDR images on Android U. */
+  static final class EnableHardwareGainmapFixOnU implements Experiment {}
 
   static final class EnableImageDecoderForBitmaps implements Experiment {}
 

--- a/library/src/main/java/com/bumptech/glide/RegistryFactory.java
+++ b/library/src/main/java/com/bumptech/glide/RegistryFactory.java
@@ -12,6 +12,7 @@ import android.os.Build;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.Nullable;
 import androidx.tracing.Trace;
+import com.bumptech.glide.GlideBuilder.EnableHardwareGainmapFixOnU;
 import com.bumptech.glide.GlideBuilder.EnableImageDecoderForBitmaps;
 import com.bumptech.glide.gifdecoder.GifDecoder;
 import com.bumptech.glide.load.ImageHeaderParser;
@@ -158,7 +159,8 @@ final class RegistryFactory {
             registry.getImageHeaderParsers(),
             resources.getDisplayMetrics(),
             bitmapPool,
-            arrayPool);
+            arrayPool,
+            experiments.isEnabled(EnableHardwareGainmapFixOnU.class));
 
     ResourceDecoder<ByteBuffer, Bitmap> byteBufferBitmapDecoder;
     ResourceDecoder<InputStream, Bitmap> streamBitmapDecoder;

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/Downsampler.java
@@ -141,16 +141,35 @@ public final class Downsampler {
   private final ArrayPool byteArrayPool;
   private final List<ImageHeaderParser> parsers;
   private final HardwareConfigState hardwareConfigState = HardwareConfigState.getInstance();
+  private final boolean enableHardwareGainmapFixOnU;
 
   public Downsampler(
       List<ImageHeaderParser> parsers,
       DisplayMetrics displayMetrics,
       BitmapPool bitmapPool,
       ArrayPool byteArrayPool) {
+    this(
+        parsers,
+        displayMetrics,
+        bitmapPool,
+        byteArrayPool,
+        /* enableHardwareGainmapFixOnU= */ false);
+  }
+
+  /**
+   * @param enableHardwareGainmapFixOnU Fixes issues with hardware gainmaps on U.
+   */
+  public Downsampler(
+      List<ImageHeaderParser> parsers,
+      DisplayMetrics displayMetrics,
+      BitmapPool bitmapPool,
+      ArrayPool byteArrayPool,
+      boolean enableHardwareGainmapFixOnU) {
     this.parsers = parsers;
     this.displayMetrics = Preconditions.checkNotNull(displayMetrics);
     this.bitmapPool = Preconditions.checkNotNull(bitmapPool);
     this.byteArrayPool = Preconditions.checkNotNull(byteArrayPool);
+    this.enableHardwareGainmapFixOnU = enableHardwareGainmapFixOnU;
   }
 
   public boolean handles(@SuppressWarnings("unused") InputStream is) {
@@ -187,7 +206,8 @@ public final class Downsampler {
       ByteBuffer buffer, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     return decode(
-        new ImageReader.ByteBufferReader(buffer, parsers, byteArrayPool),
+        new ImageReader.ByteBufferReader(
+            buffer, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
         requestedWidth,
         requestedHeight,
         options,
@@ -222,7 +242,8 @@ public final class Downsampler {
       DecodeCallbacks callbacks)
       throws IOException {
     return decode(
-        new ImageReader.InputStreamImageReader(is, parsers, byteArrayPool),
+        new ImageReader.InputStreamImageReader(
+            is, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
         requestedWidth,
         requestedHeight,
         options,
@@ -233,7 +254,7 @@ public final class Downsampler {
   void decode(byte[] bytes, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     decode(
-        new ImageReader.ByteArrayReader(bytes, parsers, byteArrayPool),
+        new ImageReader.ByteArrayReader(bytes, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
         requestedWidth,
         requestedHeight,
         options,
@@ -244,7 +265,7 @@ public final class Downsampler {
   void decode(File file, int requestedWidth, int requestedHeight, Options options)
       throws IOException {
     decode(
-        new ImageReader.FileReader(file, parsers, byteArrayPool),
+        new ImageReader.FileReader(file, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
         requestedWidth,
         requestedHeight,
         options,
@@ -257,7 +278,7 @@ public final class Downsampler {
       throws IOException {
     return decode(
         new ImageReader.ParcelFileDescriptorImageReader(
-            parcelFileDescriptor, parsers, byteArrayPool),
+            parcelFileDescriptor, parsers, byteArrayPool, enableHardwareGainmapFixOnU),
         outWidth,
         outHeight,
         options,

--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/GlideBitmapFactory.java
@@ -249,8 +249,8 @@ final class GlideBitmapFactory {
     private static Bitmap copyAlpha8ToOpaqueArgb888(Bitmap bitmap) {
       Preconditions.checkArgument(bitmap.getConfig() == Config.ALPHA_8);
       // We have to use a canvas operation with an opaque alpha filter to draw the gainmap. We can't
-      // use bitmap.copy(Config.ARGB_8888, /* isMutable= */ false) because copying from A8 to RBGA
-      // will result in zero-valued RGB values.
+      // use bitmap.copy(Config.ARGB_8888, /* isMutable= */ false) because the output bitmap will
+      // have zero values for alpha.
       Bitmap newContents =
           Bitmap.createBitmap(bitmap.getWidth(), bitmap.getHeight(), Config.ARGB_8888);
       Canvas canvas = new Canvas(newContents);


### PR DESCRIPTION
## Description
Reverts Clean up setEnableHardwareGainmapFixOnU flag #5386

## Motivation and Context
The flow executed when setEnableHardwareGainmapFixOnU is set to true excessively uses software bitmaps, and without pooling, significantly increasing memory usage in apps.

A future PR will attempt fix the memory issues, but at least the setEnableHardwareGainmapFixOnU flow will now become opt-in.