### PR TITLE
Fix NaN exception when rounding dimensions

### DIFF
--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
@@ -579,8 +579,12 @@ internal class GlideNode : DrawModifierNode, LayoutModifierNode, SemanticsModifi
     }
     val scaledSize = srcSize * scaleFactor
 
-    val minWidth = constraints.constrainWidth(scaledSize.width.roundToInt())
-    val minHeight = constraints.constrainHeight(scaledSize.height.roundToInt())
+    val minWidth = constraints.constrainWidth(
+      if (scaledSize.width.isFinite()) scaledSize.width.roundToInt() else constraints.minWidth
+    )
+    val minHeight = constraints.constrainHeight(
+      if (scaledSize.height.isFinite()) scaledSize.height.roundToInt() else constraints.minHeight
+    )
     return constraints.copy(minWidth = minWidth, minHeight = minHeight)
   }
 


### PR DESCRIPTION
<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Fixes this issue: https://github.com/bumptech/glide/issues/5356

This change:
1. Checks if the scaled width/height values are finite (not NaN or infinite) using isFinite()
2. If the value is finite, rounds it to an integer as before
3. If the value is not finite (NaN or infinite), falls back to using the constraints' minimum dimensions
This prevents any potential IllegalArgumentException that could be thrown when trying to round NaN or infinite values, making the code more robust.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->