### PR TITLE
Fix IndexOutOfBoundsException when parsing EXIF with negative IFD offset

### DIFF
--- a/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
+++ b/library/src/main/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParser.java
@@ -486,74 +486,90 @@ public final class DefaultImageHeaderParser implements ImageHeaderParser {
     segmentData.order(byteOrder);
 
     int firstIfdOffset = segmentData.getInt32(headerOffsetSize + 4) + headerOffsetSize;
-    int tagCount = segmentData.getInt16(firstIfdOffset);
-    for (int i = 0; i < tagCount; i++) {
-      final int tagOffset = calcTagOffset(firstIfdOffset, i);
-
-      final int tagType = segmentData.getInt16(tagOffset);
-      // We only want orientation.
-      if (tagType != ORIENTATION_TAG_TYPE) {
-        continue;
-      }
-
-      final int formatCode = segmentData.getInt16(tagOffset + 2);
-      // 12 is max format code.
-      if (formatCode < 1 || formatCode > 12) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-          Log.d(TAG, "Got invalid format code = " + formatCode);
-        }
-        continue;
-      }
-
-      final int componentCount = segmentData.getInt32(tagOffset + 4);
-      if (componentCount < 0) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-          Log.d(TAG, "Negative tiff component count");
-        }
-        continue;
-      }
-
+    // Validate IFD offset to prevent IndexOutOfBoundsException from abnormal EXIF data.
+    // Negative IFD offsets or offsets exceeding segment length indicate corrupt EXIF.
+    if (firstIfdOffset < 0 || firstIfdOffset >= segmentData.length()) {
       if (Log.isLoggable(TAG, Log.DEBUG)) {
-        Log.d(
-            TAG,
-            "Got tagIndex="
-                + i
-                + " tagType="
-                + tagType
-                + " formatCode="
-                + formatCode
-                + " componentCount="
-                + componentCount);
+        Log.d(TAG, "Invalid firstIfdOffset=" + firstIfdOffset + " segmentLength=" + segmentData.length());
       }
-
-      final int byteCount = componentCount + BYTES_PER_FORMAT[formatCode];
-      if (byteCount > 4) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-          Log.d(TAG, "Got byte count > 4, not orientation, continuing, formatCode=" + formatCode);
-        }
-        continue;
-      }
-
-      final int tagValueOffset = tagOffset + 8;
-      if (tagValueOffset < 0 || tagValueOffset > segmentData.length()) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-          Log.d(TAG, "Illegal tagValueOffset=" + tagValueOffset + " tagType=" + tagType);
-        }
-        continue;
-      }
-
-      if (byteCount < 0 || tagValueOffset + byteCount > segmentData.length()) {
-        if (Log.isLoggable(TAG, Log.DEBUG)) {
-          Log.d(TAG, "Illegal number of bytes for TI tag data tagType=" + tagType);
-        }
-        continue;
-      }
-
-      // assume componentCount == 1 && fmtCode == 3
-      return segmentData.getInt16(tagValueOffset);
+      return UNKNOWN_ORIENTATION;
     }
 
