### PR TITLE
Fix NPE in DrawableTransformation when custom transform returns null

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DrawableTransformation.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DrawableTransformation.java
@@ -60,7 +60,7 @@ public class DrawableTransformation implements Transformation<Drawable> {
     Resource<Bitmap> transformedBitmapResource =
         wrapped.transform(context, bitmapResourceToTransform, outWidth, outHeight);
 
-    if (transformedBitmapResource.equals(bitmapResourceToTransform)) {
+    if (bitmapResourceToTransform.equals(transformedBitmapResource)) {
       transformedBitmapResource.recycle();
       return resource;
     } else {


### PR DESCRIPTION
## Description
This PR inverts the equality check in `DrawableTransformation`'s `transform` method.
Instead of calling `.equals()` on the potentially null `transformedBitmapResource`, it now calls it on `bitmapResourceToTransform`, which is guaranteed to be non-null by the preceding null check.

## Motivation and Context
If a custom `Transformation` implementation returns `null`, the current implementation throws a `NullPointerException` when attempting to check for equality.
By swapping the order of comparison to `original.equals(transformed)`, we prevent this crash. This change also aligns the behavior with `BitmapTransformation`.

Fixes #5651