### PR TITLE
Fix crash in Glide Compose integration during fast scroll (#5739)

### DIFF
--- a/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
+++ b/integration/compose/src/androidTest/java/com/bumptech/glide/integration/compose/GlideImageTest.kt
@@ -13,6 +13,7 @@ import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.material.Text
 import androidx.compose.material.TextButton
 import androidx.compose.runtime.mutableStateOf
@@ -467,5 +468,45 @@ class GlideImageTest {
       .onNodeWithContentDescription("test")
       .captureToImage()
       .compareToGolden(testName.methodName)
+  }
+
+  // See #5739
+  @Test
+  fun glideImage_rapidLazyRowScroll_doesNotThrowDetachedScopeException() {
+    val description = "rapid-scroll"
+    val testTag = "rapid-scroll-list"
+    glideComposeRule.setContent {
+      LazyRow(
+        horizontalArrangement = Arrangement.spacedBy(10.dp),
+        modifier = Modifier.testTag(testTag)
+      ) {
+        items(20) { index ->
+          GlideImage(
+            model = android.R.drawable.star_big_on,
+            contentDescription = description + index,
+            modifier = Modifier.size(200.dp)
+          )
+        }
+      }
+    }
+
+    // Rapidly scroll back and forth to force the GlideImage nodes to detach while a sideEffect
+    // is still queued to launch its coroutine. Before the fix this threw
+    // IllegalStateException("This node does not have an owner.") from
+    // Modifier.Node.coroutineScope inside launchRequest.
+    val indices = listOf(0, 5, 10, 15, 19, 12, 7, 2, 8, 14, 18, 11, 4, 16, 1, 9, 17, 3, 6, 13, 0)
+    for (index in indices) {
+      glideComposeRule.onNode(hasTestTag(testTag)).performScrollToIndex(index)
+    }
+    glideComposeRule.waitForIdle()
+
+    // If we get here without an exception, the bug is fixed. Scroll back to the start and confirm
+    // the first image still renders correctly so we know the surviving nodes are not in a bad
+    // state either.
+    glideComposeRule.onNode(hasTestTag(testTag)).performScrollToIndex(0)
+    glideComposeRule.waitForIdle()
+    glideComposeRule
+      .onNodeWithContentDescription(description + 0)
+      .assert(expectDisplayedDrawable(context.getDrawable(android.R.drawable.star_big_on)))
   }
 }

--- a/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
+++ b/integration/compose/src/main/java/com/bumptech/glide/integration/compose/GlideModifier.kt
@@ -474,6 +474,13 @@ internal class GlideNode : DrawModifierNode, LayoutModifierNode, SemanticsModifi
   // sideEffect is called after all changes in the tree, so we can always queue a new request, but
     // drop any for old requests by comparing requests builders.
     sideEffect {
+      // The node may have been detached between the caller of launchRequest and the sideEffect
+      // actually running (e.g. during a fast scroll that recycles the GlideImage out of a
+      // LazyColumn). Modifier.Node.coroutineScope throws IllegalStateException("This node does
+      // not have an owner.") in that case, so short-circuit before touching it. See #5739.
+      if (!isAttached) {
+        return@sideEffect
+      }
       if (this.requestBuilder != requestBuilder) {
         return@sideEffect
       }


### PR DESCRIPTION
Fixes #5739

During fast scrolling of a \GlideImage\ inside a \LazyColumn\/\LazyRow\, the app would crash with:

\\\
java.lang.IllegalStateException: This node does not have an owner.
    at androidx.compose.ui.Modifier.Node.getCoroutineScope(Modifier.kt:188)
    at com.bumptech.glide.integration.compose.GlideNode.launchRequest\.invoke(GlideModifier.kt:405)
\\\

**Root cause:** the existing \isAttached\ guard at the call site (in \onEndApplyChanges\) checks the flag synchronously, but the \sideEffect\ that actually calls \coroutineScope\ is invoked later by the Compose runtime. A fast scroll can detach the \GlideNode\ between those two points, so the \coroutineScope\ property getter then throws.

**Fix:** re-check \isAttached\ inside the \sideEffect\ block, before touching \coroutineScope\. If the node is no longer attached, skip the launch — the image is not on screen, so there is no request to issue.

Adds a regression test that mounts 20 \GlideImage\s in a \LazyRow\ and rapidly scrolls back and forth through all indices, then verifies that no exception is thrown and the surviving items still render correctly.