### PR TITLE
Fix `OfResourceId` to allow all Drawable types.

### DIFF
--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideImage.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideImage.kt
@@ -19,7 +19,6 @@ import androidx.compose.ui.layout.ContentScale
 import androidx.compose.ui.layout.Layout
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.platform.LocalInspectionMode
-import androidx.compose.ui.res.painterResource
 import com.bumptech.glide.Glide
 import com.bumptech.glide.RequestBuilder
 import com.bumptech.glide.RequestManager
@@ -379,7 +378,7 @@ public sealed class Placeholder {
     @Composable
     override fun painter(): Painter {
       if (!this::_painter.isInitialized) {
-        _painter = painterResource(resourceId)
+        _painter = LocalContext.current.getDrawable(resourceId).toPainter()
       }
       return _painter
     }


### PR DESCRIPTION
The fine print in `androidx.compose.ui.res.painterResource` says that it only works for certain kinds of Drawables (Vector and Bitmap), which isn't reflected in GlideImage.

There's a potential small performance penalty for vector images (`painterResource` has a hacky fast-path for that), but such is the cost of working for all Drawables.

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->

<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->