### PR TITLE
Fall back to "loading" placeholder when all else fails.

### DIFF
--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageErrorTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageErrorTest.kt
@@ -51,6 +51,23 @@ class GlideImageErrorTest {
   }
 
   @Test
+  fun loadingParameter_withError_isUsedWhenAllElseFails() {
+    val description = "test"
+    val resourceId = android.R.drawable.star_big_off
+    glideComposeRule.setContent {
+      GlideImage(
+        model = null,
+        contentDescription = description,
+        loading = placeholder(resourceId),
+      )
+    }
+
+    glideComposeRule
+      .onNodeWithContentDescription(description)
+      .assert(expectDisplayedPainter(context, resourceId))
+  }
+
+  @Test
   fun failureParameter_withErrorResourceId_displaysError() {
     val description = "test"
     val failureResourceId = android.R.drawable.star_big_off
@@ -58,6 +75,7 @@ class GlideImageErrorTest {
       GlideImage(
         model = null,
         contentDescription = description,
+        loading = placeholder(android.R.drawable.star_on), // arbitary; shouldn't be displayed.
         failure = placeholder(failureResourceId),
       )
     }

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
@@ -434,7 +434,7 @@ internal class GlideNode : DrawModifierNode, LayoutModifierNode, SemanticsModifi
                 // Prefer the override Painters if set.
                 val painter = when (state) {
                   is RequestState.Loading -> loadingPlaceholder
-                  is RequestState.Failure -> errorPlaceholder
+                  is RequestState.Failure -> errorPlaceholder ?: loadingPlaceholder
                   is RequestState.Success -> throw IllegalStateException()
                 }
                 val primary = if (painter != null) {


### PR DESCRIPTION
Fixes regression from https://github.com/bumptech/glide/pull/5306

Similar to how regular [Glide requests
work](https://github.com/bumptech/glide/blob/c9cc739ce84b204defb1933e5f5f47d7c4a530b7/library/src/main/java/com/bumptech/glide/request/BaseRequestOptions.java#L304-L305), the "loading" placeholder is expected to be used if there's a null model and null "error" placeholder.

GlideImage.kt used to mention this: "The resource and `Drawable` variants will be displayed if the request fails and no other failure handling is specified".  Presumably, this verbiage was removed because Composeable placeholders were being broken, and for no other reason.