-    return -1;
+    try {
+      int tagCount = segmentData.getInt16(firstIfdOffset);
+      for (int i = 0; i < tagCount; i++) {
+        final int tagOffset = calcTagOffset(firstIfdOffset, i);
+
+        final int tagType = segmentData.getInt16(tagOffset);
+        // We only want orientation.
+        if (tagType != ORIENTATION_TAG_TYPE) {
+          continue;
+        }
+
+        final int formatCode = segmentData.getInt16(tagOffset + 2);
+        // 12 is max format code.
+        if (formatCode < 1 || formatCode > 12) {
+          if (Log.isLoggable(TAG, Log.DEBUG)) {
+            Log.d(TAG, "Got invalid format code = " + formatCode);
+          }
+          continue;
+        }
+
+        final int componentCount = segmentData.getInt32(tagOffset + 4);
+        if (componentCount < 0) {
+          if (Log.isLoggable(TAG, Log.DEBUG)) {
+            Log.d(TAG, "Negative tiff component count");
+          }
+          continue;
+        }
+
+        if (Log.isLoggable(TAG, Log.DEBUG)) {
+          Log.d(
+              TAG,
+              "Got tagIndex="
+                  + i
+                  + " tagType="
+                  + tagType
+                  + " formatCode="
+                  + formatCode
+                  + " componentCount="
+                  + componentCount);
+        }
+
+        final int byteCount = componentCount + BYTES_PER_FORMAT[formatCode];
+        if (byteCount > 4) {
+          if (Log.isLoggable(TAG, Log.DEBUG)) {
+            Log.d(TAG, "Got byte count > 4, not orientation, continuing, formatCode=" + formatCode);
+          }
+          continue;
+        }
+
+        final int tagValueOffset = tagOffset + 8;
+        if (tagValueOffset < 0 || tagValueOffset > segmentData.length()) {
+          if (Log.isLoggable(TAG, Log.DEBUG)) {
+            Log.d(TAG, "Illegal tagValueOffset=" + tagValueOffset + " tagType=" + tagType);
+          }
+          continue;
+        }
+
+        if (byteCount < 0 || tagValueOffset + byteCount > segmentData.length()) {
+          if (Log.isLoggable(TAG, Log.DEBUG)) {
+            Log.d(TAG, "Illegal number of bytes for TI tag data tagType=" + tagType);
+          }
+          continue;
+        }
+
+        // assume componentCount == 1 && fmtCode == 3
+        return segmentData.getInt16(tagValueOffset);
+      }
+
+      return -1;
+    } catch (RuntimeException e) {
+      if (Log.isLoggable(TAG, Log.DEBUG)) {
+        Log.d(TAG, "Error parsing EXIF segment", e);
+      }
+      return UNKNOWN_ORIENTATION;
+    }
   }
 
   private static int calcTagOffset(int ifdOffset, int tagIndex) {
@@ -590,7 +606,7 @@ public final class DefaultImageHeaderParser implements ImageHeaderParser {
     }
 
     private boolean isAvailable(int offset, int byteSize) {
-      return data.remaining() - offset >= byteSize;
+      return offset >= 0 && data.remaining() - offset >= byteSize;
     }
   }
 

--- a/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParserTest.java
+++ b/library/test/src/test/java/com/bumptech/glide/load/resource/bitmap/DefaultImageHeaderParserTest.java
@@ -1172,6 +1172,91 @@ public class DefaultImageHeaderParserTest {
         });
   }
 
