### PR TITLE
Integrate with the newly introduced MediaStore.openAssetFileDescriptor API

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/data/AssetFileDescriptorLocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/AssetFileDescriptorLocalUriFetcher.java
@@ -4,6 +4,7 @@ import android.content.ContentResolver;
 import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
 import androidx.annotation.NonNull;
+import com.bumptech.glide.load.data.mediastore.MediaStoreUtil;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -17,7 +18,13 @@ public final class AssetFileDescriptorLocalUriFetcher extends LocalUriFetcher<As
   @Override
   protected AssetFileDescriptor loadResource(Uri uri, ContentResolver contentResolver)
       throws FileNotFoundException {
-    AssetFileDescriptor result = contentResolver.openAssetFileDescriptor(uri, "r");
+
+    AssetFileDescriptor result = null;
+    if (MediaStoreUtil.isMediaStoreUri(uri) && MediaStoreUtil.isMediaStoreOpenFileAPIsAvailable()) {
+      result = MediaStoreUtil.openAssetFileDescriptor(uri, contentResolver);
+    } else {
+      result = contentResolver.openAssetFileDescriptor(uri, "r");
+    }
     if (result == null) {
       throw new FileNotFoundException("FileDescriptor is null for: " + uri);
     }

--- a/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorLocalUriFetcher.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/FileDescriptorLocalUriFetcher.java
@@ -5,6 +5,7 @@ import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
 import android.os.ParcelFileDescriptor;
 import androidx.annotation.NonNull;
+import com.bumptech.glide.load.data.mediastore.MediaStoreUtil;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 
@@ -17,7 +18,12 @@ public class FileDescriptorLocalUriFetcher extends LocalUriFetcher<ParcelFileDes
   @Override
   protected ParcelFileDescriptor loadResource(Uri uri, ContentResolver contentResolver)
       throws FileNotFoundException {
-    AssetFileDescriptor assetFileDescriptor = contentResolver.openAssetFileDescriptor(uri, "r");
+    AssetFileDescriptor assetFileDescriptor = null;
+    if (MediaStoreUtil.isMediaStoreUri(uri) && MediaStoreUtil.isMediaStoreOpenFileAPIsAvailable()) {
+      assetFileDescriptor = MediaStoreUtil.openAssetFileDescriptor(uri, contentResolver);
+    } else {
+      assetFileDescriptor = contentResolver.openAssetFileDescriptor(uri, "r");
+    }
     if (assetFileDescriptor == null) {
       throw new FileNotFoundException("FileDescriptor is null for: " + uri);
     }

--- a/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
+++ b/library/src/main/java/com/bumptech/glide/load/data/mediastore/MediaStoreUtil.java
@@ -1,9 +1,16 @@
 package com.bumptech.glide.load.data.mediastore;
 
 import android.content.ContentResolver;
+import android.content.res.AssetFileDescriptor;
 import android.net.Uri;
+import android.os.Build;
+import android.os.Build.VERSION_CODES;
+import android.os.ext.SdkExtensions;
 import android.provider.MediaStore;
+import androidx.annotation.ChecksSdkIntAtLeast;
+import androidx.annotation.RequiresExtension;
 import com.bumptech.glide.request.target.Target;
+import java.io.FileNotFoundException;
 
 /** Utility classes for interacting with the media store. */
 public final class MediaStoreUtil {
@@ -18,6 +25,18 @@ public final class MediaStoreUtil {
     return uri != null
         && ContentResolver.SCHEME_CONTENT.equals(uri.getScheme())
         && MediaStore.AUTHORITY.equals(uri.getAuthority());
+  }
+
+  @ChecksSdkIntAtLeast(api = 16, extension = VERSION_CODES.R)
+  public static boolean isMediaStoreOpenFileAPIsAvailable() {
+    return Build.VERSION.SDK_INT >= Build.VERSION_CODES.R
+        && SdkExtensions.getExtensionVersion(Build.VERSION_CODES.R) >= 16;
+  }
+
+  @RequiresExtension(extension = VERSION_CODES.R, version = 16)
+  public static AssetFileDescriptor openAssetFileDescriptor(
+      Uri uri, ContentResolver contentResolver) throws FileNotFoundException {
+    return MediaStore.openAssetFileDescriptor(contentResolver, uri, "r", null);
   }
 
   // Android picker uris contain a "picker" segment:

--- a/library/test/src/test/java/com/bumptech/glide/load/data/resource/FileDescriptorLocalUriFetcherTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/data/resource/FileDescriptorLocalUriFetcherTest.java
@@ -16,12 +16,15 @@ import androidx.test.core.app.ApplicationProvider;
 import com.bumptech.glide.Priority;
 import com.bumptech.glide.load.data.DataFetcher;
 import com.bumptech.glide.load.data.FileDescriptorLocalUriFetcher;
+import com.bumptech.glide.load.data.mediastore.MediaStoreUtil;
 import com.bumptech.glide.tests.ContentResolverShadow;
 import java.io.FileNotFoundException;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
+import org.mockito.MockedStatic;
+import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -57,6 +60,30 @@ public class FileDescriptorLocalUriFetcherTest {
         new FileDescriptorLocalUriFetcher(context.getContentResolver(), uri);
     fetcher.loadData(Priority.NORMAL, callback);
     verify(callback).onDataReady(eq(parcelFileDescriptor));
+  }
+
+  @Test
+  public void testLoadResource_mediaUri_returnsFileDescriptor() throws Exception {
+    Context context = ApplicationProvider.getApplicationContext();
+    Uri uri = Uri.parse("content://media");
+
+    ContentResolver contentResolver = context.getContentResolver();
+
+    AssetFileDescriptor assetFileDescriptor = mock(AssetFileDescriptor.class);
+    ParcelFileDescriptor parcelFileDescriptor = mock(ParcelFileDescriptor.class);
+    when(assetFileDescriptor.getParcelFileDescriptor()).thenReturn(parcelFileDescriptor);
+
+    FileDescriptorLocalUriFetcher fetcher =
+        new FileDescriptorLocalUriFetcher(context.getContentResolver(), uri);
+
+    try (MockedStatic<MediaStoreUtil> utils = Mockito.mockStatic(MediaStoreUtil.class)) {
+      utils.when(MediaStoreUtil::isMediaStoreOpenFileAPIsAvailable).thenReturn(true);
+      utils.when(() -> MediaStoreUtil.isMediaStoreUri(uri)).thenReturn(true);
+      utils.when(() -> MediaStoreUtil.openAssetFileDescriptor(uri, contentResolver))
+          .thenReturn(assetFileDescriptor);
+      fetcher.loadData(Priority.NORMAL, callback);
+      verify(callback).onDataReady(eq(parcelFileDescriptor));
+    }
   }
 
   @Test

--- a/settings.gradle
+++ b/settings.gradle
@@ -46,7 +46,7 @@ dependencyResolutionManagement {
     versionCatalogs {
         libs {
             // Versions for things other than dependencies
-            version('compile-sdk-version', 'android-34')
+            version('compile-sdk-version', 'android-36')
             version('min-sdk-version', '14')
             version('okhttp-min-sdk-version', '21')
             version('target-sdk-version', '32')


### PR DESCRIPTION

<!-- Make sure you've run `gradlew clean check jar assemble` before commit. -->
<!-- Don't forget that you can always force push to your private branches to make changes. -->
<!-- Please make sure there are no weird commits in the change set by rebasing to latest upstream. -->
<!-- Please squash typo/checkstyle/review fix commits into the base commit. -->

## Description
<!-- Please describe the changes you made on a high level. -->
<!-- Make sure you reference the GitHub issue here if this change is related to one. -->
Update FileDescriptorLocalUriFetcher, StreamLocalUriFetcher and AssetFileDescriptorLocalUriFetcher to make use of the newly created MediaStore.openAssetFileDescriptor when opening Media content URI.

## Motivation and Context
<!-- Why is this change required? What problem does it solve? -->
<!-- If it's fixing a bug reference it or provide repro steps. -->
New API (MediaStore.openAssetFileDescriptor) has been added in SDK extension 16 that helps with keeping MediaProvider stable when many cloud picker items are being opened at once.
<!-- If you have any issues feel free to create the PR anyway, we'll help to resolve them. -->