### PR TITLE
Avoid NaN when Constraints are zero (but non-fixed size).

### DIFF
--- a/integration/compose/build.gradle
+++ b/integration/compose/build.gradle
@@ -36,6 +36,12 @@ android {
     kotlinOptions {
         jvmTarget = '1.8'
     }
+
+    testOptions {
+      unitTests {
+        includeAndroidResources = true
+      }
+    }
 }
 
 // Enable strict mode, but exclude tests.
@@ -55,6 +61,12 @@ dependencies {
     implementation libs.compose.ui
     implementation libs.androidx.core.ktx
     debugImplementation libs.compose.ui.testmanifest
+    testImplementation libs.compose.ui.testmanifest
+    testImplementation libs.compose.ui.testjunit4
+    testImplementation libs.junit
+    testImplementation libs.robolectric
+    testImplementation libs.androidx.junit
+    testImplementation libs.androidx.test.runner
     androidTestImplementation libs.junit
     androidTestImplementation libs.compose.ui.testjunit4
     androidTestImplementation libs.androidx.espresso

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
@@ -540,11 +540,8 @@ internal class GlideNode : DrawModifierNode, LayoutModifierNode, SemanticsModifi
   private fun Constraints.hasFixedSize() = hasFixedWidth && hasFixedHeight
 
   private fun modifyConstraints(constraints: Constraints): Constraints {
-    if (constraints.hasFixedSize()) {
-      return constraints.copy(
-        minWidth = constraints.maxWidth,
-        minHeight = constraints.maxHeight
-      )
+    if (constraints.hasFixedSize() || constraints.isZero) {
+      return constraints
     }
 
     val intrinsicSize = primary?.painter?.intrinsicSize ?: return constraints

--- a/integration/compose/src/test/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
+++ b/integration/compose/src/test/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
@@ -1,0 +1,33 @@
+package com.bumptech.glide.integration.compose
+
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.heightIn
+import androidx.compose.foundation.layout.width
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.layout.ContentScale
+import androidx.compose.ui.test.junit4.createComposeRule
+import androidx.compose.ui.unit.dp
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+
+@OptIn(ExperimentalGlideComposeApi::class)
+@RunWith(AndroidJUnit4::class)
+class GlideImageTest {
+
+  @get:Rule(order = 1) val composeRule = createComposeRule()
+
+  @Test
+  fun glideImage_zeroWidthFillBounds_doesNotCrash() {
+    composeRule.setContent {
+      GlideImage(
+        model = null,
+        contentDescription = null,
+        modifier = Modifier.width(0.dp).heightIn(0.dp, 100.dp),
+        contentScale = ContentScale.FillBounds,
+        loading = placeholder(android.R.drawable.star_on),
+      )
+    }
+  }
+}


### PR DESCRIPTION
If e.g. constraints.width=0 the logic ends up computing:

```
 intrinsicWidth = constraints.width (i.e. 0)
 constrainedWidth = 0
 srcSize.width = 0
 scaleFactor.width = computeFillWidth(0,0) --> NaN
```