+  @Test
+  public void getOrientation_withNegativeIfdOffset_returnsUnknown() throws IOException {
+    ByteBuffer byteBuffer = createExifSegmentWithIfdOffset(-2023161846);
+    DefaultImageHeaderParser parser = new DefaultImageHeaderParser();
+    assertEquals(
+        ImageHeaderParser.UNKNOWN_ORIENTATION, parser.getOrientation(byteBuffer, byteArrayPool));
+  }
+
+  @Test
+  public void getOrientation_withOverflowIfdOffset_returnsUnknown() throws IOException {
+    ByteBuffer byteBuffer = createExifSegmentWithIfdOffset(Integer.MAX_VALUE);
+    DefaultImageHeaderParser parser = new DefaultImageHeaderParser();
+    assertEquals(
+        ImageHeaderParser.UNKNOWN_ORIENTATION, parser.getOrientation(byteBuffer, byteArrayPool));
+  }
+
+  @Test
+  public void getOrientation_withZeroIfdOffset_returnsUnknown() throws IOException {
+    ByteBuffer byteBuffer = createExifSegmentWithIfdOffset(0);
+    DefaultImageHeaderParser parser = new DefaultImageHeaderParser();
+    assertEquals(
+        ImageHeaderParser.UNKNOWN_ORIENTATION, parser.getOrientation(byteBuffer, byteArrayPool));
+  }
+
+  @Test
+  public void getOrientation_withValidExifOrientation_returnsOrientation() throws IOException {
+    ByteBuffer byteBuffer = createExifSegmentWithOrientation(6);
+    DefaultImageHeaderParser parser = new DefaultImageHeaderParser();
+    assertEquals(6, parser.getOrientation(byteBuffer, byteArrayPool));
+  }
+
+  @Test
+  public void getOrientation_withIfdOffsetExceedingSegmentLength_returnsUnknown()
+      throws IOException {
+    ByteBuffer byteBuffer = createExifSegmentWithIfdOffset(500);
+    DefaultImageHeaderParser parser = new DefaultImageHeaderParser();
+    assertEquals(
+        ImageHeaderParser.UNKNOWN_ORIENTATION, parser.getOrientation(byteBuffer, byteArrayPool));
+  }
+
+  private static ByteBuffer createExifSegmentWithIfdOffset(int ifdOffset) {
+    // Segment content: "Exif\0\0" (6) + byte order "MM" (2) + magic 42 (2) + IFD offset (4) = 14
+    // Segment length = 14 + 2 = 16
+    ByteBuffer buffer = ByteBuffer.allocate(20);
+    buffer.put((byte) 0xFF);
+    buffer.put((byte) 0xD8);
+    buffer.put((byte) DefaultImageHeaderParser.SEGMENT_START_ID);
+    buffer.put((byte) DefaultImageHeaderParser.EXIF_SEGMENT_TYPE);
+    buffer.putShort((short) 16); // segment length
+    buffer.put(DefaultImageHeaderParser.JPEG_EXIF_SEGMENT_PREAMBLE_BYTES);
+    buffer.put((byte) 0x4D); // 'M'
+    buffer.put((byte) 0x4D); // 'M' (big endian)
+    buffer.putShort((short) 42); // TIFF magic number
+    buffer.putInt(ifdOffset);
+    buffer.flip();
+    return buffer;
+  }
+
+  private static ByteBuffer createExifSegmentWithOrientation(int orientation) {
+    // Segment content: "Exif\0\0" (6) + byte order (2) + magic (2) + IFD offset (4)
+    // + tag count (2) + orientation tag (12) + next IFD offset (4) = 32
+    // Segment length = 32 + 2 = 34
+    ByteBuffer buffer = ByteBuffer.allocate(38);
+    buffer.put((byte) 0xFF);
+    buffer.put((byte) 0xD8);
+    buffer.put((byte) DefaultImageHeaderParser.SEGMENT_START_ID);
+    buffer.put((byte) DefaultImageHeaderParser.EXIF_SEGMENT_TYPE);
+    buffer.putShort((short) 34); // segment length
+    buffer.put(DefaultImageHeaderParser.JPEG_EXIF_SEGMENT_PREAMBLE_BYTES);
+    buffer.put((byte) 0x4D); // 'M'
+    buffer.put((byte) 0x4D); // 'M' (big endian)
+    buffer.putShort((short) 42); // TIFF magic number
+    buffer.putInt(8); // IFD offset (relative to byte order bytes)
+    buffer.putShort((short) 1); // tag count
+    // Orientation tag (12 bytes)
+    buffer.putShort((short) 0x0112); // orientation tag id
+    buffer.putShort((short) 3); // format: SHORT
+    buffer.putInt(1); // component count
+    buffer.putShort((short) orientation); // orientation value
+    buffer.putShort((short) 0); // padding
+    buffer.putInt(0); // next IFD offset
+    buffer.flip();
+    return buffer;
+  }
+
   private static ByteBuffer getExifMagicNumber() {
     ByteBuffer jpegHeaderBytes = ByteBuffer.allocate(2);
     jpegHeaderBytes.putShort((short) DefaultImageHeaderParser.EXIF_MAGIC_NUMBER);


### PR DESCRIPTION
## Description
Fixes #5454

Added three layers of protection against abnormal EXIF data:
1. Validate IFD offset range in `parseExifSegment` - reject negative values and overflow
2. Wrap EXIF parsing in try-catch for `RuntimeException`
3. Add offset >= 0 check in `RandomAccessReader.isAvailable()`

Added unit tests covering negative IFD offsets, overflow, exceeding segment length, and valid EXIF parsing.

## Motivation and Context
Loading JPEG images with abnormal EXIF data causes `IndexOutOfBoundsException`:
java.lang.IndexOutOfBoundsException(index=-2023161846 out of bounds (limit=86, nb=2))
at java.nio.DirectByteBuffer.get(DirectByteBuffer.java:.java.nio.DirectByteBuffer.get)
at com.bumptech.glide.load.resource.bitmap.DefaultImageHeaderParser$RandomAccessReader.getInt16(DefaultImageHeaderParser.java)


The crash occurs when EXIF data contains negative IFD offset values (e.g., -2023161846). Instead of crashing, the parser should return `UNKNOWN_ORIENTATION` and allow the image to load normally.