### PR TITLE
Remove use of Bitmap pool in TransformationUtils to fix gainmap issues.

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/TransformationUtils.java
@@ -17,7 +17,6 @@ import android.util.Log;
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
 import androidx.exifinterface.media.ExifInterface;
-import com.bumptech.glide.load.Transformation;
 import com.bumptech.glide.load.engine.bitmap_recycle.BitmapPool;
 import com.bumptech.glide.util.Preconditions;
 import com.bumptech.glide.util.Synthetic;
@@ -35,7 +34,6 @@ import java.util.concurrent.locks.ReentrantLock;
 public final class TransformationUtils {
   private static final String TAG = "TransformationUtils";
   public static final int PAINT_FLAGS = Paint.DITHER_FLAG | Paint.FILTER_BITMAP_FLAG;
-  private static final Paint DEFAULT_PAINT = new Paint(PAINT_FLAGS);
   private static final int CIRCLE_CROP_PAINT_FLAGS = PAINT_FLAGS | Paint.ANTI_ALIAS_FLAG;
   private static final Paint CIRCLE_CROP_SHAPE_PAINT = new Paint(CIRCLE_CROP_PAINT_FLAGS);
   private static final Paint CIRCLE_CROP_BITMAP_PAINT;
@@ -132,12 +130,16 @@ public final class TransformationUtils {
     m.setScale(scale, scale);
     m.postTranslate((int) (dx + 0.5f), (int) (dy + 0.5f));
 
-    Bitmap result = pool.get(width, height, getNonNullConfig(inBitmap));
-    // We don't add or remove alpha, so keep the alpha setting of the Bitmap we were given.
-    TransformationUtils.setAlpha(inBitmap, result);
+    Bitmap result =
+        Bitmap.createBitmap(inBitmap.getWidth(), inBitmap.getHeight(), getNonNullConfig(inBitmap));
+    Bitmap transformedBitmap =
+        Bitmap.createBitmap(
+            result, 0, 0, inBitmap.getWidth(), inBitmap.getHeight(), m, true /*filter*/);
 
-    applyMatrix(inBitmap, result, m);
-    return result;
+    // We don't add or remove alpha, so keep the alpha setting of the Bitmap we were given.
+    TransformationUtils.setAlpha(inBitmap, transformedBitmap);
+
+    return transformedBitmap;
   }
 
   /**
@@ -182,23 +184,31 @@ public final class TransformationUtils {
     targetHeight = (int) (minPercentage * inBitmap.getHeight());
 
     Bitmap.Config config = getNonNullConfig(inBitmap);
-    Bitmap toReuse = pool.get(targetWidth, targetHeight, config);
+
+    Matrix matrix = new Matrix();
+    matrix.setScale(minPercentage, minPercentage);
+
+    Bitmap result = Bitmap.createBitmap(inBitmap.getWidth(), inBitmap.getHeight(), config);
+    Bitmap transformedBitmap =
+        Bitmap.createBitmap(
+            result, 0, 0, inBitmap.getWidth(), inBitmap.getHeight(), matrix, true /*filter*/);
 
     // We don't add or remove alpha, so keep the alpha setting of the Bitmap we were given.
-    TransformationUtils.setAlpha(inBitmap, toReuse);
+    TransformationUtils.setAlpha(inBitmap, transformedBitmap);
 
     if (Log.isLoggable(TAG, Log.VERBOSE)) {
       Log.v(TAG, "request: " + width + "x" + height);
       Log.v(TAG, "toFit:   " + inBitmap.getWidth() + "x" + inBitmap.getHeight());
-      Log.v(TAG, "toReuse: " + toReuse.getWidth() + "x" + toReuse.getHeight());
+      Log.v(
+          TAG,
+          "transformedBitmap: "
+              + transformedBitmap.getWidth()
+              + "x"
+              + transformedBitmap.getHeight());
       Log.v(TAG, "minPct:   " + minPercentage);
     }
 
-    Matrix matrix = new Matrix();
-    matrix.setScale(minPercentage, minPercentage);
-    applyMatrix(inBitmap, toReuse, matrix);
-
-    return toReuse;
+    return transformedBitmap;
   }
 
   /**
@@ -514,14 +524,14 @@ public final class TransformationUtils {
             path.addRoundRect(
                 rect,
                 new float[] {
-                  topLeft,
-                  topLeft,
-                  topRight,
-                  topRight,
-                  bottomRight,
-                  bottomRight,
-                  bottomLeft,
-                  bottomLeft
+                    topLeft,
+                    topLeft,
+                    topRight,
+                    topRight,
+                    bottomRight,
+                    bottomRight,
+                    bottomLeft,
+                    bottomLeft
                 },
                 Path.Direction.CW);
             canvas.drawPath(path, paint);
@@ -570,18 +580,6 @@ public final class TransformationUtils {
   @NonNull
   private static Bitmap.Config getNonNullConfig(@NonNull Bitmap bitmap) {
     return bitmap.getConfig() != null ? bitmap.getConfig() : Bitmap.Config.ARGB_8888;
-  }
-
-  private static void applyMatrix(
-      @NonNull Bitmap inBitmap, @NonNull Bitmap targetBitmap, Matrix matrix) {
-    BITMAP_DRAWABLE_LOCK.lock();
-    try {
-      Canvas canvas = new Canvas(targetBitmap);
-      canvas.drawBitmap(inBitmap, matrix, DEFAULT_PAINT);
-      clear(canvas);
-    } finally {
-      BITMAP_DRAWABLE_LOCK.unlock();
-    }
   }
 
   @VisibleForTesting

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/TransformationUtilsTest.java
@@ -7,9 +7,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
-import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.reset;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -170,44 +168,7 @@ public class TransformationUtilsTest {
     assertEquals(Bitmap.Config.ARGB_8888, transformed.getConfig());
   }
 
-  @Test
-  public void testCenterCropSetsOutBitmapToHaveAlphaIfInBitmapHasAlphaAndOutBitmapIsReused() {
-    Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
 
-    Bitmap toReuse = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
-    reset(bitmapPool);
-    when(bitmapPool.get(eq(50), eq(50), eq(Bitmap.Config.ARGB_8888))).thenReturn(toReuse);
-
-    toReuse.setHasAlpha(false);
-    toTransform.setHasAlpha(true);
-
-    Bitmap result =
-        TransformationUtils.centerCrop(
-            bitmapPool, toTransform, toReuse.getWidth(), toReuse.getHeight());
-
-    assertEquals(toReuse, result);
-    assertTrue(result.hasAlpha());
-  }
-
-  @Test
-  public void
-      testCenterCropSetsOutBitmapToNotHaveAlphaIfInBitmapDoesNotHaveAlphaAndOutBitmapIsReused() {
-    Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-
-    Bitmap toReuse = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
-    reset(bitmapPool);
-    when(bitmapPool.get(eq(50), eq(50), eq(Bitmap.Config.ARGB_8888))).thenReturn(toReuse);
-
-    toReuse.setHasAlpha(true);
-    toTransform.setHasAlpha(false);
-
-    Bitmap result =
-        TransformationUtils.centerCrop(
-            bitmapPool, toTransform, toReuse.getWidth(), toReuse.getHeight());
-
-    assertEquals(toReuse, result);
-    assertFalse(result.hasAlpha());
-  }
 
   @Test
   public void testCenterCropSetsOutBitmapToHaveAlphaIfInBitmapHasAlpha() {
@@ -243,47 +204,6 @@ public class TransformationUtilsTest {
         TransformationUtils.centerCrop(
             bitmapPool, toTransform, toTransform.getWidth() / 2, toTransform.getHeight() / 2);
 
-    assertFalse(result.hasAlpha());
-  }
-
-  @Test
-  public void testFitCenterSetsOutBitmapToHaveAlphaIfInBitmapHasAlphaAndOutBitmapIsReused() {
-    Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-
-    Bitmap toReuse = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
-    reset(bitmapPool);
-    when(bitmapPool.get(eq(toReuse.getWidth()), eq(toReuse.getHeight()), eq(toReuse.getConfig())))
-        .thenReturn(toReuse);
-
-    toReuse.setHasAlpha(false);
-    toTransform.setHasAlpha(true);
-
-    Bitmap result =
-        TransformationUtils.fitCenter(
-            bitmapPool, toTransform, toReuse.getWidth(), toReuse.getHeight());
-
-    assertEquals(toReuse, result);
-    assertTrue(result.hasAlpha());
-  }
-
-  @Test
-  public void
-      testFitCenterSetsOutBitmapToNotHaveAlphaIfInBitmapDoesNotHaveAlphaAndOutBitmapIsReused() {
-    Bitmap toTransform = Bitmap.createBitmap(100, 100, Bitmap.Config.ARGB_8888);
-
-    Bitmap toReuse = Bitmap.createBitmap(50, 50, Bitmap.Config.ARGB_8888);
-    reset(bitmapPool);
-    when(bitmapPool.get(eq(toReuse.getWidth()), eq(toReuse.getHeight()), eq(toReuse.getConfig())))
-        .thenReturn(toReuse);
-
-    toReuse.setHasAlpha(true);
-    toTransform.setHasAlpha(false);
-
-    Bitmap result =
-        TransformationUtils.fitCenter(
-            bitmapPool, toTransform, toReuse.getWidth(), toReuse.getHeight());
-
-    assertEquals(toReuse, result);
     assertFalse(result.hasAlpha());
   }
 


### PR DESCRIPTION
## Description
This pull request modifies the fitCenter and centerCrop methods, located in TransformationUtils, to address gain map handling. The previous implementation used applyMatrix with the Canvas API, which dropped gain map data.

This PR replaces applyMatrix with createBitmap APIs to ensure proper gain map handling in fitCenter and centerCrop. This change avoids using the bitmap pool.

## Motivation and Context
The original fitCenter and centerCrop implementation lost gain map information, which is crucial for HDR images.

The applyMatrix method's use of the Canvas API caused this issue, as Canvas doesn't preserve gain maps.  We now use createBitmap, which retains this data.  The bitmap pool was avoided because, The BitmapPool is keyed off of three attributes, 1) width, 2) height and 3) config (bit depth). The usages of the BitmapPool do not strive to override other properties of the Bitmap like the color space before the bitmap is reused.  This ensures correct fitCenter and centerCrop behavior with gain maps.